### PR TITLE
feat: add color-coded vehicle path trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The test script accepts these options:
 |---|---|
 | `C` | Toggle camera mode (Chase / FPV) |
 | `V` | Cycle view mode (Grid / jMAVSim / Rez) |
+| `T` | Toggle path trail |
 | `TAB` | Cycle to next vehicle |
 | `[` / `]` | Previous / next vehicle |
 | `1`-`9` | Select vehicle directly |

--- a/src/main.c
+++ b/src/main.c
@@ -183,6 +183,13 @@ int main(int argc, char *argv[]) {
             }
         }
 
+        // Toggle path trail
+        if (IsKeyPressed(KEY_T)) {
+            for (int i = 0; i < vehicle_count; i++)
+                vehicles[i].show_trail = !vehicles[i].show_trail;
+            printf("Trail: %s\n", vehicles[0].show_trail ? "ON" : "OFF");
+        }
+
         // Update camera to follow selected vehicle
         scene_update_camera(&scene, vehicles[selected].position, vehicles[selected].rotation);
 

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -6,8 +6,11 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define EARTH_RADIUS 6371000.0
+#define TRAIL_MAX 2000
+#define TRAIL_INTERVAL 0.05f
 
 static const char *model_paths[] = {
     [VEHICLE_MULTICOPTER] = "models/3dr_arducopter_quad_x.obj",
@@ -39,6 +42,15 @@ void vehicle_init(vehicle_t *v, vehicle_type_t type) {
     v->model_scale = model_scales[type];
     v->red_material_idx = -1;
     v->color = WHITE;
+    v->trail = (Vector3 *)calloc(TRAIL_MAX, sizeof(Vector3));
+    v->trail_roll = (float *)calloc(TRAIL_MAX, sizeof(float));
+    v->trail_pitch = (float *)calloc(TRAIL_MAX, sizeof(float));
+    v->trail_vert = (float *)calloc(TRAIL_MAX, sizeof(float));
+    v->trail_capacity = TRAIL_MAX;
+    v->trail_count = 0;
+    v->trail_head = 0;
+    v->trail_timer = 0.0f;
+    v->show_trail = false;
 
     v->model = LoadModel(model_paths[type]);
     if (v->model.meshCount == 0) {
@@ -126,6 +138,18 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
     v->vertical_speed = -state->vz * 0.01f;
     v->airspeed = state->ind_airspeed * 0.01f;
     v->altitude_rel = (float)(alt - v->alt0);
+
+    // Sample trail position at fixed interval
+    v->trail_timer += GetFrameTime();
+    if (v->trail_timer >= TRAIL_INTERVAL) {
+        v->trail_timer = 0.0f;
+        v->trail[v->trail_head] = v->position;
+        v->trail_roll[v->trail_head] = v->roll_deg;
+        v->trail_pitch[v->trail_head] = v->pitch_deg;
+        v->trail_vert[v->trail_head] = v->vertical_speed;
+        v->trail_head = (v->trail_head + 1) % v->trail_capacity;
+        if (v->trail_count < v->trail_capacity) v->trail_count++;
+    }
 }
 
 void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
@@ -154,6 +178,102 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
 
     DrawModel(v->model, (Vector3){0}, 1.0f, WHITE);
 
+    // Draw path trail (toggled with T)
+    if (v->show_trail && v->trail_count > 1) {
+        int start = (v->trail_count < v->trail_capacity)
+            ? 0
+            : v->trail_head;
+        Color trail_color;
+        if (view_mode == VIEW_1988)
+            trail_color = (Color){ 21, 190, 254, 160 };   // teal
+        else if (view_mode == VIEW_REZ)
+            trail_color = (Color){ 255, 106, 0, 160 };    // orange
+        else
+            trail_color = (Color){ 255, 200, 50, 180 };   // yellow
+
+        // Per-mode color palette for movement-based tinting
+        Color col_back, col_up, col_down, col_roll_pos, col_roll_neg;
+        if (view_mode == VIEW_1988) {
+            col_back     = (Color){ 255, 20, 100, 255 };  // pink
+            col_up       = (Color){   0, 255, 140, 255 }; // mint green
+            col_down     = (Color){ 255, 106,   0, 255 }; // orange
+            col_roll_pos = (Color){ 255, 106,   0, 255 }; // orange
+            col_roll_neg = (Color){  40,  80, 255, 255 }; // blue
+        } else if (view_mode == VIEW_REZ) {
+            col_back     = (Color){ 180,  60, 220, 255 }; // purple
+            col_up       = (Color){  80, 220, 120, 255 }; // green
+            col_down     = (Color){ 220,  60,  40, 255 }; // red
+            col_roll_pos = (Color){ 255,  40,  40, 255 }; // red
+            col_roll_neg = (Color){  40,  80, 255, 255 }; // blue
+        } else {
+            col_back     = (Color){ 180,  80, 255, 255 }; // purple
+            col_up       = (Color){  80, 255, 120, 255 }; // green
+            col_down     = (Color){ 255,  80,  40, 255 }; // orange-red
+            col_roll_pos = (Color){ 255,  40,  40, 255 }; // red
+            col_roll_neg = (Color){  40,  80, 255, 255 }; // blue
+        }
+
+        for (int i = 1; i < v->trail_count; i++) {
+            int idx0 = (start + i - 1) % v->trail_capacity;
+            int idx1 = (start + i) % v->trail_capacity;
+            float t = (float)i / (float)v->trail_count;
+
+            float pitch = v->trail_pitch[idx1];
+            float vert  = v->trail_vert[idx1];
+            float roll  = v->trail_roll[idx1];
+
+            // Start with forward color as base
+            float cr = (float)trail_color.r;
+            float cg = (float)trail_color.g;
+            float cb = (float)trail_color.b;
+
+            // Backward: positive pitch = nose up
+            float back_t = pitch / 15.0f;
+            if (back_t < 0.0f) back_t = 0.0f;
+            if (back_t > 1.0f) back_t = 1.0f;
+            cr += (col_back.r - cr) * back_t;
+            cg += (col_back.g - cg) * back_t;
+            cb += (col_back.b - cb) * back_t;
+
+            // Vertical: ascending / descending
+            float vert_t = vert / 5.0f;
+            if (vert_t > 1.0f) vert_t = 1.0f;
+            if (vert_t < -1.0f) vert_t = -1.0f;
+            if (vert_t > 0.0f) {
+                cr += (col_up.r - cr) * vert_t;
+                cg += (col_up.g - cg) * vert_t;
+                cb += (col_up.b - cb) * vert_t;
+            } else if (vert_t < 0.0f) {
+                float dt2 = -vert_t;
+                cr += (col_down.r - cr) * dt2;
+                cg += (col_down.g - cg) * dt2;
+                cb += (col_down.b - cb) * dt2;
+            }
+
+            // Roll tint on top
+            float roll_t = roll / 15.0f;
+            if (roll_t > 1.0f) roll_t = 1.0f;
+            if (roll_t < -1.0f) roll_t = -1.0f;
+            if (roll_t > 0.0f) {
+                cr += (col_roll_pos.r - cr) * roll_t * 0.7f;
+                cg += (col_roll_pos.g - cg) * roll_t * 0.7f;
+                cb += (col_roll_pos.b - cb) * roll_t * 0.7f;
+            } else if (roll_t < 0.0f) {
+                float rt = -roll_t;
+                cr += (col_roll_neg.r - cr) * rt * 0.7f;
+                cg += (col_roll_neg.g - cg) * rt * 0.7f;
+                cb += (col_roll_neg.b - cb) * rt * 0.7f;
+            }
+
+            Color c;
+            c.r = (unsigned char)(cr > 255 ? 255 : cr);
+            c.g = (unsigned char)(cg > 255 ? 255 : cg);
+            c.b = (unsigned char)(cb > 255 ? 255 : cb);
+            c.a = (unsigned char)(t * trail_color.a);
+            DrawLine3D(v->trail[idx0], v->trail[idx1], c);
+        }
+    }
+
     // Restore original color
     if ((view_mode == VIEW_REZ || view_mode == VIEW_1988) && v->red_material_idx >= 0) {
         v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color = saved_red;
@@ -162,4 +282,12 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
 
 void vehicle_cleanup(vehicle_t *v) {
     UnloadModel(v->model);
+    free(v->trail);
+    free(v->trail_roll);
+    free(v->trail_pitch);
+    free(v->trail_vert);
+    v->trail = NULL;
+    v->trail_roll = NULL;
+    v->trail_pitch = NULL;
+    v->trail_vert = NULL;
 }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -33,6 +33,15 @@ typedef struct {
     int red_material_idx;    // material index for red arms (-1 if not found)
     uint8_t sysid;
     Color color;
+    Vector3 *trail;
+    float *trail_roll;           // roll angle at each trail sample
+    float *trail_pitch;          // pitch angle at each trail sample
+    float *trail_vert;           // vertical speed at each trail sample
+    int trail_count;
+    int trail_head;
+    int trail_capacity;
+    float trail_timer;
+    bool show_trail;
 } vehicle_t;
 
 // Load vehicle model. type selects which OBJ to load.


### PR DESCRIPTION
Add a fading 3D path trail behind each vehicle, toggled with `T`. Trail color encodes vehicle attitude in real time (pitch, roll, vertical speed) with per-view-mode color palettes.

Based on #11 by @MikePehel — resolved merge conflicts with current main. Supersedes #11.