### PR TITLE
fix: HUD improvements — sim time, disconnect detection, cleanup

### DIFF
--- a/src/hud.c
+++ b/src/hud.c
@@ -29,17 +29,11 @@
 #define SYNTH_BORDER (Color){ 255, 20, 100, 100 }
 
 void hud_init(hud_t *h) {
-    h->flight_time_s = 0.0f;
-    h->timing_active = false;
+    h->sim_time_s = 0.0f;
 }
 
-void hud_update(hud_t *h, float dt, bool connected) {
-    if (connected && !h->timing_active) {
-        h->timing_active = true;
-    }
-    if (h->timing_active) {
-        h->flight_time_s += dt;
-    }
+void hud_update(hud_t *h, uint64_t time_usec) {
+    h->sim_time_s = (float)(time_usec / 1000000.0);
 }
 
 static void draw_compass(float cx, float cy, float radius, float heading_deg, view_mode_t vm) {
@@ -249,8 +243,6 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
     // Themed text colors
     Color label_color = rez ? REZ_ACCENT_DIM : synth ? (Color){ 10, 120, 160, 255 } : (Color){150, 150, 150, 255};
     Color value_color = rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
-    Color dim_color = rez ? (Color){0, 100, 110, 255} : synth ? (Color){ 8, 80, 110, 255 } : (Color){100, 100, 100, 255};
-    Color dim2_color = rez ? (Color){0, 80, 88, 255} : synth ? (Color){ 6, 60, 85, 255 } : (Color){120, 120, 120, 255};
     Color warn_color = rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
 
     // Telemetry columns — each with its own buffer
@@ -326,49 +318,40 @@ void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, 
             snprintf(b, sizeof(b), "%.1f", v->airspeed);
             DrawText(b, (int)tel_x, value_y, 14, value_color);
         } else {
-            DrawText("--", (int)tel_x, value_y, 14, dim_color);
+            DrawText("--", (int)tel_x, value_y, 14, label_color);
         }
         tel_x += col_w - 10;
     }
 
-    // TIME
+    // TIME (sim time from HIL_STATE_QUATERNION)
     {
-        char b[8];
+        char b[16];
         DrawText("TIME", (int)tel_x, label_y, 11, label_color);
-        int mins = (int)(h->flight_time_s / 60.0f);
-        int secs = (int)h->flight_time_s % 60;
-        snprintf(b, sizeof(b), "%02d:%02d", mins, secs);
+        int total_secs = (int)h->sim_time_s;
+        int mins = total_secs / 60;
+        int secs = total_secs % 60;
+        if (mins >= 60) {
+            int hrs = mins / 60;
+            mins = mins % 60;
+            snprintf(b, sizeof(b), "%d:%02d:%02d", hrs, mins, secs);
+        } else {
+            snprintf(b, sizeof(b), "%02d:%02d", mins, secs);
+        }
         DrawText(b, (int)tel_x, value_y, 14, value_color);
     }
 
-    // Second row
+    // Second row — MAVLink status
     int row2_y = bar_y + 65;
-    float row2_x = att_cx + INSTRUMENT_RADIUS + 35;
     {
-        char b[48];
-        snprintf(b, sizeof(b), "Pos: %.1f, %.1f, %.1f",
-                 v->position.x, v->position.y, v->position.z);
-        DrawText(b, (int)row2_x, row2_y, 11, dim2_color);
-        row2_x += (float)MeasureText(b, 11) + 20;
-    }
-
-    {
-        char b[16];
-        snprintf(b, sizeof(b), "FPS: %d", GetFPS());
-        int fps_x = screen_w - 70;
-        DrawText(b, fps_x, row2_y, 11, dim_color);
-
-        {
-            char status_buf[32];
-            if (connected) {
-                snprintf(status_buf, sizeof(status_buf), "MAVLink SYS %u", sysid);
-            } else {
-                snprintf(status_buf, sizeof(status_buf), "Waiting for MAVLink...");
-            }
-            Color status_color = connected ? (Color){100, 200, 100, 255} : value_color;
-            int msg_w = MeasureText(status_buf, 11);
-            DrawText(status_buf, fps_x - msg_w - 15, row2_y, 11, status_color);
+        char status_buf[32];
+        if (connected) {
+            snprintf(status_buf, sizeof(status_buf), "MAVLink SYS %u", sysid);
+        } else {
+            snprintf(status_buf, sizeof(status_buf), "Waiting for MAVLink...");
         }
+        Color status_color = connected ? (Color){100, 200, 100, 255} : warn_color;
+        int msg_w = MeasureText(status_buf, 11);
+        DrawText(status_buf, screen_w - msg_w - 15, row2_y, 11, status_color);
     }
 }
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -5,12 +5,11 @@
 #include <stdbool.h>
 
 typedef struct {
-    float flight_time_s;
-    bool timing_active;
+    float sim_time_s;
 } hud_t;
 
 void hud_init(hud_t *h);
-void hud_update(hud_t *h, float dt, bool connected);
+void hud_update(hud_t *h, uint64_t time_usec);
 void hud_draw(const hud_t *h, const vehicle_t *v, bool connected, int screen_w, int screen_h,
               int vehicle_idx, int vehicle_total, uint8_t sysid, view_mode_t view_mode);
 void hud_cleanup(hud_t *h);

--- a/src/main.c
+++ b/src/main.c
@@ -147,8 +147,8 @@ int main(int argc, char *argv[]) {
             if (receivers[i].connected) { any_connected = true; break; }
         }
 
-        // Update HUD timer
-        hud_update(&hud, GetFrameTime(), any_connected);
+        // Update HUD sim time from selected vehicle
+        hud_update(&hud, receivers[selected].state.time_usec);
 
         // Handle input
         scene_handle_input(&scene);

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -19,6 +20,14 @@
 // MAVLink config: use common message set
 // MAVLINK_COMM_NUM_BUFFERS=16 set via CMake for multi-vehicle support
 #include <mavlink.h>
+
+#define DISCONNECT_TIMEOUT_S 2.0
+
+static double get_wall_time(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
 
 static int set_nonblocking(sock_t s) {
 #ifdef _WIN32
@@ -75,12 +84,14 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
     uint8_t buf[2048];
     struct sockaddr_in sender;
     socklen_t sender_len = sizeof(sender);
+    bool got_data = false;
 
     for (;;) {
         int n = recvfrom(recv->sockfd, (char *)buf, sizeof(buf), 0,
                          (struct sockaddr *)&sender, &sender_len);
         if (n <= 0) break;
 
+        got_data = true;
         mavlink_message_t msg;
         mavlink_status_t status;
 
@@ -116,6 +127,7 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
                         recv->state.vz = hil.vz;
                         recv->state.ind_airspeed = hil.ind_airspeed;
                         recv->state.true_airspeed = hil.true_airspeed;
+                        recv->state.time_usec = hil.time_usec;
                         recv->state.valid = true;
 
                         if (recv->debug) {
@@ -128,6 +140,17 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
                     }
                 }
             }
+        }
+    }
+
+    if (got_data) {
+        recv->last_msg_time = get_wall_time();
+    } else if (recv->connected && recv->last_msg_time > 0) {
+        double now = get_wall_time();
+        if (now - recv->last_msg_time > DISCONNECT_TIMEOUT_S) {
+            recv->connected = false;
+            recv->state.valid = false;
+            printf("Disconnected from system %u\n", recv->sysid);
         }
     }
 }

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -3,7 +3,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#ifndef _WIN32
 #include <time.h>
+#endif
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -24,9 +26,16 @@
 #define DISCONNECT_TIMEOUT_S 2.0
 
 static double get_wall_time(void) {
+#ifdef _WIN32
+    LARGE_INTEGER freq, count;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&count);
+    return (double)count.QuadPart / (double)freq.QuadPart;
+#else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+#endif
 }
 
 static int set_nonblocking(sock_t s) {

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -20,6 +20,7 @@ typedef struct {
     int16_t vx, vy, vz;          // cm/s, NED
     uint16_t ind_airspeed;       // cm/s
     uint16_t true_airspeed;      // cm/s
+    uint64_t time_usec;          // timestamp (time since boot), microseconds
     bool valid;
 } hil_state_t;
 
@@ -30,6 +31,7 @@ typedef struct {
     bool connected;
     bool debug;
     uint8_t sysid;
+    double last_msg_time;        // wall-clock time of last received message
     hil_state_t state;
 } mavlink_receiver_t;
 


### PR DESCRIPTION
- Use sim time from HIL_STATE_QUATERNION.time_usec for the TIME display instead of wall-clock, so accelerated sims (e.g. PX4_SIM_SPEED_FACTOR=10) show correct sim elapsed time
- Detect MAVLink disconnect after 2s of no messages and update status text back to "Waiting for MAVLink..."
- Remove FPS counter (always showed ~59 due to SetTargetFPS(60))
- Remove position coordinates text that overlapped the attitude indicator