### PR TITLE
feat: GLSL shader grid, attitude indicator, and HUD theming

### DIFF
--- a/shaders/grid.fs
+++ b/shaders/grid.fs
@@ -1,0 +1,49 @@
+#version 330
+
+in vec3 fragWorldPos;
+in vec2 fragTexCoord;
+in vec4 fragColor;
+
+uniform vec4 colGround;
+uniform vec4 colMinor;
+uniform vec4 colMajor;
+uniform vec4 colAxisX;
+uniform vec4 colAxisZ;
+uniform float spacing;
+uniform float majorEvery;
+uniform float axisWidth;
+
+out vec4 finalColor;
+
+void main() {
+    vec2 coord = fragWorldPos.xz;
+
+    // Minor grid lines
+    vec2 grid = abs(fract(coord / spacing - 0.5) - 0.5) / fwidth(coord / spacing);
+    float lineMinor = 1.0 - clamp(min(grid.x, grid.y), 0.0, 1.0);
+
+    // Major grid lines
+    float majorSpacing = spacing * majorEvery;
+    vec2 gridMajor = abs(fract(coord / majorSpacing - 0.5) - 0.5) / fwidth(coord / majorSpacing);
+    float lineMajor = 1.0 - clamp(min(gridMajor.x, gridMajor.y), 0.0, 1.0);
+
+    // Axis lines (world origin)
+    vec2 axisGrid = abs(coord) / fwidth(coord);
+    float axisXLine = 1.0 - clamp(axisGrid.y / axisWidth, 0.0, 1.0); // Z=0 line (X axis)
+    float axisZLine = 1.0 - clamp(axisGrid.x / axisWidth, 0.0, 1.0); // X=0 line (Z axis)
+
+    // Compose: ground -> minor -> major -> axes
+    vec4 color = colGround;
+    color = mix(color, colMinor, lineMinor * colMinor.a);
+    color = mix(color, colMajor, lineMajor * colMajor.a);
+    color = mix(color, colAxisX, axisXLine * colAxisX.a);
+    color = mix(color, colAxisZ, axisZLine * colAxisZ.a);
+
+    // Distance fade — prevent aliasing at horizon
+    float dist = length(fragWorldPos.xz);
+    float fade = 1.0 - smoothstep(400.0, 800.0, dist);
+    color = mix(colGround, color, fade);
+
+    color.a = 1.0;
+    finalColor = color;
+}

--- a/shaders/grid.vs
+++ b/shaders/grid.vs
@@ -1,0 +1,19 @@
+#version 330
+
+in vec3 vertexPosition;
+in vec2 vertexTexCoord;
+in vec4 vertexColor;
+
+uniform mat4 mvp;
+uniform mat4 matModel;
+
+out vec3 fragWorldPos;
+out vec2 fragTexCoord;
+out vec4 fragColor;
+
+void main() {
+    fragWorldPos = (matModel * vec4(vertexPosition, 1.0)).xyz;
+    fragTexCoord = vertexTexCoord;
+    fragColor = vertexColor;
+    gl_Position = mvp * vec4(vertexPosition, 1.0);
+}

--- a/src/hud.c
+++ b/src/hud.c
@@ -14,6 +14,20 @@
 #define INSTRUMENT_RADIUS 45
 #define INSTRUMENT_PADDING 12
 
+// Rez HUD accent colors
+#define REZ_ACCENT (Color){ 0, 204, 218, 255 }
+#define REZ_ACCENT_DIM (Color){ 0, 204, 218, 140 }
+#define REZ_ORANGE (Color){ 255, 106, 0, 255 }
+#define REZ_BG (Color){ 8, 8, 12, 220 }
+#define REZ_BORDER (Color){ 0, 204, 218, 100 }
+
+// 1988 HUD accent colors
+#define SYNTH_ACCENT (Color){ 255, 20, 100, 255 }
+#define SYNTH_ACCENT_DIM (Color){ 255, 20, 100, 140 }
+#define SYNTH_HIGHLIGHT (Color){ 21, 190, 254, 255 }
+#define SYNTH_BG (Color){ 5, 5, 16, 220 }
+#define SYNTH_BORDER (Color){ 255, 20, 100, 100 }
+
 void hud_init(hud_t *h) {
     h->flight_time_s = 0.0f;
     h->timing_active = false;
@@ -28,9 +42,19 @@ void hud_update(hud_t *h, float dt, bool connected) {
     }
 }
 
-static void draw_compass(float cx, float cy, float radius, float heading_deg) {
-    DrawCircle((int)cx, (int)cy, radius, (Color){30, 30, 30, 220});
-    DrawCircleLines((int)cx, (int)cy, radius, (Color){100, 100, 100, 255});
+static void draw_compass(float cx, float cy, float radius, float heading_deg, view_mode_t vm) {
+    bool rez = (vm == VIEW_REZ);
+    bool synth = (vm == VIEW_1988);
+    Color bg = rez ? REZ_BG : synth ? SYNTH_BG : (Color){30, 30, 30, 220};
+    Color border = rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){100, 100, 100, 255};
+    Color tick_major = rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
+    Color tick_minor = rez ? REZ_ACCENT_DIM : synth ? (Color){ 10, 120, 160, 255 } : (Color){160, 160, 160, 255};
+    Color text_color = rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
+    Color north_color = rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
+    Color pointer_color = rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
+
+    DrawCircle((int)cx, (int)cy, radius, bg);
+    DrawCircleLines((int)cx, (int)cy, radius, border);
 
     for (int deg = 0; deg < 360; deg += 10) {
         float angle = (deg - heading_deg) * DEG2RAD - PI / 2.0f;
@@ -40,7 +64,7 @@ static void draw_compass(float cx, float cy, float radius, float heading_deg) {
         float y1 = cy + sinf(angle) * inner;
         float x2 = cx + cosf(angle) * outer;
         float y2 = cy + sinf(angle) * outer;
-        Color tc = (deg % 90 == 0) ? WHITE : (Color){160, 160, 160, 255};
+        Color tc = (deg % 90 == 0) ? tick_major : tick_minor;
         DrawLineEx((Vector2){x1, y1}, (Vector2){x2, y2}, (deg % 90 == 0) ? 2.0f : 1.0f, tc);
     }
 
@@ -52,31 +76,31 @@ static void draw_compass(float cx, float cy, float radius, float heading_deg) {
         float lx = cx + cosf(angle) * lr;
         float ly = cy + sinf(angle) * lr;
         int tw = MeasureText(labels[i], 12);
-        Color lc = (i == 0) ? RED : WHITE;
+        Color lc = (i == 0) ? north_color : text_color;
         DrawText(labels[i], (int)(lx - tw / 2), (int)(ly - 6), 12, lc);
     }
 
-    // Red triangle pointer at top
     DrawTriangle((Vector2){cx, cy - radius - 4},
                  (Vector2){cx + 5, cy - radius + 6},
-                 (Vector2){cx - 5, cy - radius + 6}, RED);
+                 (Vector2){cx - 5, cy - radius + 6}, pointer_color);
 
-    // Heading text inside the circle at bottom
     char hdg_buf[8];
     snprintf(hdg_buf, sizeof(hdg_buf), "%03d", ((int)heading_deg % 360 + 360) % 360);
     int tw = MeasureText(hdg_buf, 12);
-    DrawText(hdg_buf, (int)(cx - tw / 2), (int)(cy + radius * 0.6f), 12, WHITE);
+    DrawText(hdg_buf, (int)(cx - tw / 2), (int)(cy + radius * 0.6f), 12, text_color);
 }
 
-static void draw_attitude(float cx, float cy, float radius, float roll_deg, float pitch_deg) {
-    Color bg = (Color){30, 30, 30, 220};
-    Color border = (Color){100, 100, 100, 255};
-    Color horizon_color = WHITE;
-    Color pitch_bar_color = (Color){200, 200, 200, 160};
-    Color wing_color = YELLOW;
-    Color roll_tri_color = WHITE;
-    Color sky_color = (Color){ 80, 140, 200, 200 };
-    Color gnd_color = (Color){ 120, 85, 50, 200 };
+static void draw_attitude(float cx, float cy, float radius, float roll_deg, float pitch_deg, view_mode_t vm) {
+    bool rez = (vm == VIEW_REZ);
+    bool synth = (vm == VIEW_1988);
+    Color bg = rez ? REZ_BG : synth ? SYNTH_BG : (Color){30, 30, 30, 220};
+    Color border = rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){100, 100, 100, 255};
+    Color horizon_color = rez ? REZ_ACCENT : synth ? (Color){ 112, 40, 21, 255 } : WHITE;
+    Color pitch_bar_color = rez ? REZ_ACCENT_DIM : synth ? SYNTH_ACCENT_DIM : (Color){200, 200, 200, 160};
+    Color wing_color = rez ? REZ_ORANGE : synth ? SYNTH_HIGHLIGHT : YELLOW;
+    Color roll_tri_color = rez ? REZ_ACCENT : synth ? SYNTH_ACCENT : WHITE;
+    Color sky_color = rez ? (Color){ 0, 40, 45, 200 } : synth ? (Color){ 0, 4, 12, 200 } : (Color){ 80, 140, 200, 200 };
+    Color gnd_color = rez ? (Color){ 20, 10, 2, 200 } : synth ? (Color){ 251, 153, 54, 200 } : (Color){ 120, 85, 50, 200 };
 
     DrawCircle((int)cx, (int)cy, radius, bg);
 
@@ -84,50 +108,23 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
     if (pitch_clamped > 40.0f) pitch_clamped = 40.0f;
     if (pitch_clamped < -40.0f) pitch_clamped = -40.0f;
 
-    // Pitch offset in pixels (positive pitch = nose up = horizon moves down)
     float pitch_px = pitch_clamped * (radius * 0.6f / 40.0f);
 
     float roll_rad = -roll_deg * DEG2RAD;
     float cos_r = cosf(roll_rad);
     float sin_r = sinf(roll_rad);
 
-    // Horizon line endpoints (rotated)
     float hw = radius * 1.5f;
     float hx1 = cx + (-hw) * cos_r - pitch_px * sin_r;
     float hy1 = cy + (-hw) * sin_r + pitch_px * cos_r;
     float hx2 = cx + ( hw) * cos_r - pitch_px * sin_r;
     float hy2 = cy + ( hw) * sin_r + pitch_px * cos_r;
 
-    // Sky/ground fill using triangle fan clipped to circle
-    // Draw ground half (below horizon)
     BeginScissorMode((int)(cx - radius), (int)(cy - radius),
                      (int)(radius * 2), (int)(radius * 2));
     {
-        // Large triangle fan for ground (below horizon line)
-        Vector2 mid_gnd = {cx - pitch_px * sin_r, cy + pitch_px * cos_r};
-        float gnd_offset = radius * 2.0f;
-        Vector2 gnd_center = {mid_gnd.x + gnd_offset * sin_r,
-                              mid_gnd.y - gnd_offset * (-cos_r)};
-        // Use 4 corners + center for a filled quad below horizon
         float big = radius * 3.0f;
-        Vector2 corners[4] = {
-            {cx - big, cy - big}, {cx + big, cy - big},
-            {cx + big, cy + big}, {cx - big, cy + big}
-        };
-        // Fill entire circle with sky first
         DrawCircle((int)cx, (int)cy, radius - 1, sky_color);
-        // Then fill ground below horizon
-        // Ground is the half-plane on the "down" side of the horizon line
-        // Normal direction: (sin_r, -cos_r) points toward sky
-        for (int i = 0; i < 4; i++) {
-            int j = (i + 1) % 4;
-            Vector2 a = corners[i], b = corners[j];
-            // Check which corners are below horizon
-            float da = (a.x - hx1) * (hy2 - hy1) - (a.y - hy1) * (hx2 - hx1);
-            float db = (b.x - hx1) * (hy2 - hy1) - (b.y - hy1) * (hx2 - hx1);
-            (void)da; (void)db;
-        }
-        // Simpler approach: draw ground as a large rect on the ground side
         Vector2 gnd_pts[4];
         float down_x = -sin_r;
         float down_y = cos_r;
@@ -140,10 +137,8 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
     }
     EndScissorMode();
 
-    // Horizon line
     DrawLineEx((Vector2){hx1, hy1}, (Vector2){hx2, hy2}, 2.0f, horizon_color);
 
-    // Pitch bars at +/-10, +/-20 degrees
     int pitch_marks[] = {-20, -10, 10, 20};
     for (int p = 0; p < 4; p++) {
         float py = pitch_marks[p] * (radius * 0.6f / 40.0f);
@@ -152,18 +147,13 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
         float by1 = cy + (-bar_w) * sin_r + (pitch_px - py) * cos_r;
         float bx2 = cx + ( bar_w) * cos_r - (pitch_px - py) * sin_r;
         float by2 = cy + ( bar_w) * sin_r + (pitch_px - py) * cos_r;
-        float dx = bx2 - bx1, dy = by2 - by1;
-        float len = sqrtf(dx*dx + dy*dy);
-        if (len > 0) {
-            float dist_from_center = sqrtf(
-                powf((bx1+bx2)/2 - cx, 2) + powf((by1+by2)/2 - cy, 2));
-            if (dist_from_center < radius * 0.85f) {
-                DrawLineEx((Vector2){bx1, by1}, (Vector2){bx2, by2}, 1.0f, pitch_bar_color);
-            }
+        float dist_from_center = sqrtf(
+            powf((bx1+bx2)/2 - cx, 2) + powf((by1+by2)/2 - cy, 2));
+        if (dist_from_center < radius * 0.85f) {
+            DrawLineEx((Vector2){bx1, by1}, (Vector2){bx2, by2}, 1.0f, pitch_bar_color);
         }
     }
 
-    // Center wings (yellow reference)
     float wing_w = radius * 0.25f;
     float wing_gap = radius * 0.08f;
     DrawLineEx((Vector2){cx - wing_gap - wing_w, cy},
@@ -172,7 +162,6 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
                (Vector2){cx + wing_gap + wing_w, cy}, 3.0f, wing_color);
     DrawCircle((int)cx, (int)cy, 3, wing_color);
 
-    // Roll indicator triangle at top
     float tri_r = radius - 3;
     DrawTriangle(
         (Vector2){cx, cy - tri_r},
@@ -180,12 +169,14 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
         (Vector2){cx - 4, cy - tri_r + 7},
         roll_tri_color);
 
-    // Border circle
     DrawCircleLines((int)cx, (int)cy, radius, border);
 }
 
 void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
-              int vehicle_idx, int vehicle_total, uint8_t sysid) {
+              int vehicle_idx, int vehicle_total, uint8_t sysid, view_mode_t view_mode) {
+
+    bool rez = (view_mode == VIEW_REZ);
+    bool synth = (view_mode == VIEW_1988);
 
     // Vehicle tab header (above the bottom bar, only for multi-vehicle)
     int tab_h = 0;
@@ -205,19 +196,28 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
 
     // Bottom bar
     int bar_y = screen_h - BAR_HEIGHT;
-    DrawRectangle(0, bar_y, screen_w, BAR_HEIGHT, (Color){20, 20, 20, 180});
+    Color bar_bg = rez ? (Color){4, 4, 8, 220} : synth ? SYNTH_BG : (Color){20, 20, 20, 180};
+    Color bar_line = rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){80, 80, 80, 200};
+    DrawRectangle(0, bar_y, screen_w, BAR_HEIGHT, bar_bg);
     DrawLineEx((Vector2){0, (float)bar_y}, (Vector2){(float)screen_w, (float)bar_y},
-               1.0f, (Color){80, 80, 80, 200});
+               1.0f, bar_line);
 
     // Instruments — centered vertically in bar
     float inst_y = bar_y + BAR_HEIGHT / 2.0f - 5;
     float att_cx = INSTRUMENT_PADDING + INSTRUMENT_RADIUS + 8;
 
-    draw_compass(att_cx, inst_y, INSTRUMENT_RADIUS, v->heading_deg);
+    draw_compass(att_cx, inst_y, INSTRUMENT_RADIUS, v->heading_deg, view_mode);
 
     // Attitude indicator — right of compass
     float adi_cx = att_cx + INSTRUMENT_RADIUS * 2 + INSTRUMENT_PADDING + 8;
-    draw_attitude(adi_cx, inst_y, INSTRUMENT_RADIUS, v->roll_deg, v->pitch_deg);
+    draw_attitude(adi_cx, inst_y, INSTRUMENT_RADIUS, v->roll_deg, v->pitch_deg, view_mode);
+
+    // Themed text colors
+    Color label_color = rez ? REZ_ACCENT_DIM : synth ? (Color){ 10, 120, 160, 255 } : (Color){150, 150, 150, 255};
+    Color value_color = rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
+    Color dim_color = rez ? (Color){0, 100, 110, 255} : synth ? (Color){ 8, 80, 110, 255 } : (Color){100, 100, 100, 255};
+    Color dim2_color = rez ? (Color){0, 80, 88, 255} : synth ? (Color){ 6, 60, 85, 255 } : (Color){120, 120, 120, 255};
+    Color warn_color = rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
 
     // Telemetry columns — each with its own buffer
     float tel_x = adi_cx + INSTRUMENT_RADIUS + 35;
@@ -229,54 +229,54 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
     // ALT
     {
         char b[16];
-        DrawText("ALT", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("ALT", (int)tel_x, label_y, 11, label_color);
         snprintf(b, sizeof(b), "%.1f m", v->altitude_rel);
-        DrawText(b, (int)tel_x, value_y, 14, WHITE);
+        DrawText(b, (int)tel_x, value_y, 14, value_color);
         tel_x += col_w;
     }
 
     // HDG
     {
         char b[8];
-        DrawText("HDG", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("HDG", (int)tel_x, label_y, 11, label_color);
         snprintf(b, sizeof(b), "%03d", ((int)v->heading_deg % 360 + 360) % 360);
-        DrawText(b, (int)tel_x, value_y, 14, WHITE);
+        DrawText(b, (int)tel_x, value_y, 14, value_color);
         tel_x += col_w - 10;
     }
 
     // ROLL
     {
         char b[8];
-        DrawText("ROLL", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("ROLL", (int)tel_x, label_y, 11, label_color);
         snprintf(b, sizeof(b), "%+.0f", v->roll_deg);
-        DrawText(b, (int)tel_x, value_y, 14, WHITE);
+        DrawText(b, (int)tel_x, value_y, 14, value_color);
         tel_x += col_w - 10;
     }
 
     // PITCH
     {
         char b[8];
-        DrawText("PITCH", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("PITCH", (int)tel_x, label_y, 11, label_color);
         snprintf(b, sizeof(b), "%+.0f", v->pitch_deg);
-        DrawText(b, (int)tel_x, value_y, 14, WHITE);
+        DrawText(b, (int)tel_x, value_y, 14, value_color);
         tel_x += col_w - 10;
     }
 
     // GS
     {
         char b[16];
-        DrawText("GS", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("GS", (int)tel_x, label_y, 11, label_color);
         snprintf(b, sizeof(b), "%.1f", v->ground_speed);
-        DrawText(b, (int)tel_x, value_y, 14, WHITE);
+        DrawText(b, (int)tel_x, value_y, 14, value_color);
         tel_x += col_w - 10;
     }
 
     // VS
     {
         char b[16];
-        DrawText("VS", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("VS", (int)tel_x, label_y, 11, label_color);
         Color vs_color = (v->vertical_speed > 0.1f) ? GREEN :
-                         (v->vertical_speed < -0.1f) ? RED : WHITE;
+                         (v->vertical_speed < -0.1f) ? warn_color : value_color;
         const char *arrow = (v->vertical_speed > 0.1f) ? "^" :
                             (v->vertical_speed < -0.1f) ? "v" : "";
         snprintf(b, sizeof(b), "%.1f%s", v->vertical_speed, arrow);
@@ -287,12 +287,12 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
     // AS
     {
         char b[16];
-        DrawText("AS", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("AS", (int)tel_x, label_y, 11, label_color);
         if (v->airspeed > 0.1f) {
             snprintf(b, sizeof(b), "%.1f", v->airspeed);
-            DrawText(b, (int)tel_x, value_y, 14, WHITE);
+            DrawText(b, (int)tel_x, value_y, 14, value_color);
         } else {
-            DrawText("--", (int)tel_x, value_y, 14, (Color){100, 100, 100, 255});
+            DrawText("--", (int)tel_x, value_y, 14, dim_color);
         }
         tel_x += col_w - 10;
     }
@@ -300,11 +300,11 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
     // TIME
     {
         char b[8];
-        DrawText("TIME", (int)tel_x, label_y, 11, (Color){150, 150, 150, 255});
+        DrawText("TIME", (int)tel_x, label_y, 11, label_color);
         int mins = (int)(h->flight_time_s / 60.0f);
         int secs = (int)h->flight_time_s % 60;
         snprintf(b, sizeof(b), "%02d:%02d", mins, secs);
-        DrawText(b, (int)tel_x, value_y, 14, WHITE);
+        DrawText(b, (int)tel_x, value_y, 14, value_color);
     }
 
     // Second row
@@ -314,7 +314,7 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
         char b[48];
         snprintf(b, sizeof(b), "Pos: %.1f, %.1f, %.1f",
                  v->position.x, v->position.y, v->position.z);
-        DrawText(b, (int)row2_x, row2_y, 11, (Color){120, 120, 120, 255});
+        DrawText(b, (int)row2_x, row2_y, 11, dim2_color);
         row2_x += (float)MeasureText(b, 11) + 20;
     }
 
@@ -322,7 +322,7 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
         char b[16];
         snprintf(b, sizeof(b), "FPS: %d", GetFPS());
         int fps_x = screen_w - 70;
-        DrawText(b, fps_x, row2_y, 11, (Color){100, 100, 100, 255});
+        DrawText(b, fps_x, row2_y, 11, dim_color);
 
         {
             char status_buf[32];
@@ -331,7 +331,7 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
             } else {
                 snprintf(status_buf, sizeof(status_buf), "Waiting for MAVLink...");
             }
-            Color status_color = connected ? (Color){100, 200, 100, 255} : WHITE;
+            Color status_color = connected ? (Color){100, 200, 100, 255} : value_color;
             int msg_w = MeasureText(status_buf, 11);
             DrawText(status_buf, fps_x - msg_w - 15, row2_y, 11, status_color);
         }

--- a/src/hud.c
+++ b/src/hud.c
@@ -68,6 +68,122 @@ static void draw_compass(float cx, float cy, float radius, float heading_deg) {
     DrawText(hdg_buf, (int)(cx - tw / 2), (int)(cy + radius * 0.6f), 12, WHITE);
 }
 
+static void draw_attitude(float cx, float cy, float radius, float roll_deg, float pitch_deg) {
+    Color bg = (Color){30, 30, 30, 220};
+    Color border = (Color){100, 100, 100, 255};
+    Color horizon_color = WHITE;
+    Color pitch_bar_color = (Color){200, 200, 200, 160};
+    Color wing_color = YELLOW;
+    Color roll_tri_color = WHITE;
+    Color sky_color = (Color){ 80, 140, 200, 200 };
+    Color gnd_color = (Color){ 120, 85, 50, 200 };
+
+    DrawCircle((int)cx, (int)cy, radius, bg);
+
+    float pitch_clamped = pitch_deg;
+    if (pitch_clamped > 40.0f) pitch_clamped = 40.0f;
+    if (pitch_clamped < -40.0f) pitch_clamped = -40.0f;
+
+    // Pitch offset in pixels (positive pitch = nose up = horizon moves down)
+    float pitch_px = pitch_clamped * (radius * 0.6f / 40.0f);
+
+    float roll_rad = -roll_deg * DEG2RAD;
+    float cos_r = cosf(roll_rad);
+    float sin_r = sinf(roll_rad);
+
+    // Horizon line endpoints (rotated)
+    float hw = radius * 1.5f;
+    float hx1 = cx + (-hw) * cos_r - pitch_px * sin_r;
+    float hy1 = cy + (-hw) * sin_r + pitch_px * cos_r;
+    float hx2 = cx + ( hw) * cos_r - pitch_px * sin_r;
+    float hy2 = cy + ( hw) * sin_r + pitch_px * cos_r;
+
+    // Sky/ground fill using triangle fan clipped to circle
+    // Draw ground half (below horizon)
+    BeginScissorMode((int)(cx - radius), (int)(cy - radius),
+                     (int)(radius * 2), (int)(radius * 2));
+    {
+        // Large triangle fan for ground (below horizon line)
+        Vector2 mid_gnd = {cx - pitch_px * sin_r, cy + pitch_px * cos_r};
+        float gnd_offset = radius * 2.0f;
+        Vector2 gnd_center = {mid_gnd.x + gnd_offset * sin_r,
+                              mid_gnd.y - gnd_offset * (-cos_r)};
+        // Use 4 corners + center for a filled quad below horizon
+        float big = radius * 3.0f;
+        Vector2 corners[4] = {
+            {cx - big, cy - big}, {cx + big, cy - big},
+            {cx + big, cy + big}, {cx - big, cy + big}
+        };
+        // Fill entire circle with sky first
+        DrawCircle((int)cx, (int)cy, radius - 1, sky_color);
+        // Then fill ground below horizon
+        // Ground is the half-plane on the "down" side of the horizon line
+        // Normal direction: (sin_r, -cos_r) points toward sky
+        for (int i = 0; i < 4; i++) {
+            int j = (i + 1) % 4;
+            Vector2 a = corners[i], b = corners[j];
+            // Check which corners are below horizon
+            float da = (a.x - hx1) * (hy2 - hy1) - (a.y - hy1) * (hx2 - hx1);
+            float db = (b.x - hx1) * (hy2 - hy1) - (b.y - hy1) * (hx2 - hx1);
+            (void)da; (void)db;
+        }
+        // Simpler approach: draw ground as a large rect on the ground side
+        Vector2 gnd_pts[4];
+        float down_x = -sin_r;
+        float down_y = cos_r;
+        gnd_pts[0] = (Vector2){hx1, hy1};
+        gnd_pts[1] = (Vector2){hx2, hy2};
+        gnd_pts[2] = (Vector2){hx2 + down_x * big, hy2 + down_y * big};
+        gnd_pts[3] = (Vector2){hx1 + down_x * big, hy1 + down_y * big};
+        DrawTriangle(gnd_pts[0], gnd_pts[2], gnd_pts[1], gnd_color);
+        DrawTriangle(gnd_pts[0], gnd_pts[3], gnd_pts[2], gnd_color);
+    }
+    EndScissorMode();
+
+    // Horizon line
+    DrawLineEx((Vector2){hx1, hy1}, (Vector2){hx2, hy2}, 2.0f, horizon_color);
+
+    // Pitch bars at +/-10, +/-20 degrees
+    int pitch_marks[] = {-20, -10, 10, 20};
+    for (int p = 0; p < 4; p++) {
+        float py = pitch_marks[p] * (radius * 0.6f / 40.0f);
+        float bar_w = (abs(pitch_marks[p]) == 20) ? radius * 0.3f : radius * 0.2f;
+        float bx1 = cx + (-bar_w) * cos_r - (pitch_px - py) * sin_r;
+        float by1 = cy + (-bar_w) * sin_r + (pitch_px - py) * cos_r;
+        float bx2 = cx + ( bar_w) * cos_r - (pitch_px - py) * sin_r;
+        float by2 = cy + ( bar_w) * sin_r + (pitch_px - py) * cos_r;
+        float dx = bx2 - bx1, dy = by2 - by1;
+        float len = sqrtf(dx*dx + dy*dy);
+        if (len > 0) {
+            float dist_from_center = sqrtf(
+                powf((bx1+bx2)/2 - cx, 2) + powf((by1+by2)/2 - cy, 2));
+            if (dist_from_center < radius * 0.85f) {
+                DrawLineEx((Vector2){bx1, by1}, (Vector2){bx2, by2}, 1.0f, pitch_bar_color);
+            }
+        }
+    }
+
+    // Center wings (yellow reference)
+    float wing_w = radius * 0.25f;
+    float wing_gap = radius * 0.08f;
+    DrawLineEx((Vector2){cx - wing_gap - wing_w, cy},
+               (Vector2){cx - wing_gap, cy}, 3.0f, wing_color);
+    DrawLineEx((Vector2){cx + wing_gap, cy},
+               (Vector2){cx + wing_gap + wing_w, cy}, 3.0f, wing_color);
+    DrawCircle((int)cx, (int)cy, 3, wing_color);
+
+    // Roll indicator triangle at top
+    float tri_r = radius - 3;
+    DrawTriangle(
+        (Vector2){cx, cy - tri_r},
+        (Vector2){cx + 4, cy - tri_r + 7},
+        (Vector2){cx - 4, cy - tri_r + 7},
+        roll_tri_color);
+
+    // Border circle
+    DrawCircleLines((int)cx, (int)cy, radius, border);
+}
+
 void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
               int vehicle_idx, int vehicle_total, uint8_t sysid) {
 
@@ -99,8 +215,12 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
 
     draw_compass(att_cx, inst_y, INSTRUMENT_RADIUS, v->heading_deg);
 
+    // Attitude indicator — right of compass
+    float adi_cx = att_cx + INSTRUMENT_RADIUS * 2 + INSTRUMENT_PADDING + 8;
+    draw_attitude(adi_cx, inst_y, INSTRUMENT_RADIUS, v->roll_deg, v->pitch_deg);
+
     // Telemetry columns — each with its own buffer
-    float tel_x = att_cx + INSTRUMENT_RADIUS + 35;
+    float tel_x = adi_cx + INSTRUMENT_RADIUS + 35;
     int label_y = bar_y + 15;
     int value_y = bar_y + 38;
     float col_w = 70.0f;

--- a/src/hud.h
+++ b/src/hud.h
@@ -12,7 +12,7 @@ typedef struct {
 void hud_init(hud_t *h);
 void hud_update(hud_t *h, float dt, bool connected);
 void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
-              int vehicle_idx, int vehicle_total, uint8_t sysid);
+              int vehicle_idx, int vehicle_total, uint8_t sysid, view_mode_t view_mode);
 void hud_cleanup(hud_t *h);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -204,7 +204,8 @@ int main(int argc, char *argv[]) {
             // HUD
             hud_draw(&hud, &vehicles[selected], any_connected,
                      GetScreenWidth(), GetScreenHeight(),
-                     selected, vehicle_count, vehicles[selected].sysid);
+                     selected, vehicle_count, vehicles[selected].sysid,
+                     scene.view_mode);
 
         EndDrawing();
     }

--- a/src/scene.c
+++ b/src/scene.c
@@ -29,6 +29,14 @@
 #define REZ_AXIS_X     (Color){ 0,  204, 218, 220 }  // teal, full
 #define REZ_AXIS_Z     (Color){ 0,  204, 218, 220 }  // teal, full
 
+// 1988 mode colors (synthwave)
+#define SYNTH_SKY      (Color){ 8,   8,  20, 255 }
+#define SYNTH_GROUND   (Color){ 5,   5,  16, 255 }
+#define SYNTH_MINOR    (Color){ 255, 20, 100, 50 }   // hot pink, subtle
+#define SYNTH_MAJOR    (Color){ 255, 20, 100, 160 }   // hot pink, bright
+#define SYNTH_AXIS_X   (Color){ 255, 20, 100, 220 }   // hot pink, full
+#define SYNTH_AXIS_Z   (Color){ 255, 20, 100, 220 }   // hot pink, full
+
 void scene_init(scene_t *s) {
     s->cam_mode = CAM_MODE_CHASE;
     s->view_mode = VIEW_GRID;
@@ -143,9 +151,32 @@ void scene_handle_input(scene_t *s) {
     }
 
     if (IsKeyPressed(KEY_V)) {
-        s->view_mode = (s->view_mode + 1) % VIEW_COUNT;
+        // If in hidden mode, return to Grid; otherwise cycle public modes
+        if (s->view_mode >= VIEW_COUNT)
+            s->view_mode = VIEW_GRID;
+        else
+            s->view_mode = (s->view_mode + 1) % VIEW_COUNT;
         const char *names[] = {"Grid", "jMAVSim", "Rez"};
         printf("View: %s\n", names[s->view_mode]);
+    }
+
+    // Ctrl+1988 sequence detection for hidden mode
+    if (IsKeyDown(KEY_LEFT_CONTROL)) {
+        int expected[] = { KEY_ONE, KEY_NINE, KEY_EIGHT, KEY_EIGHT };
+        if (s->seq_1988 < 4 && IsKeyPressed(expected[s->seq_1988])) {
+            s->seq_1988++;
+            if (s->seq_1988 == 4) {
+                s->view_mode = (s->view_mode == VIEW_1988) ? VIEW_GRID : VIEW_1988;
+                s->seq_1988 = 0;
+            }
+        } else if (IsKeyPressed(KEY_ONE) || IsKeyPressed(KEY_TWO) || IsKeyPressed(KEY_THREE) ||
+                   IsKeyPressed(KEY_FOUR) || IsKeyPressed(KEY_FIVE) || IsKeyPressed(KEY_SIX) ||
+                   IsKeyPressed(KEY_SEVEN) || IsKeyPressed(KEY_EIGHT) || IsKeyPressed(KEY_NINE) ||
+                   IsKeyPressed(KEY_ZERO)) {
+            s->seq_1988 = IsKeyPressed(KEY_ONE) ? 1 : 0;
+        }
+    } else {
+        s->seq_1988 = 0;
     }
 
     // Mouse drag to orbit (left button)
@@ -204,6 +235,8 @@ void scene_draw(const scene_t *s) {
         draw_shader_grid(s, GRID_GROUND, GRID_MINOR, GRID_MAJOR, GRID_AXIS_X, GRID_AXIS_Z);
     } else if (s->view_mode == VIEW_REZ) {
         draw_shader_grid(s, REZ_GROUND, REZ_MINOR, REZ_MAJOR, REZ_AXIS_X, REZ_AXIS_Z);
+    } else if (s->view_mode == VIEW_1988) {
+        draw_shader_grid(s, SYNTH_GROUND, SYNTH_MINOR, SYNTH_MAJOR, SYNTH_AXIS_X, SYNTH_AXIS_Z);
     } else {
         // Sky sphere centered on camera — disable culling so we see it from inside
         rlDisableBackfaceCulling();
@@ -220,7 +253,8 @@ void scene_draw(const scene_t *s) {
 void scene_draw_sky(const scene_t *s) {
     switch (s->view_mode) {
         case VIEW_GRID: ClearBackground(GRID_SKY); break;
-        case VIEW_REZ:  ClearBackground(REZ_SKY);  break;
+        case VIEW_REZ:  ClearBackground(REZ_SKY);   break;
+        case VIEW_1988: ClearBackground(SYNTH_SKY); break;
         default:        ClearBackground((Color){135, 206, 235, 255}); break;
     }
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -9,8 +9,8 @@
 #define SKY_RADIUS 6000.0f    // sky sphere radius (larger than ground diagonal)
 
 // Grid shared settings
-#define GRID_EXTENT      250.0f
-#define GRID_SPACING     5.0f
+#define GRID_EXTENT      500.0f
+#define GRID_SPACING     10.0f
 #define GRID_MAJOR_EVERY 5
 
 // Grid mode colors
@@ -45,8 +45,8 @@ void scene_init(scene_t *s) {
         .projection = CAMERA_PERSPECTIVE,
     };
 
-    // Ground plane mesh
-    Mesh ground_mesh = GenMeshPlane(GROUND_SIZE * 2, GROUND_SIZE * 2, 1, 1);
+    // Ground plane mesh (10x10 subdivisions to avoid diagonal tearing)
+    Mesh ground_mesh = GenMeshPlane(GROUND_SIZE * 2, GROUND_SIZE * 2, 10, 10);
     s->ground = LoadModelFromMesh(ground_mesh);
 
     // Ground texture
@@ -81,6 +81,22 @@ void scene_init(scene_t *s) {
 
         s->sky_sphere.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = s->sky_tex;
     }
+
+    // Grid shader and plane (100x100 subdivisions for fwidth() precision)
+    s->grid_shader = LoadShader("shaders/grid.vs", "shaders/grid.fs");
+    s->loc_colGround  = GetShaderLocation(s->grid_shader, "colGround");
+    s->loc_colMinor   = GetShaderLocation(s->grid_shader, "colMinor");
+    s->loc_colMajor   = GetShaderLocation(s->grid_shader, "colMajor");
+    s->loc_colAxisX   = GetShaderLocation(s->grid_shader, "colAxisX");
+    s->loc_colAxisZ   = GetShaderLocation(s->grid_shader, "colAxisZ");
+    s->loc_spacing    = GetShaderLocation(s->grid_shader, "spacing");
+    s->loc_majorEvery = GetShaderLocation(s->grid_shader, "majorEvery");
+    s->loc_axisWidth  = GetShaderLocation(s->grid_shader, "axisWidth");
+    s->loc_matModel   = GetShaderLocation(s->grid_shader, "matModel");
+
+    Mesh grid_mesh = GenMeshPlane(GROUND_SIZE * 2, GROUND_SIZE * 2, 100, 100);
+    s->grid_plane = LoadModelFromMesh(grid_mesh);
+    s->grid_plane.materials[0].shader = s->grid_shader;
 }
 
 static void update_chase_camera(scene_t *s, Vector3 pos) {
@@ -152,35 +168,42 @@ void scene_handle_input(scene_t *s) {
     }
 }
 
-static void draw_grid(Color minor, Color major, Color axis_x, Color axis_z, Color ground) {
-    // Dark ground volume — top face below Y=0 to avoid z-fighting
-    DrawCube((Vector3){0, -5000.05f, 0}, GROUND_SIZE * 2, 10000.0f, GROUND_SIZE * 2, ground);
+static void color_to_vec4(Color c, float out[4]) {
+    out[0] = c.r / 255.0f;
+    out[1] = c.g / 255.0f;
+    out[2] = c.b / 255.0f;
+    out[3] = c.a / 255.0f;
+}
 
-    float extent = GRID_EXTENT;
+static void draw_shader_grid(const scene_t *s,
+    Color ground, Color minor, Color major, Color axis_x, Color axis_z)
+{
+    float v[4];
+    color_to_vec4(ground, v); SetShaderValue(s->grid_shader, s->loc_colGround, v, SHADER_UNIFORM_VEC4);
+    color_to_vec4(minor, v);  SetShaderValue(s->grid_shader, s->loc_colMinor, v, SHADER_UNIFORM_VEC4);
+    color_to_vec4(major, v);  SetShaderValue(s->grid_shader, s->loc_colMajor, v, SHADER_UNIFORM_VEC4);
+    color_to_vec4(axis_x, v); SetShaderValue(s->grid_shader, s->loc_colAxisX, v, SHADER_UNIFORM_VEC4);
+    color_to_vec4(axis_z, v); SetShaderValue(s->grid_shader, s->loc_colAxisZ, v, SHADER_UNIFORM_VEC4);
+
     float spacing = GRID_SPACING;
-    int lines = (int)(extent / spacing);
+    float majorEvery = (float)GRID_MAJOR_EVERY;
+    float axisWidth = 1.5f;
+    SetShaderValue(s->grid_shader, s->loc_spacing, &spacing, SHADER_UNIFORM_FLOAT);
+    SetShaderValue(s->grid_shader, s->loc_majorEvery, &majorEvery, SHADER_UNIFORM_FLOAT);
+    SetShaderValue(s->grid_shader, s->loc_axisWidth, &axisWidth, SHADER_UNIFORM_FLOAT);
 
-    for (int i = -lines; i <= lines; i++) {
-        bool is_major = (i % GRID_MAJOR_EVERY == 0);
-        bool is_origin = (i == 0);
-        float pos = i * spacing;
+    // Pass identity model matrix (plane is at origin)
+    Matrix model = MatrixIdentity();
+    SetShaderValueMatrix(s->grid_shader, s->loc_matModel, model);
 
-        if (is_origin) {
-            DrawLine3D((Vector3){-extent, 0, 0}, (Vector3){extent, 0, 0}, axis_x);
-            DrawLine3D((Vector3){0, 0, -extent}, (Vector3){0, 0, extent}, axis_z);
-        } else {
-            Color col = is_major ? major : minor;
-            DrawLine3D((Vector3){-extent, 0, pos}, (Vector3){extent, 0, pos}, col);
-            DrawLine3D((Vector3){pos, 0, -extent}, (Vector3){pos, 0, extent}, col);
-        }
-    }
+    DrawModel(s->grid_plane, (Vector3){0, 0, 0}, 1.0f, WHITE);
 }
 
 void scene_draw(const scene_t *s) {
     if (s->view_mode == VIEW_GRID) {
-        draw_grid(GRID_MINOR, GRID_MAJOR, GRID_AXIS_X, GRID_AXIS_Z, GRID_GROUND);
+        draw_shader_grid(s, GRID_GROUND, GRID_MINOR, GRID_MAJOR, GRID_AXIS_X, GRID_AXIS_Z);
     } else if (s->view_mode == VIEW_REZ) {
-        draw_grid(REZ_MINOR, REZ_MAJOR, REZ_AXIS_X, REZ_AXIS_Z, REZ_GROUND);
+        draw_shader_grid(s, REZ_GROUND, REZ_MINOR, REZ_MAJOR, REZ_AXIS_X, REZ_AXIS_Z);
     } else {
         // Sky sphere centered on camera — disable culling so we see it from inside
         rlDisableBackfaceCulling();
@@ -205,6 +228,8 @@ void scene_draw_sky(const scene_t *s) {
 void scene_cleanup(scene_t *s) {
     UnloadModel(s->ground);
     UnloadModel(s->sky_sphere);
+    UnloadModel(s->grid_plane);
+    UnloadShader(s->grid_shader);
     if (s->ground_tex.id > 0) UnloadTexture(s->ground_tex);
     if (s->sky_tex.id > 0) UnloadTexture(s->sky_tex);
 }

--- a/src/scene.h
+++ b/src/scene.h
@@ -14,7 +14,8 @@ typedef enum {
     VIEW_GRID = 0,
     VIEW_JMAVSIM,
     VIEW_REZ,
-    VIEW_COUNT,
+    VIEW_COUNT,     // public modes end here
+    VIEW_1988,      // hidden mode (not in V cycle)
 } view_mode_t;
 
 typedef struct {
@@ -40,6 +41,7 @@ typedef struct {
     int loc_axisWidth;
     int loc_matModel;
     Model grid_plane;    // separate ground plane for grid modes
+    int seq_1988;        // key sequence tracker
 } scene_t;
 
 // Initialize scene (ground plane, sky, camera, lighting).

--- a/src/scene.h
+++ b/src/scene.h
@@ -28,6 +28,18 @@ typedef struct {
     float chase_distance;
     float chase_yaw;    // horizontal orbit angle (radians)
     float chase_pitch;  // vertical orbit angle (radians)
+    // Grid shader
+    Shader grid_shader;
+    int loc_colGround;
+    int loc_colMinor;
+    int loc_colMajor;
+    int loc_colAxisX;
+    int loc_colAxisZ;
+    int loc_spacing;
+    int loc_majorEvery;
+    int loc_axisWidth;
+    int loc_matModel;
+    Model grid_plane;    // separate ground plane for grid modes
 } scene_t;
 
 // Initialize scene (ground plane, sky, camera, lighting).

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -121,12 +121,15 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
 }
 
 void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
-    // In Rez mode, swap red arms to orange
+    // In Rez/1988 mode, swap red arm color
     Color saved_red = {0};
-    if (view_mode == VIEW_REZ && v->red_material_idx >= 0) {
+    if ((view_mode == VIEW_REZ || view_mode == VIEW_1988) && v->red_material_idx >= 0) {
         Color *c = &v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color;
         saved_red = *c;
-        *c = (Color){ 255, 106, 0, 255 }; // #ff6a00 orange
+        if (view_mode == VIEW_1988)
+            *c = (Color){ 255, 20, 100, 255 }; // hot pink
+        else
+            *c = (Color){ 255, 106, 0, 255 }; // #ff6a00 orange
     }
     // OBJ model: flat in XY, thin in Z (Z is model's up).
     // Raylib: Y is up. Rotate +90° around X so model Z → Raylib Y.
@@ -141,7 +144,7 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
     DrawModel(v->model, (Vector3){0}, 1.0f, WHITE);
 
     // Restore original color
-    if (view_mode == VIEW_REZ && v->red_material_idx >= 0) {
+    if ((view_mode == VIEW_REZ || view_mode == VIEW_1988) && v->red_material_idx >= 0) {
         v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color = saved_red;
     }
 }


### PR DESCRIPTION
## Summary
- Replace GL_LINES grid with GLSL fragment shader grid to fix rendering failures on AMD GPUs (diamond-exit rule with MSAA)
- Add attitude indicator (artificial horizon) gauge to HUD alongside the compass
- Theme all HUD elements (compass, attitude, telemetry, bottom bar) per view mode with distinct color palettes
- Increase ground plane subdivisions to fix diagonal tearing artifacts

## Test plan
- [ ] Verify grid renders without flickering at all altitudes and camera angles
- [ ] Verify attitude indicator shows correct roll/pitch
- [ ] Cycle view modes with V and confirm HUD colors match each mode
- [ ] Verify no regressions in multi-vehicle mode