### PR TITLE
feat: add vehicle path trail and fix attitude indicator clipping

### DIFF
--- a/src/hud.c
+++ b/src/hud.c
@@ -120,24 +120,58 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
     float hx2 = cx + ( hw) * cos_r - pitch_px * sin_r;
     float hy2 = cy + ( hw) * sin_r + pitch_px * cos_r;
 
-    BeginScissorMode((int)(cx - radius), (int)(cy - radius),
-                     (int)(radius * 2), (int)(radius * 2));
-    {
-        float big = radius * 3.0f;
-        DrawCircle((int)cx, (int)cy, radius - 1, sky_color);
-        Vector2 gnd_pts[4];
-        float down_x = -sin_r;
-        float down_y = cos_r;
-        gnd_pts[0] = (Vector2){hx1, hy1};
-        gnd_pts[1] = (Vector2){hx2, hy2};
-        gnd_pts[2] = (Vector2){hx2 + down_x * big, hy2 + down_y * big};
-        gnd_pts[3] = (Vector2){hx1 + down_x * big, hy1 + down_y * big};
-        DrawTriangle(gnd_pts[0], gnd_pts[2], gnd_pts[1], gnd_color);
-        DrawTriangle(gnd_pts[0], gnd_pts[3], gnd_pts[2], gnd_color);
-    }
-    EndScissorMode();
+    // Draw sky/ground clipped to circle (no scissor — avoids rectangular corner leak)
+    float r = radius - 1;
+    DrawCircle((int)cx, (int)cy, r, sky_color);
 
-    DrawLineEx((Vector2){hx1, hy1}, (Vector2){hx2, hy2}, 2.0f, horizon_color);
+    // Compute where horizon line intersects the circle
+    float pp = pitch_px;
+    if (pp > r) pp = r;
+    if (pp < -r) pp = -r;
+    float half_chord = sqrtf(r * r - pp * pp);
+
+    // Intersection points in screen coords
+    float ix1 = cx + (-half_chord) * cos_r + pp * sin_r;
+    float iy1 = cy + (-half_chord) * sin_r + pp * cos_r;
+    float ix2 = cx + ( half_chord) * cos_r + pp * sin_r;
+    float iy2 = cy + ( half_chord) * sin_r + pp * cos_r;
+
+    // Angles of intersection points on the circle
+    float a1 = atan2f(iy1 - cy, ix1 - cx);
+    float a2 = atan2f(iy2 - cy, ix2 - cx);
+
+    // Ground center angle (roll-down direction)
+    float gnd_center = atan2f(cos_r, -sin_r);
+
+    // Normalize angles relative to ground center
+    float da1 = a1 - gnd_center;
+    float da2 = a2 - gnd_center;
+    while (da1 > PI) da1 -= 2*PI;
+    while (da1 < -PI) da1 += 2*PI;
+    while (da2 > PI) da2 -= 2*PI;
+    while (da2 < -PI) da2 += 2*PI;
+
+    float a_start = (da1 < da2) ? a1 : a2;
+    float a_end   = (da1 < da2) ? a2 : a1;
+
+    // Draw ground as arc-polygon (triangle fan along circle edge)
+    {
+        int arc_segs = 32;
+        float sweep = a_end - a_start;
+        if (sweep < 0) sweep += 2*PI;
+        float fan_cx = (ix1 + ix2) * 0.5f;
+        float fan_cy = (iy1 + iy2) * 0.5f;
+        Vector2 prev = { cx + cosf(a_start) * r, cy + sinf(a_start) * r };
+        for (int i = 1; i <= arc_segs; i++) {
+            float a = a_start + sweep * (float)i / arc_segs;
+            Vector2 cur = { cx + cosf(a) * r, cy + sinf(a) * r };
+            DrawTriangle(prev, (Vector2){fan_cx, fan_cy}, cur, gnd_color);
+            prev = cur;
+        }
+    }
+
+    // Horizon line clipped to circle
+    DrawLineEx((Vector2){ix1, iy1}, (Vector2){ix2, iy2}, 2.0f, horizon_color);
 
     int pitch_marks[] = {-20, -10, 10, 20};
     for (int p = 0; p < 4; p++) {

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -6,8 +6,11 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define EARTH_RADIUS 6371000.0
+#define TRAIL_MAX 2000
+#define TRAIL_INTERVAL 0.05f
 
 static const char *model_paths[] = {
     [VEHICLE_MULTICOPTER] = "models/3dr_arducopter_quad_x.obj",
@@ -39,6 +42,11 @@ void vehicle_init(vehicle_t *v, vehicle_type_t type) {
     v->model_scale = model_scales[type];
     v->red_material_idx = -1;
     v->color = WHITE;
+    v->trail = (Vector3 *)calloc(TRAIL_MAX, sizeof(Vector3));
+    v->trail_capacity = TRAIL_MAX;
+    v->trail_count = 0;
+    v->trail_head = 0;
+    v->trail_timer = 0.0f;
 
     v->model = LoadModel(model_paths[type]);
     if (v->model.meshCount == 0) {
@@ -126,6 +134,15 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
     v->vertical_speed = -state->vz * 0.01f;
     v->airspeed = state->ind_airspeed * 0.01f;
     v->altitude_rel = (float)(alt - v->alt0);
+
+    // Sample trail position at fixed interval
+    v->trail_timer += GetFrameTime();
+    if (v->trail_timer >= TRAIL_INTERVAL) {
+        v->trail_timer = 0.0f;
+        v->trail[v->trail_head] = v->position;
+        v->trail_head = (v->trail_head + 1) % v->trail_capacity;
+        if (v->trail_count < v->trail_capacity) v->trail_count++;
+    }
 }
 
 void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
@@ -154,6 +171,28 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
 
     DrawModel(v->model, (Vector3){0}, 1.0f, WHITE);
 
+    // Draw path trail
+    if (v->trail_count > 1) {
+        int start = (v->trail_count < v->trail_capacity)
+            ? 0
+            : v->trail_head;
+        Color trail_color;
+        if (view_mode == VIEW_1988)
+            trail_color = (Color){ 21, 190, 254, 160 };   // teal
+        else if (view_mode == VIEW_REZ)
+            trail_color = (Color){ 255, 106, 0, 160 };    // orange
+        else
+            trail_color = (Color){ 255, 200, 50, 180 };   // yellow
+        for (int i = 1; i < v->trail_count; i++) {
+            int idx0 = (start + i - 1) % v->trail_capacity;
+            int idx1 = (start + i) % v->trail_capacity;
+            float t = (float)i / (float)v->trail_count;
+            Color c = trail_color;
+            c.a = (unsigned char)(t * trail_color.a);
+            DrawLine3D(v->trail[idx0], v->trail[idx1], c);
+        }
+    }
+
     // Restore original color
     if ((view_mode == VIEW_REZ || view_mode == VIEW_1988) && v->red_material_idx >= 0) {
         v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color = saved_red;
@@ -162,4 +201,6 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
 
 void vehicle_cleanup(vehicle_t *v) {
     UnloadModel(v->model);
+    free(v->trail);
+    v->trail = NULL;
 }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -33,6 +33,11 @@ typedef struct {
     int red_material_idx;    // material index for red arms (-1 if not found)
     uint8_t sysid;
     Color color;
+    Vector3 *trail;
+    int trail_count;
+    int trail_head;
+    int trail_capacity;
+    float trail_timer;
 } vehicle_t;
 
 // Load vehicle model. type selects which OBJ to load.


### PR DESCRIPTION
## Summary
- Add a fading 3D path trail behind each vehicle using a circular buffer (2000 samples at 50ms intervals), with per-view-mode trail colors
- Fix attitude indicator sky/ground rendering: replace scissor-based clipping with arc-polygon clipping to eliminate rectangular corner artifacts, and clip the horizon line to the circle boundary

## Test plan
- [ ] Verify path trail renders behind vehicle during flight
- [ ] Verify trail fades from transparent (oldest) to opaque (newest)
- [ ] Verify attitude indicator has clean circular edges with no corner leaks
- [ ] Verify horizon line stays within the circle boundary
- [ ] Build and test on Linux, macOS, and Windows