### PR TITLE
Add Windows/MSVC build support and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-latest
+            deps: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+          - name: macOS
+            os: macos-latest
+          - name: Windows
+            os: windows-latest
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        if: matrix.deps
+        run: ${{ matrix.deps }}
+
+      - name: Cache raylib build
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: ${{ runner.os }}-deps-raylib5.5-${{ hashFiles('CMakeLists.txt') }}
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ if(APPLE)
         "-framework Cocoa"
         "-framework OpenGL"
     )
+elseif(WIN32)
+    target_link_libraries(mavsim-viewer PRIVATE ws2_32)
 elseif(UNIX)
     target_link_libraries(mavsim-viewer PRIVATE m pthread dl)
 endif()

--- a/src/hud.c
+++ b/src/hud.c
@@ -1,6 +1,11 @@
 #include "hud.h"
 #include "raylib.h"
 #include "raymath.h"
+
+#ifdef _WIN32
+// windows.h defines DrawText as DrawTextA, conflicting with raylib
+#undef DrawText
+#endif
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -2,31 +2,55 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
+
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#define SOCK_CLOSE(s) closesocket(s)
+#else
 #include <unistd.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#define SOCK_CLOSE(s) close(s)
+#endif
 
 // MAVLink config: use common message set
 #include <mavlink.h>
+
+static int set_nonblocking(sock_t s) {
+#ifdef _WIN32
+    u_long mode = 1;
+    return ioctlsocket(s, FIONBIO, &mode);
+#else
+    int flags = fcntl(s, F_GETFL, 0);
+    return fcntl(s, F_SETFL, flags | O_NONBLOCK);
+#endif
+}
 
 int mavlink_receiver_init(mavlink_receiver_t *recv, uint16_t port) {
     bool debug = recv->debug;
     memset(recv, 0, sizeof(*recv));
     recv->debug = debug;
     recv->port = port;
+    recv->sockfd = SOCK_INVALID;
+
+#ifdef _WIN32
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        fprintf(stderr, "WSAStartup failed: %d\n", WSAGetLastError());
+        return -1;
+    }
+#endif
 
     recv->sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (recv->sockfd < 0) {
+    if (recv->sockfd == SOCK_INVALID) {
         perror("socket");
         return -1;
     }
 
-    // Set non-blocking
-    int flags = fcntl(recv->sockfd, F_GETFL, 0);
-    fcntl(recv->sockfd, F_SETFL, flags | O_NONBLOCK);
+    set_nonblocking(recv->sockfd);
 
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
@@ -36,7 +60,8 @@ int mavlink_receiver_init(mavlink_receiver_t *recv, uint16_t port) {
 
     if (bind(recv->sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         perror("bind");
-        close(recv->sockfd);
+        SOCK_CLOSE(recv->sockfd);
+        recv->sockfd = SOCK_INVALID;
         return -1;
     }
 
@@ -50,14 +75,14 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
     socklen_t sender_len = sizeof(sender);
 
     for (;;) {
-        ssize_t n = recvfrom(recv->sockfd, buf, sizeof(buf), 0,
-                             (struct sockaddr *)&sender, &sender_len);
+        int n = recvfrom(recv->sockfd, (char *)buf, sizeof(buf), 0,
+                         (struct sockaddr *)&sender, &sender_len);
         if (n <= 0) break;
 
         mavlink_message_t msg;
         mavlink_status_t status;
 
-        for (ssize_t i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             if (mavlink_parse_char(MAVLINK_COMM_0, buf[i], &msg, &status)) {
                 if (recv->debug) {
                     printf("[MAVLink] msgid=%u sysid=%u compid=%u seq=%u len=%u\n",
@@ -106,8 +131,11 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
 }
 
 void mavlink_receiver_close(mavlink_receiver_t *recv) {
-    if (recv->sockfd >= 0) {
-        close(recv->sockfd);
-        recv->sockfd = -1;
+    if (recv->sockfd != SOCK_INVALID) {
+        SOCK_CLOSE(recv->sockfd);
+        recv->sockfd = SOCK_INVALID;
     }
+#ifdef _WIN32
+    WSACleanup();
+#endif
 }

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -4,6 +4,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef _WIN32
+typedef uintptr_t sock_t;
+#define SOCK_INVALID (~(sock_t)0)
+#else
+typedef int sock_t;
+#define SOCK_INVALID (-1)
+#endif
+
 typedef struct {
     float quaternion[4]; // w, x, y, z
     int32_t lat;         // degE7
@@ -16,7 +24,7 @@ typedef struct {
 } hil_state_t;
 
 typedef struct {
-    int sockfd;
+    sock_t sockfd;
     uint16_t port;
     bool connected;
     bool debug;

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -1,5 +1,8 @@
 #include "vehicle.h"
 #include "raymath.h"
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Add Winsock2 platform abstraction in mavlink_receiver, define _USE_MATH_DEFINES for MSVC, and link ws2_32 on Windows.

Add CI workflow with matrix strategy for Linux, macOS, and Windows with raylib dep caching.

Fixes #2