### PR TITLE
fix: reset path trail on MAVLink reconnect

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -133,6 +133,8 @@ int main(int argc, char *argv[]) {
     hud_init(&hud);
 
     int selected = 0;
+    bool was_connected[MAX_VEHICLES];
+    memset(was_connected, 0, sizeof(was_connected));
     bool show_hud = true;
 
     // Main loop
@@ -140,6 +142,13 @@ int main(int argc, char *argv[]) {
         // Poll all MAVLink receivers and update vehicles
         for (int i = 0; i < vehicle_count; i++) {
             mavlink_receiver_poll(&receivers[i]);
+
+            // Reset trail on reconnect
+            if (receivers[i].connected && !was_connected[i]) {
+                vehicle_reset_trail(&vehicles[i]);
+            }
+            was_connected[i] = receivers[i].connected;
+
             vehicle_update(&vehicles[i], &receivers[i].state);
             vehicles[i].sysid = receivers[i].sysid;
         }

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -278,6 +278,12 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
     }
 }
 
+void vehicle_reset_trail(vehicle_t *v) {
+    v->trail_count = 0;
+    v->trail_head = 0;
+    v->trail_timer = 0.0f;
+}
+
 void vehicle_cleanup(vehicle_t *v) {
     UnloadModel(v->model);
     free(v->trail);

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -52,6 +52,9 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state);
 // Draw the vehicle model. Pass view mode for per-mode coloring and selected state.
 void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected);
 
+// Reset the path trail.
+void vehicle_reset_trail(vehicle_t *v);
+
 // Unload model resources.
 void vehicle_cleanup(vehicle_t *v);
 


### PR DESCRIPTION
Clear the trail buffer when a vehicle reconnects, preventing stale trails from a previous session.