### PR TITLE
Add Grid and Rez view modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,16 @@ make px4_sitl sihsim_quadx
 | Key/Input | Action |
 |---|---|
 | `C` | Toggle camera mode (Chase / FPV) |
+| `G` | Toggle Grid view mode |
+| `Ctrl+R` | Toggle Rez view mode |
 | Left-drag | Orbit camera (chase mode) |
 | Scroll wheel | Zoom FOV |
+
+### View Modes
+
+- **Texture** (default) — Panoramic sky with ground texture
+- **Grid** — Debug grid with minor/major lines and colored axes
+- **Rez** — Teal grid on black ground with dark sky
 
 ## Acknowledgments
 

--- a/src/main.c
+++ b/src/main.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
 
             BeginMode3D(scene.camera);
                 scene_draw(&scene);
-                vehicle_draw(&vehicle);
+                vehicle_draw(&vehicle, scene.view_mode);
             EndMode3D();
 
             // HUD

--- a/src/scene.c
+++ b/src/scene.c
@@ -8,8 +8,30 @@
 #define GROUND_TILES 100.0f   // texture repeat count
 #define SKY_RADIUS 6000.0f    // sky sphere radius (larger than ground diagonal)
 
+// Grid shared settings
+#define GRID_EXTENT      500.0f
+#define GRID_SPACING     10.0f
+#define GRID_MAJOR_EVERY 5
+
+// Grid mode colors
+#define GRID_SKY       (Color){ 56,  56,  60, 255 }
+#define GRID_GROUND    (Color){ 32,  32,  34, 255 }
+#define GRID_MINOR     (Color){ 97,  97,  97, 128 }
+#define GRID_MAJOR     (Color){ 143, 143, 143, 128 }
+#define GRID_AXIS_X    (Color){ 200,  60,  60, 180 }
+#define GRID_AXIS_Z    (Color){ 60,   60, 200, 180 }
+
+// Rez mode colors
+#define REZ_SKY        (Color){ 12,  12,  18, 255 }  // near-black
+#define REZ_GROUND     (Color){ 2,    2,   4, 255 }  // black
+#define REZ_MINOR      (Color){ 0,  204, 218, 50 }   // teal, subtle
+#define REZ_MAJOR      (Color){ 0,  204, 218, 140 }  // teal, bright
+#define REZ_AXIS_X     (Color){ 0,  204, 218, 220 }  // teal, full
+#define REZ_AXIS_Z     (Color){ 0,  204, 218, 220 }  // teal, full
+
 void scene_init(scene_t *s) {
     s->cam_mode = CAM_MODE_CHASE;
+    s->view_mode = VIEW_TEXTURE;
     s->chase_distance = 3.0f;
     s->chase_yaw = 0.0f;
     s->chase_pitch = 0.4f;  // ~23° above horizontal
@@ -104,6 +126,16 @@ void scene_handle_input(scene_t *s) {
         s->camera.up = (Vector3){0, 1, 0};
     }
 
+    if (IsKeyPressed(KEY_G)) {
+        s->view_mode = (s->view_mode == VIEW_GRID) ? VIEW_TEXTURE : VIEW_GRID;
+        printf("View: %s\n", s->view_mode == VIEW_GRID ? "Grid" : "Texture");
+    }
+
+    if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_R)) {
+        s->view_mode = (s->view_mode == VIEW_REZ) ? VIEW_TEXTURE : VIEW_REZ;
+        printf("View: %s\n", s->view_mode == VIEW_REZ ? "Rez" : "Texture");
+    }
+
     // Mouse drag to orbit (left button)
     if (s->cam_mode == CAM_MODE_CHASE && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
         Vector2 delta = GetMouseDelta();
@@ -124,21 +156,55 @@ void scene_handle_input(scene_t *s) {
     }
 }
 
+static void draw_grid(Color minor, Color major, Color axis_x, Color axis_z, Color ground) {
+    // Dark ground volume — top face below Y=0 to avoid z-fighting
+    DrawCube((Vector3){0, -5000.05f, 0}, GROUND_SIZE * 2, 10000.0f, GROUND_SIZE * 2, ground);
+
+    float extent = GRID_EXTENT;
+    float spacing = GRID_SPACING;
+    int lines = (int)(extent / spacing);
+
+    for (int i = -lines; i <= lines; i++) {
+        bool is_major = (i % GRID_MAJOR_EVERY == 0);
+        bool is_origin = (i == 0);
+        float pos = i * spacing;
+
+        if (is_origin) {
+            DrawLine3D((Vector3){-extent, 0, 0}, (Vector3){extent, 0, 0}, axis_x);
+            DrawLine3D((Vector3){0, 0, -extent}, (Vector3){0, 0, extent}, axis_z);
+        } else {
+            Color col = is_major ? major : minor;
+            DrawLine3D((Vector3){-extent, 0, pos}, (Vector3){extent, 0, pos}, col);
+            DrawLine3D((Vector3){pos, 0, -extent}, (Vector3){pos, 0, extent}, col);
+        }
+    }
+}
+
 void scene_draw(const scene_t *s) {
-    // Sky sphere centered on camera — disable culling so we see it from inside
-    rlDisableBackfaceCulling();
-    DrawModel(s->sky_sphere, s->camera.position, 1.0f, WHITE);
-    rlEnableBackfaceCulling();
+    if (s->view_mode == VIEW_GRID) {
+        draw_grid(GRID_MINOR, GRID_MAJOR, GRID_AXIS_X, GRID_AXIS_Z, GRID_GROUND);
+    } else if (s->view_mode == VIEW_REZ) {
+        draw_grid(REZ_MINOR, REZ_MAJOR, REZ_AXIS_X, REZ_AXIS_Z, REZ_GROUND);
+    } else {
+        // Sky sphere centered on camera — disable culling so we see it from inside
+        rlDisableBackfaceCulling();
+        DrawModel(s->sky_sphere, s->camera.position, 1.0f, WHITE);
+        rlEnableBackfaceCulling();
 
-    // Ground
-    DrawModel(s->ground, (Vector3){0, 0, 0}, 1.0f, WHITE);
+        // Ground
+        DrawModel(s->ground, (Vector3){0, 0, 0}, 1.0f, WHITE);
 
-    // Reference grid
-    DrawGrid(100, 10.0f);
+        // Reference grid
+        DrawGrid(100, 10.0f);
+    }
 }
 
 void scene_draw_sky(const scene_t *s) {
-    ClearBackground((Color){135, 206, 235, 255});
+    switch (s->view_mode) {
+        case VIEW_GRID: ClearBackground(GRID_SKY); break;
+        case VIEW_REZ:  ClearBackground(REZ_SKY);  break;
+        default:        ClearBackground((Color){135, 206, 235, 255}); break;
+    }
 }
 
 void scene_cleanup(scene_t *s) {

--- a/src/scene.h
+++ b/src/scene.h
@@ -2,12 +2,19 @@
 #define SCENE_H
 
 #include "raylib.h"
+#include <stdbool.h>
 
 typedef enum {
     CAM_MODE_CHASE = 0,
     CAM_MODE_FPV,
     CAM_MODE_COUNT
 } camera_mode_t;
+
+typedef enum {
+    VIEW_TEXTURE = 0,
+    VIEW_GRID,
+    VIEW_REZ,
+} view_mode_t;
 
 typedef struct {
     Model ground;
@@ -16,6 +23,7 @@ typedef struct {
     Texture2D sky_tex;
     Camera3D camera;
     camera_mode_t cam_mode;
+    view_mode_t view_mode;
     float chase_distance;
     float chase_yaw;    // horizontal orbit angle (radians)
     float chase_pitch;  // vertical orbit angle (radians)

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -25,10 +25,31 @@ void vehicle_init(vehicle_t *v, vehicle_type_t type) {
     v->rotation = QuaternionIdentity();
     v->origin_set = false;
     v->model_scale = model_scales[type];
+    v->red_material_idx = -1;
 
     v->model = LoadModel(model_paths[type]);
     if (v->model.meshCount == 0) {
         printf("Warning: failed to load model %s\n", model_paths[type]);
+    }
+
+    // Remap material colors
+    // MTL order: 0=default, 1=Blue_Metal, 2=Gray_Plastic, 3=Red_Metal, 4=Textolite
+    for (int i = 0; i < v->model.materialCount; i++) {
+        Color *c = &v->model.materials[i].maps[MATERIAL_MAP_DIFFUSE].color;
+        // Blue_Metal → #272fc5
+        if (c->b > 100 && c->r < 50)
+            *c = (Color){ 39, 47, 197, 255 };
+        // Red_Metal → #ff2f2b
+        else if (c->r > 100 && c->g < 50 && c->b < 50) {
+            *c = (Color){ 255, 47, 43, 255 };
+            v->red_material_idx = i;
+        }
+        // Gray_Plastic (props) → #5075a2
+        else if (c->r > 60 && c->r < 140 && c->g > 60 && c->g < 140)
+            *c = (Color){ 80, 117, 162, 255 };
+        // Textolite (body, near-black) → #0e1f2f
+        else if (c->r < 20 && c->g < 20 && c->b < 20)
+            *c = (Color){ 14, 31, 47, 255 };
     }
 }
 
@@ -99,7 +120,14 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
     v->altitude_rel = (float)((state->alt * 1e-3) - v->alt0);
 }
 
-void vehicle_draw(vehicle_t *v) {
+void vehicle_draw(vehicle_t *v, view_mode_t view_mode) {
+    // In Rez mode, swap red arms to orange
+    Color saved_red = {0};
+    if (view_mode == VIEW_REZ && v->red_material_idx >= 0) {
+        Color *c = &v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color;
+        saved_red = *c;
+        *c = (Color){ 255, 106, 0, 255 }; // #ff6a00 orange
+    }
     // OBJ model: flat in XY, thin in Z (Z is model's up).
     // Raylib: Y is up. Rotate +90° around X so model Z → Raylib Y.
     Matrix base_rot = MatrixRotateX(90.0f * DEG2RAD);
@@ -111,6 +139,11 @@ void vehicle_draw(vehicle_t *v) {
     v->model.transform = MatrixMultiply(MatrixMultiply(MatrixMultiply(scale, base_rot), rot), trans);
 
     DrawModel(v->model, (Vector3){0}, 1.0f, WHITE);
+
+    // Restore original color
+    if (view_mode == VIEW_REZ && v->red_material_idx >= 0) {
+        v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color = saved_red;
+    }
 }
 
 void vehicle_cleanup(vehicle_t *v) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -3,6 +3,7 @@
 
 #include "raylib.h"
 #include "mavlink_receiver.h"
+#include "scene.h"
 
 typedef enum {
     VEHICLE_MULTICOPTER = 0,
@@ -28,6 +29,7 @@ typedef struct {
     float vertical_speed;    // m/s (positive = climbing)
     float airspeed;          // m/s
     float altitude_rel;      // meters above origin
+    int red_material_idx;    // material index for red arms (-1 if not found)
 } vehicle_t;
 
 // Load vehicle model. type selects which OBJ to load.
@@ -36,8 +38,8 @@ void vehicle_init(vehicle_t *v, vehicle_type_t type);
 // Update position/rotation from HIL_STATE_QUATERNION data.
 void vehicle_update(vehicle_t *v, const hil_state_t *state);
 
-// Draw the vehicle model.
-void vehicle_draw(vehicle_t *v);
+// Draw the vehicle model. Pass current view mode for per-mode coloring.
+void vehicle_draw(vehicle_t *v, view_mode_t view_mode);
 
 // Unload model resources.
 void vehicle_cleanup(vehicle_t *v);


### PR DESCRIPTION
## Summary

- **Grid mode** (`G`): Debug grid with minor/major lines, colored axes, dark ground and sky
- **Rez mode** (`Ctrl+R`): Teal grid on black ground with dark sky; vehicle arms swap to orange
- Remap vehicle material colors at init (body `#0e1f2f`, props `#5075a2`, red arms `#ff2f2b`, blue arms `#272fc5`)
- Updated README with new controls and view mode descriptions

## Test plan

- [ ] Build and launch viewer
- [ ] Press `G` to toggle Grid mode — verify grid lines, colored axes, dark background
- [ ] Press `Ctrl+R` to toggle Rez mode — verify teal grid, black ground, dark sky
- [ ] Verify vehicle arms turn orange in Rez mode and red in other modes
- [ ] Press `G` or `Ctrl+R` again to return to Texture mode