### PR TITLE
Add multi-vehicle swarm support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ target_include_directories(mavsim-viewer PRIVATE
     ${MAVLINK_DIR}/common
 )
 
+# Need 16 MAVLink parse channels for multi-vehicle support
+target_compile_definitions(mavsim-viewer PRIVATE MAVLINK_COMM_NUM_BUFFERS=16)
+
 target_link_libraries(mavsim-viewer PRIVATE raylib)
 
 if(APPLE)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Built with [Raylib](https://www.raylib.com/) and [MAVLink](https://mavlink.io/).
 ## Features
 
 - Real-time 3D visualization of vehicle position and orientation
+- **Multi-vehicle swarm support** — up to 16 vehicles simultaneously
 - Multiple vehicle models: multicopter, fixed-wing, tailsitter
 - Chase and FPV camera modes (press `C` to toggle)
+- Vehicle selection: TAB, `[`/`]`, or number keys `1`-`9`
 - Mouse orbit (left-drag) and FOV zoom (scroll wheel)
-- HUD with compass, telemetry readouts (altitude, heading, roll, pitch, ground speed, vertical speed, airspeed, flight timer)
+- HUD with compass, telemetry readouts, vehicle selector indicator
 - Panoramic sky with ground texture
 - Cross-platform: macOS, Linux, and Windows supported out of the box thanks to Raylib
 
@@ -40,7 +42,9 @@ make -j$(nproc)
 
 | Option | Description |
 |---|---|
-| `-udp <port>` | UDP listen port (default: 19410) |
+| `-udp <port>` | UDP base port (default: 19410) |
+| `-n <count>` | Number of vehicles (default: 1, max: 16) |
+| `-origin <lat> <lon> <alt>` | NED origin in degrees/meters (default: PX4 SIH default) |
 | `-mc` | Multicopter model (default) |
 | `-fw` | Fixed-wing model |
 | `-ts` | Tailsitter model |
@@ -48,7 +52,9 @@ make -j$(nproc)
 | `-h <height>` | Window height (default: 720) |
 | `-d` | Debug output |
 
-### With PX4 SITL
+Each vehicle listens on its own UDP port: `base_port`, `base_port+1`, ..., `base_port+n-1`.
+
+### With PX4 SITL (single vehicle)
 
 ```bash
 # Terminal 1: Start PX4 SITL with SIH
@@ -58,6 +64,47 @@ make px4_sitl sihsim_quadx
 ./mavsim-viewer
 ```
 
+### Multi-vehicle swarm
+
+PX4 SIH supports multi-instance SITL where each instance sends `HIL_STATE_QUATERNION` on port `19410+N`. The viewer simply opens N sockets and renders all vehicles — all formation/spawn logic is handled externally (e.g. by setting `SIH_LOC_LAT0`/`SIH_LOC_LON0` params per instance).
+
+A MAVSDK Python test script is included that orchestrates a complete swarm mission: sets spawn offsets for line formation, arms all vehicles, takes off in parallel, flies a waypoint, and lands.
+
+#### Step-by-step swarm example
+
+```bash
+# 1. Build PX4 (once)
+cd PX4-Autopilot
+make px4_sitl_sih
+
+# 2. Clear any persisted spawn params from previous runs
+rm -rf build/px4_sitl_sih/instance_*/parameters*.bson
+
+# 3. Launch 5 PX4 SIH instances (10x speed optional)
+PX4_SIM_SPEED_FACTOR=10 ./Tools/simulation/sitl_multiple_run.sh 5 sihsim_quadx px4_sitl_sih
+
+# 4. In a new terminal, launch the viewer
+cd mavsim-viewer
+./build/mavsim-viewer -n 5
+
+# 5. In a new terminal, install MAVSDK and run the swarm test
+pip install mavsdk
+python tests/swarm_test.py --n 5 --speed 10
+```
+
+The test script accepts these options:
+
+| Option | Description |
+|---|---|
+| `--n <count>` | Number of vehicles (default: 5) |
+| `--spacing <meters>` | Formation spacing (default: 2.0) |
+| `--altitude <meters>` | Takeoff altitude AGL (default: 10.0) |
+| `--base-port <port>` | PX4 MAVLink base UDP port (default: 14540) |
+| `--grpc-base <port>` | MAVSDK gRPC base port (default: 50051) |
+| `--speed <factor>` | Sim speed factor to scale wait times (default: 1.0) |
+
+**Note:** If vehicles appear in formation before running the test script, it's because `SIH_LOC_LON0` params were persisted from a previous run. Clear them with `rm -rf instance_*/parameters*.bson` in the PX4 build directory.
+
 ## Controls
 
 | Key/Input | Action |
@@ -65,6 +112,9 @@ make px4_sitl sihsim_quadx
 | `C` | Toggle camera mode (Chase / FPV) |
 | `G` | Toggle Grid view mode |
 | `Ctrl+R` | Toggle Rez view mode |
+| `TAB` | Cycle to next vehicle |
+| `[` / `]` | Previous / next vehicle |
+| `1`-`9` | Select vehicle directly |
 | Left-drag | Orbit camera (chase mode) |
 | Scroll wheel | Zoom FOV |
 

--- a/src/hud.c
+++ b/src/hud.c
@@ -68,8 +68,25 @@ static void draw_compass(float cx, float cy, float radius, float heading_deg) {
     DrawText(hdg_buf, (int)(cx - tw / 2), (int)(cy + radius * 0.6f), 12, WHITE);
 }
 
-void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h) {
+void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
+              int vehicle_idx, int vehicle_total, uint8_t sysid) {
     (void)connected; // handled in second row below
+
+    // Vehicle tab header (above the bottom bar, only for multi-vehicle)
+    int tab_h = 0;
+    if (vehicle_total > 1) {
+        tab_h = 30;
+        int tab_y = screen_h - BAR_HEIGHT - tab_h;
+        DrawRectangle(0, tab_y, screen_w, tab_h, (Color){15, 15, 15, 200});
+        DrawLineEx((Vector2){0, (float)tab_y}, (Vector2){(float)screen_w, (float)tab_y},
+                   1.0f, (Color){80, 80, 80, 200});
+
+        char tab_buf[32];
+        snprintf(tab_buf, sizeof(tab_buf), "Vehicle %d/%d  [SYS %u]",
+                 vehicle_idx + 1, vehicle_total, sysid);
+        int tab_tw = MeasureText(tab_buf, 18);
+        DrawText(tab_buf, (screen_w - tab_tw) / 2, tab_y + 6, 18, (Color){240, 240, 100, 255});
+    }
 
     // Bottom bar
     int bar_y = screen_h - BAR_HEIGHT;
@@ -173,12 +190,15 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
 
     // Second row
     int row2_y = bar_y + 65;
+    float row2_x = att_cx + INSTRUMENT_RADIUS + 35;
     {
         char b[48];
         snprintf(b, sizeof(b), "Pos: %.1f, %.1f, %.1f",
                  v->position.x, v->position.y, v->position.z);
-        DrawText(b, (int)(att_cx + INSTRUMENT_RADIUS + 35), row2_y, 11, (Color){120, 120, 120, 255});
+        DrawText(b, (int)row2_x, row2_y, 11, (Color){120, 120, 120, 255});
+        row2_x += (float)MeasureText(b, 11) + 20;
     }
+
     {
         char b[16];
         snprintf(b, sizeof(b), "FPS: %d", GetFPS());

--- a/src/hud.h
+++ b/src/hud.h
@@ -11,7 +11,8 @@ typedef struct {
 
 void hud_init(hud_t *h);
 void hud_update(hud_t *h, float dt, bool connected);
-void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h);
+void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
+              int vehicle_idx, int vehicle_total, uint8_t sysid);
 void hud_cleanup(hud_t *h);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
+#include <math.h>
 
 #include "raylib.h"
 #include "mavlink_receiver.h"
@@ -8,26 +12,64 @@
 #include "scene.h"
 #include "hud.h"
 
+#define MAX_VEHICLES 16
+
+static const Color vehicle_colors[MAX_VEHICLES] = {
+    {230, 230, 230, 255}, // 0: white (default single)
+    {230,  41,  55, 255}, // 1: red
+    {  0, 228,  48, 255}, // 2: green
+    {  0, 121, 241, 255}, // 3: blue
+    {253, 249,   0, 255}, // 4: yellow
+    {255,   0, 255, 255}, // 5: magenta
+    {  0, 255, 255, 255}, // 6: cyan
+    {255, 161,   0, 255}, // 7: orange
+    {200, 122, 255, 255}, // 8: purple
+    {127, 106,  79, 255}, // 9: brown
+    {255, 109, 194, 255}, // 10: pink
+    {  0, 182, 172, 255}, // 11: teal
+    {135, 206, 235, 255}, // 12: sky blue
+    {255, 203, 164, 255}, // 13: peach
+    {170, 255, 128, 255}, // 14: lime
+    {200, 200, 200, 255}, // 15: silver
+};
+
 static void print_usage(const char *prog) {
     printf("Usage: %s [options]\n", prog);
-    printf("  -udp <port>    UDP listen port (default: 19410)\n");
+    printf("  -udp <port>    UDP base port (default: 19410)\n");
+    printf("  -n <count>     Number of vehicles (default: 1, max: %d)\n", MAX_VEHICLES);
     printf("  -mc            Multicopter model (default)\n");
     printf("  -fw            Fixed-wing model\n");
     printf("  -ts            Tailsitter model\n");
+    printf("  -origin <lat> <lon> <alt>  NED origin in degrees/meters (default: PX4 SIH)\n");
     printf("  -w <width>     Window width (default: 1280)\n");
     printf("  -h <height>    Window height (default: 720)\n");
 }
 
 int main(int argc, char *argv[]) {
-    uint16_t port = 19410;
+    uint16_t base_port = 19410;
+    int vehicle_count = 1;
     vehicle_type_t vtype = VEHICLE_MULTICOPTER;
     int win_w = 1280;
     int win_h = 720;
     bool debug = false;
+    // PX4 SIH default spawn position
+    double origin_lat = 47.397742;
+    double origin_lon = 8.545594;
+    double origin_alt = 489.4;
+    bool origin_specified = false;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-udp") == 0 && i + 1 < argc) {
-            port = (uint16_t)atoi(argv[++i]);
+            base_port = (uint16_t)atoi(argv[++i]);
+        } else if (strcmp(argv[i], "-n") == 0 && i + 1 < argc) {
+            vehicle_count = atoi(argv[++i]);
+            if (vehicle_count < 1) vehicle_count = 1;
+            if (vehicle_count > MAX_VEHICLES) vehicle_count = MAX_VEHICLES;
+        } else if (strcmp(argv[i], "-origin") == 0 && i + 3 < argc) {
+            origin_lat = atof(argv[++i]);
+            origin_lon = atof(argv[++i]);
+            origin_alt = atof(argv[++i]);
+            origin_specified = true;
         } else if (strcmp(argv[i], "-mc") == 0) {
             vtype = VEHICLE_MULTICOPTER;
         } else if (strcmp(argv[i], "-fw") == 0) {
@@ -51,18 +93,36 @@ int main(int argc, char *argv[]) {
     InitWindow(win_w, win_h, "MAVSim Viewer");
     SetTargetFPS(60);
 
-    // Init MAVLink receiver
-    mavlink_receiver_t recv;
-    recv.debug = debug;
-    if (mavlink_receiver_init(&recv, port) != 0) {
-        fprintf(stderr, "Failed to init MAVLink receiver on port %u\n", port);
-        CloseWindow();
-        return 1;
+    // Init MAVLink receivers
+    mavlink_receiver_t receivers[MAX_VEHICLES];
+    for (int i = 0; i < vehicle_count; i++) {
+        receivers[i].debug = debug;
+        if (mavlink_receiver_init(&receivers[i], base_port + i, (uint8_t)i) != 0) {
+            fprintf(stderr, "Failed to init MAVLink receiver on port %u\n", base_port + i);
+            CloseWindow();
+            return 1;
+        }
     }
 
-    // Init vehicle and scene
-    vehicle_t vehicle;
-    vehicle_init(&vehicle, vtype);
+    // Init vehicles
+    vehicle_t vehicles[MAX_VEHICLES];
+    for (int i = 0; i < vehicle_count; i++) {
+        vehicle_init(&vehicles[i], vtype);
+        vehicles[i].color = vehicle_colors[i];
+    }
+
+    // For multi-vehicle or explicit origin: pre-set the NED origin on all vehicles
+    if (vehicle_count > 1 || origin_specified) {
+        double lat0_rad = origin_lat * (M_PI / 180.0);
+        double lon0_rad = origin_lon * (M_PI / 180.0);
+        for (int i = 0; i < vehicle_count; i++) {
+            vehicles[i].lat0 = lat0_rad;
+            vehicles[i].lon0 = lon0_rad;
+            vehicles[i].alt0 = origin_alt;
+            vehicles[i].origin_set = true;
+        }
+        printf("NED origin: lat=%.6f lon=%.6f alt=%.1f\n", origin_lat, origin_lon, origin_alt);
+    }
 
     scene_t scene;
     scene_init(&scene);
@@ -70,22 +130,61 @@ int main(int argc, char *argv[]) {
     hud_t hud;
     hud_init(&hud);
 
+    int selected = 0;
+
     // Main loop
     while (!WindowShouldClose()) {
-        // Poll MAVLink
-        mavlink_receiver_poll(&recv);
+        // Poll all MAVLink receivers and update vehicles
+        for (int i = 0; i < vehicle_count; i++) {
+            mavlink_receiver_poll(&receivers[i]);
+            vehicle_update(&vehicles[i], &receivers[i].state);
+            vehicles[i].sysid = receivers[i].sysid;
+        }
 
-        // Update vehicle from latest MAVLink state
-        vehicle_update(&vehicle, &recv.state);
+        // Check if any receiver is connected (for HUD)
+        bool any_connected = false;
+        for (int i = 0; i < vehicle_count; i++) {
+            if (receivers[i].connected) { any_connected = true; break; }
+        }
 
         // Update HUD timer
-        hud_update(&hud, GetFrameTime(), recv.connected);
+        hud_update(&hud, GetFrameTime(), any_connected);
 
         // Handle input
         scene_handle_input(&scene);
 
-        // Update camera
-        scene_update_camera(&scene, vehicle.position, vehicle.rotation);
+        // Vehicle selection input
+        if (vehicle_count > 1) {
+            if (IsKeyPressed(KEY_TAB)) {
+                // Cycle to next connected vehicle
+                for (int j = 1; j <= vehicle_count; j++) {
+                    int next = (selected + j) % vehicle_count;
+                    if (receivers[next].connected) { selected = next; break; }
+                }
+            }
+            if (IsKeyPressed(KEY_LEFT_BRACKET)) {
+                for (int j = 1; j <= vehicle_count; j++) {
+                    int prev = (selected - j + vehicle_count) % vehicle_count;
+                    if (receivers[prev].connected) { selected = prev; break; }
+                }
+            }
+            if (IsKeyPressed(KEY_RIGHT_BRACKET)) {
+                for (int j = 1; j <= vehicle_count; j++) {
+                    int next = (selected + j) % vehicle_count;
+                    if (receivers[next].connected) { selected = next; break; }
+                }
+            }
+            // Number keys 1-9 for direct selection
+            for (int k = KEY_ONE; k <= KEY_NINE; k++) {
+                if (IsKeyPressed(k)) {
+                    int idx = k - KEY_ONE;
+                    if (idx < vehicle_count) selected = idx;
+                }
+            }
+        }
+
+        // Update camera to follow selected vehicle
+        scene_update_camera(&scene, vehicles[selected].position, vehicles[selected].rotation);
 
         // Render
         BeginDrawing();
@@ -95,20 +194,28 @@ int main(int argc, char *argv[]) {
 
             BeginMode3D(scene.camera);
                 scene_draw(&scene);
-                vehicle_draw(&vehicle, scene.view_mode);
+                for (int i = 0; i < vehicle_count; i++) {
+                    if (vehicles[i].active || vehicle_count == 1) {
+                        vehicle_draw(&vehicles[i], scene.view_mode, i == selected);
+                    }
+                }
             EndMode3D();
 
             // HUD
-            hud_draw(&hud, &vehicle, recv.connected, GetScreenWidth(), GetScreenHeight());
+            hud_draw(&hud, &vehicles[selected], any_connected,
+                     GetScreenWidth(), GetScreenHeight(),
+                     selected, vehicle_count, vehicles[selected].sysid);
 
         EndDrawing();
     }
 
     // Cleanup
     hud_cleanup(&hud);
-    vehicle_cleanup(&vehicle);
+    for (int i = 0; i < vehicle_count; i++) {
+        vehicle_cleanup(&vehicles[i]);
+        mavlink_receiver_close(&receivers[i]);
+    }
     scene_cleanup(&scene);
-    mavlink_receiver_close(&recv);
     CloseWindow();
 
     return 0;

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -17,6 +17,7 @@
 #endif
 
 // MAVLink config: use common message set
+// MAVLINK_COMM_NUM_BUFFERS=16 set via CMake for multi-vehicle support
 #include <mavlink.h>
 
 static int set_nonblocking(sock_t s) {
@@ -29,11 +30,12 @@ static int set_nonblocking(sock_t s) {
 #endif
 }
 
-int mavlink_receiver_init(mavlink_receiver_t *recv, uint16_t port) {
+int mavlink_receiver_init(mavlink_receiver_t *recv, uint16_t port, uint8_t channel) {
     bool debug = recv->debug;
     memset(recv, 0, sizeof(*recv));
     recv->debug = debug;
     recv->port = port;
+    recv->channel = channel;
     recv->sockfd = SOCK_INVALID;
 
 #ifdef _WIN32
@@ -83,7 +85,7 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
         mavlink_status_t status;
 
         for (int i = 0; i < n; i++) {
-            if (mavlink_parse_char(MAVLINK_COMM_0, buf[i], &msg, &status)) {
+            if (mavlink_parse_char(recv->channel, buf[i], &msg, &status)) {
                 if (recv->debug) {
                     printf("[MAVLink] msgid=%u sysid=%u compid=%u seq=%u len=%u\n",
                            msg.msgid, msg.sysid, msg.compid, msg.seq, msg.len);

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -26,14 +26,15 @@ typedef struct {
 typedef struct {
     sock_t sockfd;
     uint16_t port;
+    uint8_t channel;
     bool connected;
     bool debug;
     uint8_t sysid;
     hil_state_t state;
 } mavlink_receiver_t;
 
-// Initialize UDP socket on given port. Returns 0 on success.
-int mavlink_receiver_init(mavlink_receiver_t *recv, uint16_t port);
+// Initialize UDP socket on given port with MAVLink parse channel. Returns 0 on success.
+int mavlink_receiver_init(mavlink_receiver_t *recv, uint16_t port, uint8_t channel);
 
 // Poll for new messages (non-blocking). Call once per frame.
 void mavlink_receiver_poll(mavlink_receiver_t *recv);

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -27,8 +27,10 @@ void vehicle_init(vehicle_t *v, vehicle_type_t type) {
     v->position = (Vector3){0};
     v->rotation = QuaternionIdentity();
     v->origin_set = false;
+    v->active = false;
     v->model_scale = model_scales[type];
     v->red_material_idx = -1;
+    v->color = WHITE;
 
     v->model = LoadModel(model_paths[type]);
     if (v->model.meshCount == 0) {
@@ -70,28 +72,24 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
         v->origin_set = true;
     }
 
-    // jMAVSim local position: X=North, Y=East, Z=Up (same as MAVLinkDisplayOnly.java)
-    double jmav_x = EARTH_RADIUS * (lat - v->lat0);               // North
-    double jmav_y = EARTH_RADIUS * (lon - v->lon0) * cos(v->lat0); // East
-    double jmav_z = alt - v->alt0;                                  // Up
+    v->active = true;
 
-    // jMAVSim frame (X=North,Y=East,Z=Up) → Raylib (X=right,Y=up,Z=back)
-    // jMAVSim X (North) → Raylib -Z
-    // jMAVSim Y (East)  → Raylib +X
-    // jMAVSim Z (Up)    → Raylib +Y
+    // Local NED position relative to origin
+    double jmav_x = EARTH_RADIUS * (lat - v->lat0);                // North
+    double jmav_y = EARTH_RADIUS * (lon - v->lon0) * cos(v->lat0); // East
+    double jmav_z = alt - v->alt0;                                   // Up
+
+    // NED frame → Raylib (X=right, Y=up, Z=back)
     v->position.x = (float)jmav_y;
     v->position.y = (float)jmav_z;
     if (v->position.y < 0.0f) v->position.y = 0.0f;
     v->position.z = (float)(-jmav_x);
 
-    // MAVLink quaternion: w,x,y,z in NED frame
-    // NED rotation axes: X=North, Y=East, Z=Down
-    // Raylib rotation axes: X=East, Y=Up, Z=South
-    // Mapping: NED_X→-Ray_Z, NED_Y→Ray_X, NED_Z→-Ray_Y
+    // MAVLink quaternion: w,x,y,z in NED frame → Raylib
     float qw = state->quaternion[0];
-    float qx = state->quaternion[1]; // NED X (North) → -Raylib Z
-    float qy = state->quaternion[2]; // NED Y (East)  → +Raylib X
-    float qz = state->quaternion[3]; // NED Z (Down)  → -Raylib Y
+    float qx = state->quaternion[1];
+    float qy = state->quaternion[2];
+    float qz = state->quaternion[3];
 
     v->rotation.w = qw;
     v->rotation.x = qy;
@@ -99,7 +97,6 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
     v->rotation.z = -qx;
 
     // Derived telemetry from NED quaternion
-    // Normalize quaternion sign so qw >= 0 (avoids flipped Euler angles)
     float nw = qw, nx = qx, ny = qy, nz = qz;
     if (nw < 0.0f) { nw = -nw; nx = -nx; ny = -ny; nz = -nz; }
 
@@ -120,10 +117,10 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
                             (float)state->vy * state->vy) * 0.01f;
     v->vertical_speed = -state->vz * 0.01f;
     v->airspeed = state->ind_airspeed * 0.01f;
-    v->altitude_rel = (float)((state->alt * 1e-3) - v->alt0);
+    v->altitude_rel = (float)(alt - v->alt0);
 }
 
-void vehicle_draw(vehicle_t *v, view_mode_t view_mode) {
+void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
     // In Rez mode, swap red arms to orange
     Color saved_red = {0};
     if (view_mode == VIEW_REZ && v->red_material_idx >= 0) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -18,6 +18,7 @@ typedef struct {
     Quaternion rotation;     // Raylib quaternion
     vehicle_type_t type;
     bool origin_set;
+    bool active;             // has received data
     double lat0;             // radians
     double lon0;             // radians
     double alt0;             // meters
@@ -30,6 +31,8 @@ typedef struct {
     float airspeed;          // m/s
     float altitude_rel;      // meters above origin
     int red_material_idx;    // material index for red arms (-1 if not found)
+    uint8_t sysid;
+    Color color;
 } vehicle_t;
 
 // Load vehicle model. type selects which OBJ to load.
@@ -38,8 +41,8 @@ void vehicle_init(vehicle_t *v, vehicle_type_t type);
 // Update position/rotation from HIL_STATE_QUATERNION data.
 void vehicle_update(vehicle_t *v, const hil_state_t *state);
 
-// Draw the vehicle model. Pass current view mode for per-mode coloring.
-void vehicle_draw(vehicle_t *v, view_mode_t view_mode);
+// Draw the vehicle model. Pass view mode for per-mode coloring and selected state.
+void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected);
 
 // Unload model resources.
 void vehicle_cleanup(vehicle_t *v);

--- a/tests/swarm_test.py
+++ b/tests/swarm_test.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+MAVSDK swarm test for PX4 SIH SITL multi-vehicle.
+
+Orchestrates N vehicles through: set spawn offsets, takeoff, fly to waypoint, land.
+The test script handles all formation/grid logic externally -- the viewer just renders.
+
+Prerequisites:
+  - PX4 SIH instances running:
+      cd /path/to/PX4-Autopilot
+      make px4_sitl_sih
+      ./Tools/simulation/sitl_multiple_run.sh 5 sihsim_quadx px4_sitl_sih
+
+  - One mavsdk_server per vehicle (ports 50051+i, connecting to udpin://0.0.0.0:14540+i)
+
+  - pip install mavsdk
+
+  - mavsim-viewer running:
+      ./build/mavsim-viewer -n 5
+
+Usage:
+  python tests/swarm_test.py --n 5
+
+Verification:
+  1. Build PX4:    cd PX4-Autopilot && make px4_sitl_sih
+  2. Launch swarm:  ./Tools/simulation/sitl_multiple_run.sh 5 sihsim_quadx px4_sitl_sih
+  3. Launch viewer: ./build/mavsim-viewer -n 5
+  4. Run test:      python tests/swarm_test.py --n 5
+  5. Expected:
+     - All 5 vehicles take off simultaneously in tight line formation (2m spacing)
+     - Fly North 20m together maintaining formation
+     - Hold 5 seconds
+     - Return to spawn positions
+     - Land all together
+     - Viewer shows all 5 vehicles, TAB cycles between them, HUD updates per selection
+"""
+
+import argparse
+import asyncio
+import sys
+
+from mavsdk import System
+from mavsdk.offboard import OffboardError, PositionNedYaw
+
+BASE_LAT = 47.397742
+BASE_LON = 8.545594
+METERS_PER_DEG_LON = 75500.0  # at lat ~47.4
+
+
+def get_spawn_lon(index, n_vehicles, spacing_m):
+    """Calculate longitude offset for line formation along East axis."""
+    offset_m = (index - (n_vehicles - 1) / 2.0) * spacing_m
+    return BASE_LON + offset_m / METERS_PER_DEG_LON
+
+
+async def set_spawn_offset(drone, index, n_vehicles, spacing_m):
+    """Set SIH spawn position parameters for line formation."""
+    spawn_lon = get_spawn_lon(index, n_vehicles, spacing_m)
+    print(f"[Vehicle {index}] Setting spawn: lat={BASE_LAT:.6f} lon={spawn_lon:.6f}")
+    await drone.param.set_param_float("SIH_LOC_LAT0", BASE_LAT)
+    await drone.param.set_param_float("SIH_LOC_LON0", spawn_lon)
+
+
+async def connect_drone(index, grpc_port, udp_port):
+    """Connect to a single PX4 instance via MAVSDK."""
+    drone = System(port=grpc_port)
+    address = f"udpin://0.0.0.0:{udp_port}"
+    print(f"[Vehicle {index}] Connecting on {address} (gRPC:{grpc_port})...")
+    await drone.connect(system_address=address)
+
+    # Wait for connection with timeout
+    async def wait_connected():
+        async for state in drone.core.connection_state():
+            if state.is_connected:
+                print(f"[Vehicle {index}] Connected")
+                return
+    await asyncio.wait_for(wait_connected(), timeout=30)
+
+    return drone
+
+
+async def wait_for_gps(drone, index):
+    """Wait until the vehicle has a GPS fix."""
+    print(f"[Vehicle {index}] Waiting for GPS fix...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print(f"[Vehicle {index}] GPS fix acquired")
+            return
+    raise RuntimeError(f"Vehicle {index}: GPS fix timeout")
+
+
+
+async def arm_and_takeoff(drone, index, altitude, max_retries=10):
+    """Arm and take off to specified altitude, with retry on COMMAND_DENIED."""
+    await drone.action.set_takeoff_altitude(altitude)
+
+    for attempt in range(max_retries):
+        try:
+            print(f"[Vehicle {index}] Arming (attempt {attempt + 1})...")
+            await drone.action.arm()
+            print(f"[Vehicle {index}] Armed, taking off to {altitude}m...")
+            await drone.action.takeoff()
+            break
+        except Exception as e:
+            if "COMMAND_DENIED" in str(e) and attempt < max_retries - 1:
+                print(f"[Vehicle {index}] Arm denied, waiting for estimator... ({e})")
+                await asyncio.sleep(1)
+            else:
+                raise
+
+    # Wait until near target altitude (with timeout)
+    async def wait_altitude():
+        async for position in drone.telemetry.position():
+            if position.relative_altitude_m >= altitude * 0.9:
+                print(f"[Vehicle {index}] Reached {position.relative_altitude_m:.1f}m")
+                return
+    try:
+        await asyncio.wait_for(wait_altitude(), timeout=30)
+    except asyncio.TimeoutError:
+        print(f"[Vehicle {index}] WARNING: altitude wait timed out, continuing...")
+
+
+async def start_offboard(drone, index, initial_ned):
+    """Start offboard mode with initial setpoint."""
+    await drone.offboard.set_position_ned(initial_ned)
+    try:
+        await drone.offboard.start()
+        print(f"[Vehicle {index}] Offboard mode started")
+    except OffboardError as e:
+        print(f"[Vehicle {index}] Offboard start failed: {e}")
+        raise
+
+
+async def fly_to_ned(drone, index, position_ned, tolerance=1.0):
+    """Fly to NED position and wait until reached."""
+    await drone.offboard.set_position_ned(position_ned)
+    print(f"[Vehicle {index}] Flying to N={position_ned.north_m:.1f} "
+          f"E={position_ned.east_m:.1f} D={position_ned.down_m:.1f}")
+
+    # Wait until close to target (with timeout)
+    async def wait_position():
+        async for odom in drone.telemetry.position_velocity_ned():
+            pos = odom.position
+            dn = pos.north_m - position_ned.north_m
+            de = pos.east_m - position_ned.east_m
+            dd = pos.down_m - position_ned.down_m
+            dist = (dn**2 + de**2 + dd**2) ** 0.5
+            if dist < tolerance:
+                print(f"[Vehicle {index}] Reached target (dist={dist:.2f}m)")
+                return
+    try:
+        await asyncio.wait_for(wait_position(), timeout=30)
+    except asyncio.TimeoutError:
+        print(f"[Vehicle {index}] WARNING: position wait timed out, continuing...")
+
+
+async def land_drone(drone, index):
+    """Switch to land mode."""
+    print(f"[Vehicle {index}] Landing...")
+    try:
+        await drone.offboard.stop()
+    except OffboardError:
+        pass
+    await drone.action.land()
+
+    # Wait for disarm (indicates touchdown)
+    async def wait_disarm():
+        async for armed in drone.telemetry.armed():
+            if not armed:
+                print(f"[Vehicle {index}] Landed and disarmed")
+                return
+    try:
+        await asyncio.wait_for(wait_disarm(), timeout=30)
+    except asyncio.TimeoutError:
+        print(f"[Vehicle {index}] WARNING: disarm wait timed out")
+
+
+async def run_swarm_mission(n_vehicles, spacing, altitude, base_udp_port, grpc_base,
+                            speed=1.0):
+    """Run the complete swarm mission."""
+    # Scale sleep durations by speed factor (faster sim = shorter waits)
+    def sim_sleep(real_seconds):
+        return asyncio.sleep(real_seconds / speed)
+
+    # 1. Connect to all vehicles (sequential to avoid mavsdk_server port contention)
+    print(f"\n=== Connecting to {n_vehicles} vehicles (speed={speed}x) ===")
+    drones = []
+    for i in range(n_vehicles):
+        drone = await connect_drone(i, grpc_base + i, base_udp_port + i)
+        drones.append(drone)
+
+    # 2. Wait for GPS on all
+    print("\n=== Waiting for GPS ===")
+    await asyncio.gather(*[
+        asyncio.wait_for(wait_for_gps(d, i), timeout=60)
+        for i, d in enumerate(drones)
+    ])
+
+    # 3. Set spawn offsets for line formation
+    print("\n=== Setting spawn positions ===")
+    for i, d in enumerate(drones):
+        await set_spawn_offset(d, i, n_vehicles, spacing)
+
+    # Wait for SIH to apply new positions and estimator to reinitialize
+    # Note: do NOT scale this by speed — estimator needs real wall-clock time
+    print("\n=== Waiting for estimator to reinitialize ===")
+    await asyncio.sleep(5)
+    await asyncio.gather(*[
+        asyncio.wait_for(wait_for_gps(d, i), timeout=60)
+        for i, d in enumerate(drones)
+    ])
+
+    # 4. Arm and takeoff (parallel)
+    print("\n=== Arming and taking off ===")
+    await asyncio.gather(*[
+        arm_and_takeoff(d, i, altitude)
+        for i, d in enumerate(drones)
+    ])
+
+    # 5. Start offboard mode on all vehicles
+    print("\n=== Starting offboard mode ===")
+    await asyncio.gather(*[
+        start_offboard(d, i, PositionNedYaw(0.0, 0.0, -altitude, 0.0))
+        for i, d in enumerate(drones)
+    ])
+
+    # 6. Fly 20m North maintaining formation
+    print("\n=== Flying 20m North ===")
+    await asyncio.gather(*[
+        fly_to_ned(d, i, PositionNedYaw(20.0, 0.0, -altitude, 0.0))
+        for i, d in enumerate(drones)
+    ])
+
+    # 7. Hold position
+    print("\n=== Holding position for 5s ===")
+    await sim_sleep(5)
+
+    # 8. Return to above spawn positions
+    print("\n=== Returning to spawn positions ===")
+    await asyncio.gather(*[
+        fly_to_ned(d, i, PositionNedYaw(0.0, 0.0, -altitude, 0.0))
+        for i, d in enumerate(drones)
+    ])
+
+    # 9. Land all together
+    print("\n=== Landing ===")
+    await asyncio.gather(*[
+        land_drone(d, i)
+        for i, d in enumerate(drones)
+    ])
+
+    print("\n=== Mission complete ===")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="MAVSDK swarm test for PX4 SIH")
+    parser.add_argument("--n", type=int, default=5, help="Number of vehicles (default: 5)")
+    parser.add_argument("--spacing", type=float, default=2.0,
+                        help="Formation spacing in meters (default: 2.0)")
+    parser.add_argument("--altitude", type=float, default=10.0,
+                        help="Takeoff altitude AGL in meters (default: 10.0)")
+    parser.add_argument("--base-port", type=int, default=14540,
+                        help="PX4 MAVLink base UDP port (default: 14540)")
+    parser.add_argument("--grpc-base", type=int, default=50051,
+                        help="MAVSDK gRPC base port (default: 50051)")
+    parser.add_argument("--speed", type=float, default=1.0,
+                        help="PX4 sim speed factor (default: 1.0, use 10 for 10x)")
+    args = parser.parse_args()
+
+    try:
+        await run_swarm_mission(args.n, args.spacing, args.altitude,
+                                args.base_port, args.grpc_base, args.speed)
+    except Exception as e:
+        print(f"\nMission failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/swarm_test.py
+++ b/tests/swarm_test.py
@@ -210,6 +210,10 @@ async def run_swarm_mission(n_vehicles, spacing, altitude, base_udp_port, grpc_b
         for i, d in enumerate(drones)
     ])
 
+    # Compute East offsets so vehicles maintain formation spacing in offboard mode
+    # (offboard NED is relative to home, which doesn't update with SIH spawn params)
+    east_offsets = [(i - (n_vehicles - 1) / 2.0) * spacing for i in range(n_vehicles)]
+
     # 4. Arm and takeoff (parallel)
     print("\n=== Arming and taking off ===")
     await asyncio.gather(*[
@@ -220,14 +224,14 @@ async def run_swarm_mission(n_vehicles, spacing, altitude, base_udp_port, grpc_b
     # 5. Start offboard mode on all vehicles
     print("\n=== Starting offboard mode ===")
     await asyncio.gather(*[
-        start_offboard(d, i, PositionNedYaw(0.0, 0.0, -altitude, 0.0))
+        start_offboard(d, i, PositionNedYaw(0.0, east_offsets[i], -altitude, 0.0))
         for i, d in enumerate(drones)
     ])
 
     # 6. Fly 20m North maintaining formation
     print("\n=== Flying 20m North ===")
     await asyncio.gather(*[
-        fly_to_ned(d, i, PositionNedYaw(20.0, 0.0, -altitude, 0.0))
+        fly_to_ned(d, i, PositionNedYaw(20.0, east_offsets[i], -altitude, 0.0))
         for i, d in enumerate(drones)
     ])
 
@@ -238,7 +242,7 @@ async def run_swarm_mission(n_vehicles, spacing, altitude, base_udp_port, grpc_b
     # 8. Return to above spawn positions
     print("\n=== Returning to spawn positions ===")
     await asyncio.gather(*[
-        fly_to_ned(d, i, PositionNedYaw(0.0, 0.0, -altitude, 0.0))
+        fly_to_ned(d, i, PositionNedYaw(0.0, east_offsets[i], -altitude, 0.0))
         for i, d in enumerate(drones)
     ])
 


### PR DESCRIPTION
- **Multi-vehicle rendering**: up to 16 vehicles simultaneously, each on its own UDP port (`base_port+N`) with independent MAVLink parse channels
- **Vehicle selection**: TAB cycles vehicles, `[`/`]` for prev/next, number keys `1`-`9` for direct selection; HUD shows selected vehicle ID and sysid
- **CLI options**: `-n <count>` for vehicle count, `-origin <lat> <lon> <alt>` for shared NED origin (defaults to PX4 SIH spawn position)
- **MAVSDK swarm test script** (`tests/swarm_test.py`): orchestrates N vehicles through spawn offset setup, parallel arm/takeoff, formation flight, and landing with arm retry logic and `--speed` factor for faster-than-realtime testing

The viewer is intentionally "dumb" — all formation/spawn logic is handled externally (e.g. via PX4 params or MAVSDK). The viewer just opens N sockets and renders whatever PX4 sends.