### PR TITLE
feat: single-key view cycling and HUD connection status

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ The test script accepts these options:
 | Key/Input | Action |
 |---|---|
 | `C` | Toggle camera mode (Chase / FPV) |
-| `G` | Toggle Grid view mode |
-| `Ctrl+R` | Toggle Rez view mode |
+| `V` | Cycle view mode (Grid / jMAVSim / Rez) |
 | `TAB` | Cycle to next vehicle |
 | `[` / `]` | Previous / next vehicle |
 | `1`-`9` | Select vehicle directly |
@@ -120,8 +119,8 @@ The test script accepts these options:
 
 ### View Modes
 
-- **Texture** (default) — Panoramic sky with ground texture
-- **Grid** — Debug grid with minor/major lines and colored axes
+- **Grid** (default) — Debug grid with minor/major lines and colored axes
+- **jMAVSim** — Panoramic sky with ground texture
 - **Rez** — Teal grid on black ground with dark sky
 
 ## Acknowledgments

--- a/src/hud.c
+++ b/src/hud.c
@@ -70,7 +70,6 @@ static void draw_compass(float cx, float cy, float radius, float heading_deg) {
 
 void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
               int vehicle_idx, int vehicle_total, uint8_t sysid) {
-    (void)connected; // handled in second row below
 
     // Vehicle tab header (above the bottom bar, only for multi-vehicle)
     int tab_h = 0;
@@ -205,10 +204,16 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
         int fps_x = screen_w - 70;
         DrawText(b, fps_x, row2_y, 11, (Color){100, 100, 100, 255});
 
-        if (!connected) {
-            const char *msg = "Waiting for MAVLink...";
-            int msg_w = MeasureText(msg, 11);
-            DrawText(msg, fps_x - msg_w - 15, row2_y, 11, RED);
+        {
+            char status_buf[32];
+            if (connected) {
+                snprintf(status_buf, sizeof(status_buf), "MAVLink SYS %u", sysid);
+            } else {
+                snprintf(status_buf, sizeof(status_buf), "Waiting for MAVLink...");
+            }
+            Color status_color = connected ? (Color){100, 200, 100, 255} : WHITE;
+            int msg_w = MeasureText(status_buf, 11);
+            DrawText(status_buf, fps_x - msg_w - 15, row2_y, 11, status_color);
         }
     }
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -9,8 +9,8 @@
 #define SKY_RADIUS 6000.0f    // sky sphere radius (larger than ground diagonal)
 
 // Grid shared settings
-#define GRID_EXTENT      500.0f
-#define GRID_SPACING     10.0f
+#define GRID_EXTENT      250.0f
+#define GRID_SPACING     5.0f
 #define GRID_MAJOR_EVERY 5
 
 // Grid mode colors
@@ -31,7 +31,7 @@
 
 void scene_init(scene_t *s) {
     s->cam_mode = CAM_MODE_CHASE;
-    s->view_mode = VIEW_TEXTURE;
+    s->view_mode = VIEW_GRID;
     s->chase_distance = 3.0f;
     s->chase_yaw = 0.0f;
     s->chase_pitch = 0.4f;  // ~23° above horizontal
@@ -126,14 +126,10 @@ void scene_handle_input(scene_t *s) {
         s->camera.up = (Vector3){0, 1, 0};
     }
 
-    if (IsKeyPressed(KEY_G)) {
-        s->view_mode = (s->view_mode == VIEW_GRID) ? VIEW_TEXTURE : VIEW_GRID;
-        printf("View: %s\n", s->view_mode == VIEW_GRID ? "Grid" : "Texture");
-    }
-
-    if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_R)) {
-        s->view_mode = (s->view_mode == VIEW_REZ) ? VIEW_TEXTURE : VIEW_REZ;
-        printf("View: %s\n", s->view_mode == VIEW_REZ ? "Rez" : "Texture");
+    if (IsKeyPressed(KEY_V)) {
+        s->view_mode = (s->view_mode + 1) % VIEW_COUNT;
+        const char *names[] = {"Grid", "jMAVSim", "Rez"};
+        printf("View: %s\n", names[s->view_mode]);
     }
 
     // Mouse drag to orbit (left button)
@@ -194,8 +190,7 @@ void scene_draw(const scene_t *s) {
         // Ground
         DrawModel(s->ground, (Vector3){0, 0, 0}, 1.0f, WHITE);
 
-        // Reference grid
-        DrawGrid(100, 10.0f);
+
     }
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -11,9 +11,10 @@ typedef enum {
 } camera_mode_t;
 
 typedef enum {
-    VIEW_TEXTURE = 0,
-    VIEW_GRID,
+    VIEW_GRID = 0,
+    VIEW_JMAVSIM,
     VIEW_REZ,
+    VIEW_COUNT,
 } view_mode_t;
 
 typedef struct {


### PR DESCRIPTION
Replace the separate **G** and **Ctrl+R** view shortcuts with a single **V** key that cycles through **Grid → jMAVSim → Rez**. Grid is now the default view mode, and the old "Texture" mode is renamed to "jMAVSim".

Also reduces grid size by 50%, removes the redundant `DrawGrid` overlay from jMAVSim mode, and shows the MAVLink connection status persistently in the HUD — *"Waiting for MAVLink..."* when disconnected, *"MAVLink SYS \<id\>"* in green when connected.