### PR TITLE
fix: reset trail on disconnect instead of reconnect

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -143,8 +143,8 @@ int main(int argc, char *argv[]) {
         for (int i = 0; i < vehicle_count; i++) {
             mavlink_receiver_poll(&receivers[i]);
 
-            // Reset trail on reconnect
-            if (receivers[i].connected && !was_connected[i]) {
+            // Reset trail on disconnect (so it's clean for next connection)
+            if (!receivers[i].connected && was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);
             }
             was_connected[i] = receivers[i].connected;

--- a/src/main.c
+++ b/src/main.c
@@ -145,9 +145,12 @@ int main(int argc, char *argv[]) {
         for (int i = 0; i < vehicle_count; i++) {
             mavlink_receiver_poll(&receivers[i]);
 
-            // Reset trail on reconnect or large position jump (new SITL instance)
+            // Reset trail and origin on reconnect
             if (receivers[i].connected && !was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);
+                if (!origin_specified && vehicle_count == 1) {
+                    vehicles[i].origin_set = false;
+                }
             }
             was_connected[i] = receivers[i].connected;
 

--- a/src/main.c
+++ b/src/main.c
@@ -135,6 +135,8 @@ int main(int argc, char *argv[]) {
     int selected = 0;
     bool was_connected[MAX_VEHICLES];
     memset(was_connected, 0, sizeof(was_connected));
+    Vector3 last_pos[MAX_VEHICLES];
+    memset(last_pos, 0, sizeof(last_pos));
     bool show_hud = true;
 
     // Main loop
@@ -143,14 +145,23 @@ int main(int argc, char *argv[]) {
         for (int i = 0; i < vehicle_count; i++) {
             mavlink_receiver_poll(&receivers[i]);
 
-            // Reset trail on disconnect (so it's clean for next connection)
-            if (!receivers[i].connected && was_connected[i]) {
+            // Reset trail on reconnect or large position jump (new SITL instance)
+            if (receivers[i].connected && !was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);
             }
             was_connected[i] = receivers[i].connected;
 
             vehicle_update(&vehicles[i], &receivers[i].state);
             vehicles[i].sysid = receivers[i].sysid;
+
+            // Detect position jump (new SITL connecting before disconnect timeout)
+            if (vehicles[i].active && vehicles[i].trail_count > 0) {
+                Vector3 delta = Vector3Subtract(vehicles[i].position, last_pos[i]);
+                if (Vector3Length(delta) > 50.0f) {
+                    vehicle_reset_trail(&vehicles[i]);
+                }
+            }
+            last_pos[i] = vehicles[i].position;
         }
 
         // Check if any receiver is connected (for HUD)


### PR DESCRIPTION
Reset trail on disconnect rather than reconnect. Fixes cases where a new SITL instance connects before the 2s timeout, bypassing the reconnect detection.