### PR TITLE
docs: update keyboard shortcuts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ The test script accepts these options:
 |---|---|
 | `C` | Toggle camera mode (Chase / FPV) |
 | `V` | Cycle view mode (Grid / jMAVSim / Rez) |
-| `T` | Toggle path trail |
 | `TAB` | Cycle to next vehicle |
 | `[` / `]` | Previous / next vehicle |
 | `1`-`9` | Select vehicle directly |
+| `Shift+1`-`9` | Toggle pin/unpin vehicle to HUD |
 | Left-drag | Orbit camera (chase mode) |
 | Scroll wheel | Zoom FOV |
 


### PR DESCRIPTION
Remove `T` (toggle trail) shortcut that was documented but not implemented — trails are always active. Add `Shift+1-9` pin/unpin shortcut that was implemented but not documented.