### PR TITLE
feat: add directional lighting to vehicle models

### DIFF
--- a/shaders/lighting.fs
+++ b/shaders/lighting.fs
@@ -1,0 +1,16 @@
+#version 330
+
+in vec3 fragNormal;
+
+uniform vec4 colDiffuse;
+uniform vec3 lightDir;
+uniform float ambient;
+
+out vec4 finalColor;
+
+void main() {
+    vec3 n = normalize(fragNormal);
+    float diff = max(dot(n, lightDir), 0.0);
+    float light = ambient + (1.0 - ambient) * diff;
+    finalColor = vec4(colDiffuse.rgb * light, colDiffuse.a);
+}

--- a/shaders/lighting.vs
+++ b/shaders/lighting.vs
@@ -1,0 +1,14 @@
+#version 330
+
+in vec3 vertexPosition;
+in vec3 vertexNormal;
+
+uniform mat4 mvp;
+uniform mat4 matNormal;
+
+out vec3 fragNormal;
+
+void main() {
+    fragNormal = normalize(mat3(matNormal) * vertexNormal);
+    gl_Position = mvp * vec4(vertexPosition, 1.0);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -107,9 +107,13 @@ int main(int argc, char *argv[]) {
     }
 
     // Init vehicles
+    // Init scene first (provides lighting shader for vehicles)
+    scene_t scene;
+    scene_init(&scene);
+
     vehicle_t vehicles[MAX_VEHICLES];
     for (int i = 0; i < vehicle_count; i++) {
-        vehicle_init(&vehicles[i], model_idx);
+        vehicle_init(&vehicles[i], model_idx, scene.lighting_shader);
         vehicles[i].color = vehicle_colors[i];
     }
 
@@ -125,9 +129,6 @@ int main(int argc, char *argv[]) {
         }
         printf("NED origin: lat=%.6f lon=%.6f alt=%.1f\n", origin_lat, origin_lon, origin_alt);
     }
-
-    scene_t scene;
-    scene_init(&scene);
 
     hud_t hud;
     hud_init(&hud);

--- a/src/scene.c
+++ b/src/scene.c
@@ -68,6 +68,18 @@ void scene_init(scene_t *s) {
     Mesh grid_mesh = GenMeshPlane(GROUND_SIZE * 2, GROUND_SIZE * 2, 100, 100);
     s->grid_plane = LoadModelFromMesh(grid_mesh);
     s->grid_plane.materials[0].shader = s->grid_shader;
+
+    // Vehicle lighting shader — single directional light
+    s->lighting_shader = LoadShader("shaders/lighting.vs", "shaders/lighting.fs");
+    s->loc_lightDir  = GetShaderLocation(s->lighting_shader, "lightDir");
+    s->loc_ambient   = GetShaderLocation(s->lighting_shader, "ambient");
+    s->loc_matNormal = GetShaderLocation(s->lighting_shader, "matNormal");
+
+    // Sun from upper-left-front
+    Vector3 sun = Vector3Normalize((Vector3){ -0.4f, 0.8f, -0.3f });
+    SetShaderValue(s->lighting_shader, s->loc_lightDir, &sun, SHADER_UNIFORM_VEC3);
+    float ambient = 0.35f;
+    SetShaderValue(s->lighting_shader, s->loc_ambient, &ambient, SHADER_UNIFORM_FLOAT);
 }
 
 static void update_chase_camera(scene_t *s, Vector3 pos) {
@@ -241,4 +253,5 @@ void scene_draw_sky(const scene_t *s) {
 void scene_cleanup(scene_t *s) {
     UnloadModel(s->grid_plane);
     UnloadShader(s->grid_shader);
+    UnloadShader(s->lighting_shader);
 }

--- a/src/scene.h
+++ b/src/scene.h
@@ -39,6 +39,11 @@ typedef struct {
     int loc_matModel;
     Model grid_plane;    // separate ground plane for grid modes
     int seq_1988;        // key sequence tracker
+    // Vehicle lighting shader
+    Shader lighting_shader;
+    int loc_lightDir;
+    int loc_ambient;
+    int loc_matNormal;
 } scene_t;
 
 // Initialize scene (ground plane, sky, camera, lighting).

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -43,6 +43,13 @@ static void remap_materials(vehicle_t *v) {
         else if (c->r < 20 && c->g < 20 && c->b < 20)
             *c = (Color){ 14, 31, 47, 255 };
     }
+
+    // Assign lighting shader to all materials (shader stored in vehicle_init)
+    if (v->lighting_shader.id > 0) {
+        for (int i = 0; i < v->model.materialCount; i++) {
+            v->model.materials[i].shader = v->lighting_shader;
+        }
+    }
 }
 
 // ── Model loading ───────────────────────────────────────────────────────────
@@ -75,7 +82,7 @@ void vehicle_cycle_model(vehicle_t *v) {
 }
 
 // ── Init / update / draw ────────────────────────────────────────────────────
-void vehicle_init(vehicle_t *v, int model_idx) {
+void vehicle_init(vehicle_t *v, int model_idx, Shader lighting_shader) {
     memset(v, 0, sizeof(*v));
     v->position = (Vector3){0};
     v->rotation = QuaternionIdentity();
@@ -91,6 +98,12 @@ void vehicle_init(vehicle_t *v, int model_idx) {
     v->trail_count = 0;
     v->trail_head = 0;
     v->trail_timer = 0.0f;
+
+    v->lighting_shader = lighting_shader;
+    v->loc_matNormal = -1;
+    if (lighting_shader.id > 0) {
+        v->loc_matNormal = GetShaderLocation(lighting_shader, "matNormal");
+    }
 
     vehicle_load_model(v, model_idx);
 }
@@ -193,7 +206,13 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
     Matrix trans = MatrixTranslate(v->position.x, v->position.y, v->position.z);
 
     // Transform = Scale * BaseRot * AttitudeRot * Translation
-    v->model.transform = MatrixMultiply(MatrixMultiply(MatrixMultiply(scale, base_rot), rot), trans);
+    Matrix rot_only = MatrixMultiply(base_rot, rot);
+    v->model.transform = MatrixMultiply(MatrixMultiply(scale, rot_only), trans);
+
+    // Set normal matrix (rotation only, no scale/translation) before drawing
+    if (v->loc_matNormal >= 0) {
+        SetShaderValueMatrix(v->lighting_shader, v->loc_matNormal, rot_only);
+    }
 
     DrawModel(v->model, (Vector3){0}, 1.0f, WHITE);
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -53,10 +53,12 @@ typedef struct {
     int trail_head;
     int trail_capacity;
     float trail_timer;
+    Shader lighting_shader;  // shared lighting shader (id=0 if none)
+    int loc_matNormal;       // shader uniform for normal matrix
 } vehicle_t;
 
-// Initialize vehicle state and load the model at model_idx.
-void vehicle_init(vehicle_t *v, int model_idx);
+// Initialize vehicle state and load the model at model_idx. shader is optional lighting shader (id=0 to skip).
+void vehicle_init(vehicle_t *v, int model_idx, Shader lighting_shader);
 
 // Swap to a different model at runtime (unloads old, loads new).
 void vehicle_load_model(vehicle_t *v, int model_idx);


### PR DESCRIPTION
## Summary
- Adds a simple GLSL directional lighting shader (single sun light + ambient) to all vehicle models
- Scene owns the shared shader and passes it to vehicles at init; each vehicle sets a rotation-only normal matrix before drawing so lighting responds correctly to attitude changes
- Sun direction: upper-left-front `(-0.4, 0.8, -0.3)` normalized, ambient: `0.35`

## Changes
- `shaders/lighting.vs` / `shaders/lighting.fs` — new vertex/fragment shader pair (GLSL 330)
- `src/scene.h` / `src/scene.c` — load and configure the lighting shader, unload on cleanup
- `src/vehicle.h` / `src/vehicle.c` — accept lighting shader at init, assign to all materials, set `matNormal` uniform before each `DrawModel` call
- `src/main.c` — init scene before vehicles so the shader is available

## Test plan
- [ ] Build and run with a PX4 SITL instance — verify vehicle model shows visible light/shadow sides
- [ ] Rotate camera around the vehicle — confirm shading stays consistent relative to the sun direction
- [ ] Verify all three vehicle types (multicopter, fixed-wing, tailsitter) render with lighting
- [ ] Check Rez and 1988 view modes still display correctly
- [ ] Confirm no performance regression (shader is a single dot product per fragment)