### PR TITLE
feat: orthographic view panel and fullscreen camera modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(mavsim-viewer
     src/vehicle.c
     src/scene.c
     src/hud.c
+    src/ortho_panel.c
 )
 
 target_include_directories(mavsim-viewer PRIVATE

--- a/README.md
+++ b/README.md
@@ -115,17 +115,24 @@ The test script accepts these options:
 | `V` | Cycle view mode (Grid / Rez) |
 | `H` | Toggle HUD visibility |
 | `M` | Cycle vehicle model |
+| `O` | Toggle orthographic side panel (Top / Front / Right) |
+| `Alt+1` | Return to perspective camera |
+| `Alt+2`-`7` | Fullscreen ortho view (Top / Front / Left / Right / Bottom / Back) |
 | `TAB` | Cycle to next vehicle |
 | `[` / `]` | Previous / next vehicle |
 | `1`-`9` | Select vehicle directly |
 | `Shift+1`-`9` | Toggle pin/unpin vehicle to HUD |
 | Left-drag | Orbit camera (chase mode) |
-| Scroll wheel | Zoom FOV |
+| Scroll wheel | Zoom FOV (perspective) or span (ortho) |
 
 ### View Modes
 
 - **Grid** (default) — Debug grid with minor/major lines and colored axes
 - **Rez** — Teal grid on black ground with dark sky
+
+### Orthographic Views
+
+Press `O` to open a side panel with three synchronized orthographic views (Top, Front, Right) that follow the selected vehicle. Use `Alt+2`-`7` to switch the main viewport to a fullscreen orthographic camera. Scroll wheel adjusts the visible span. Side views (Front, Back, Left, Right) include a ground plane fill and distance grid with adaptive spacing.
 
 ## Acknowledgments
 

--- a/src/hud.c
+++ b/src/hud.c
@@ -666,6 +666,14 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     }
 }
 
+int hud_bar_height(const hud_t *h, int screen_h) {
+    float s = powf(screen_h / 720.0f, 0.7f);
+    if (s < 1.0f) s = 1.0f;
+    int primary_h = (int)(120 * s);
+    int secondary_h = (int)(38 * s);
+    return primary_h + (h->pinned_count > 0 ? h->pinned_count * secondary_h + (int)(4 * s) : 0);
+}
+
 void hud_cleanup(hud_t *h) {
     UnloadFont(h->font_value);
     UnloadFont(h->font_label);

--- a/src/hud.h
+++ b/src/hud.h
@@ -23,4 +23,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
               int selected, int screen_w, int screen_h, view_mode_t view_mode);
 void hud_cleanup(hud_t *h);
 
+// Returns the total height of the HUD bar in pixels (for layout by other panels).
+int hud_bar_height(const hud_t *h, int screen_h);
+
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "vehicle.h"
 #include "scene.h"
 #include "hud.h"
+#include "ortho_panel.h"
 
 #define MAX_VEHICLES 16
 
@@ -132,6 +133,9 @@ int main(int argc, char *argv[]) {
     hud_t hud;
     hud_init(&hud);
 
+    ortho_panel_t ortho;
+    ortho_panel_init(&ortho);
+
     int selected = 0;
     bool was_connected[MAX_VEHICLES];
     memset(was_connected, 0, sizeof(was_connected));
@@ -174,6 +178,11 @@ int main(int argc, char *argv[]) {
         // Toggle HUD visibility
         if (IsKeyPressed(KEY_H)) {
             show_hud = !show_hud;
+        }
+
+        // Toggle ortho panel
+        if (IsKeyPressed(KEY_O)) {
+            ortho.visible = !ortho.visible;
         }
 
         // Cycle model for selected vehicle
@@ -247,6 +256,13 @@ int main(int argc, char *argv[]) {
         // Update camera to follow selected vehicle
         scene_update_camera(&scene, vehicles[selected].position, vehicles[selected].rotation);
 
+        // Render ortho views to textures (before main BeginDrawing)
+        if (ortho.visible) {
+            ortho_panel_update(&ortho, vehicles[selected].position);
+            ortho_panel_render(&ortho, &scene, vehicles, vehicle_count,
+                               selected, scene.view_mode);
+        }
+
         // Render
         BeginDrawing();
 
@@ -262,6 +278,9 @@ int main(int argc, char *argv[]) {
                 }
             EndMode3D();
 
+            // Ortho ground fill (2D overlay)
+            scene_draw_ortho_ground(&scene, GetScreenWidth(), GetScreenHeight());
+
             // HUD
             if (show_hud) {
                 hud_draw(&hud, vehicles, receivers, vehicle_count,
@@ -269,10 +288,19 @@ int main(int argc, char *argv[]) {
                          scene.view_mode);
             }
 
+            // Ortho panel overlay
+            int bar_h = show_hud ? hud_bar_height(&hud, GetScreenHeight()) : 0;
+            ortho_panel_draw(&ortho, GetScreenHeight(), bar_h, scene.view_mode, hud.font_label);
+
+            // Fullscreen ortho view label
+            ortho_panel_draw_fullscreen_label(GetScreenWidth(), GetScreenHeight(),
+                scene.ortho_mode, scene.ortho_span, scene.view_mode, hud.font_label);
+
         EndDrawing();
     }
 
     // Cleanup
+    ortho_panel_cleanup(&ortho);
     hud_cleanup(&hud);
     for (int i = 0; i < vehicle_count; i++) {
         vehicle_cleanup(&vehicles[i]);

--- a/src/ortho_panel.c
+++ b/src/ortho_panel.c
@@ -1,0 +1,321 @@
+#include "ortho_panel.h"
+#include "rlgl.h"
+#include <stdio.h>
+#include <math.h>
+
+static const char *view_labels[ORTHO_VIEW_COUNT] = { "TOP", "FRONT", "RIGHT" };
+
+void ortho_panel_init(ortho_panel_t *op) {
+    op->ortho_span = 60.0f;
+    op->visible = false;
+
+    for (int i = 0; i < ORTHO_VIEW_COUNT; i++) {
+        op->targets[i] = LoadRenderTexture(ORTHO_TEX_SIZE, ORTHO_TEX_SIZE);
+        op->cameras[i] = (Camera3D){
+            .position = (Vector3){0, 0, 0},
+            .target   = (Vector3){0, 0, 0},
+            .up       = (Vector3){0, 1, 0},
+            .fovy     = 1.0f,
+            .projection = CAMERA_ORTHOGRAPHIC,
+        };
+    }
+}
+
+void ortho_panel_update(ortho_panel_t *op, Vector3 pos) {
+    float span = op->ortho_span;
+
+    // Top-down: camera above, looking down
+    op->cameras[0].position = (Vector3){ pos.x, pos.y + 100.0f, pos.z };
+    op->cameras[0].target   = pos;
+    op->cameras[0].up       = (Vector3){ 0, 0, -1 };
+    op->cameras[0].fovy     = span;
+
+    // Front: camera in front (looking -Z), shows XY plane
+    op->cameras[1].position = (Vector3){ pos.x, pos.y, pos.z - 100.0f };
+    op->cameras[1].target   = pos;
+    op->cameras[1].up       = (Vector3){ 0, 1, 0 };
+    op->cameras[1].fovy     = span;
+
+    // Side: camera to the right (looking -X), shows ZY plane
+    op->cameras[2].position = (Vector3){ pos.x + 100.0f, pos.y, pos.z };
+    op->cameras[2].target   = pos;
+    op->cameras[2].up       = (Vector3){ 0, 1, 0 };
+    op->cameras[2].fovy     = span;
+
+    // Alt+scroll to zoom ortho views
+    if (IsKeyDown(KEY_LEFT_ALT)) {
+        float wheel = GetMouseWheelMove();
+        if (wheel != 0.0f) {
+            op->ortho_span -= wheel * 10.0f;
+            if (op->ortho_span < 10.0f) op->ortho_span = 10.0f;
+            if (op->ortho_span > 500.0f) op->ortho_span = 500.0f;
+        }
+    }
+}
+
+void ortho_panel_render(ortho_panel_t *op, const scene_t *s,
+                        const vehicle_t *vehicles, int vehicle_count,
+                        int selected, view_mode_t view_mode)
+{
+    for (int v = 0; v < ORTHO_VIEW_COUNT; v++) {
+        BeginTextureMode(op->targets[v]);
+            ClearBackground((Color){ 10, 10, 18, 255 });
+            BeginMode3D(op->cameras[v]);
+                scene_draw(s);
+
+                float ext = op->ortho_span * 2.0f;
+                // Pick grid spacing based on span
+                float spacing = 10.0f;
+                if (op->ortho_span > 200.0f) spacing = 50.0f;
+                else if (op->ortho_span > 80.0f) spacing = 20.0f;
+                else if (op->ortho_span < 20.0f) spacing = 2.0f;
+
+                Color grid_minor = { 40, 40, 55, 60 };
+                Color grid_major = { 60, 60, 80, 100 };
+
+                Vector3 center = op->cameras[v].target;
+
+                if (v == 0) {
+                    // Top-down: XZ grid
+                    float snap_x = floorf(center.x / spacing) * spacing;
+                    float snap_z = floorf(center.z / spacing) * spacing;
+                    for (float g = -ext; g <= ext; g += spacing) {
+                        bool major = fabsf(fmodf(snap_x + g, spacing * 5)) < 0.1f;
+                        Color c = major ? grid_major : grid_minor;
+                        DrawLine3D((Vector3){snap_x + g, 0.01f, center.z - ext},
+                                   (Vector3){snap_x + g, 0.01f, center.z + ext}, c);
+                    }
+                    for (float g = -ext; g <= ext; g += spacing) {
+                        bool major = fabsf(fmodf(snap_z + g, spacing * 5)) < 0.1f;
+                        Color c = major ? grid_major : grid_minor;
+                        DrawLine3D((Vector3){center.x - ext, 0.01f, snap_z + g},
+                                   (Vector3){center.x + ext, 0.01f, snap_z + g}, c);
+                    }
+                } else if (v == 1) {
+                    // Front: XY grid (constant Z)
+                    float snap_x = floorf(center.x / spacing) * spacing;
+                    float snap_y = floorf(center.y / spacing) * spacing;
+                    float z = center.z;
+                    for (float g = -ext; g <= ext; g += spacing) {
+                        bool major = fabsf(fmodf(snap_x + g, spacing * 5)) < 0.1f;
+                        Color c = major ? grid_major : grid_minor;
+                        DrawLine3D((Vector3){snap_x + g, center.y - ext, z},
+                                   (Vector3){snap_x + g, center.y + ext, z}, c);
+                    }
+                    for (float g = -ext; g <= ext; g += spacing) {
+                        bool major = fabsf(fmodf(snap_y + g, spacing * 5)) < 0.1f;
+                        Color c = major ? grid_major : grid_minor;
+                        DrawLine3D((Vector3){center.x - ext, snap_y + g, z},
+                                   (Vector3){center.x + ext, snap_y + g, z}, c);
+                    }
+                } else {
+                    // Side (Right): ZY grid (constant X)
+                    float snap_z = floorf(center.z / spacing) * spacing;
+                    float snap_y = floorf(center.y / spacing) * spacing;
+                    float x = center.x;
+                    for (float g = -ext; g <= ext; g += spacing) {
+                        bool major = fabsf(fmodf(snap_z + g, spacing * 5)) < 0.1f;
+                        Color c = major ? grid_major : grid_minor;
+                        DrawLine3D((Vector3){x, center.y - ext, snap_z + g},
+                                   (Vector3){x, center.y + ext, snap_z + g}, c);
+                    }
+                    for (float g = -ext; g <= ext; g += spacing) {
+                        bool major = fabsf(fmodf(snap_y + g, spacing * 5)) < 0.1f;
+                        Color c = major ? grid_major : grid_minor;
+                        DrawLine3D((Vector3){x, snap_y + g, center.z - ext},
+                                   (Vector3){x, snap_y + g, center.z + ext}, c);
+                    }
+                }
+
+                // Ground line at Y=0 (side/front views)
+                if (v > 0) {
+                    Color gnd_line = { 120, 120, 150, 200 };
+                    DrawLine3D((Vector3){-ext, 0, -ext}, (Vector3){ ext, 0, -ext}, gnd_line);
+                    DrawLine3D((Vector3){-ext, 0,  ext}, (Vector3){ ext, 0,  ext}, gnd_line);
+                    DrawLine3D((Vector3){-ext, 0, -ext}, (Vector3){-ext, 0,  ext}, gnd_line);
+                    DrawLine3D((Vector3){ ext, 0, -ext}, (Vector3){ ext, 0,  ext}, gnd_line);
+                }
+
+                for (int i = 0; i < vehicle_count; i++) {
+                    if (vehicles[i].active || vehicle_count == 1) {
+                        vehicle_draw((vehicle_t *)&vehicles[i], view_mode, i == selected);
+                    }
+                }
+            EndMode3D();
+
+            // 2D ground fill below Y=0 for side/front views
+            if (v > 0) {
+                Vector3 gnd_pt = op->cameras[v].target;
+                gnd_pt.y = 0.0f;
+                Vector2 sp = GetWorldToScreen(gnd_pt, op->cameras[v]);
+                int gy = (int)sp.y;
+                if (gy < 0) gy = 0;
+                if (gy + 1 < ORTHO_TEX_SIZE) {
+                    DrawRectangle(0, gy + 1, ORTHO_TEX_SIZE, ORTHO_TEX_SIZE - gy - 1, (Color){ 2, 2, 6, 180 });
+                }
+            }
+        EndTextureMode();
+    }
+}
+
+static void draw_scale_bar(float x, float y, float ps, float span, Color col, Font font, float font_size) {
+    float target_px = ps * 0.35f;
+    float meters_per_px = span / ps;
+    float target_m = target_px * meters_per_px;
+
+    float nice[] = { 1, 2, 5, 10, 20, 50, 100, 200, 500 };
+    float scale_m = nice[0];
+    for (int i = 0; i < 9; i++) {
+        if (nice[i] <= target_m) scale_m = nice[i];
+        else break;
+    }
+    float scale_px = scale_m / meters_per_px;
+
+    float sx = x + 8;
+    float sy = y + ps - 12;
+
+    DrawRectangle((int)sx, (int)sy, (int)scale_px, 2, col);
+    DrawRectangle((int)sx, (int)(sy - 3), 1, 8, col);
+    DrawRectangle((int)(sx + scale_px), (int)(sy - 3), 1, 8, col);
+
+    char buf[32];
+    if (scale_m >= 1.0f)
+        snprintf(buf, sizeof(buf), "%.0fm", scale_m);
+    else
+        snprintf(buf, sizeof(buf), "%.1fm", scale_m);
+    Vector2 ts = MeasureTextEx(font, buf, font_size, 0);
+    DrawTextEx(font, buf, (Vector2){ sx + scale_px / 2 - ts.x / 2, sy - font_size - 4 }, font_size, 0, col);
+}
+
+static void draw_crosshair(float cx, float cy, float size, Color col) {
+    DrawLine((int)(cx - size), (int)cy, (int)(cx + size), (int)cy, col);
+    DrawLine((int)cx, (int)(cy - size), (int)cx, (int)(cy + size), col);
+}
+
+void ortho_panel_draw(const ortho_panel_t *op, int screen_h, int hud_bar_h,
+                      view_mode_t view_mode, Font font)
+{
+    if (!op->visible) return;
+
+    int margin = 8;
+    int gap = 4;
+
+    // Available height = screen minus HUD bar minus margins
+    int avail_h = screen_h - hud_bar_h - margin * 2;
+    int ps = (avail_h - gap * (ORTHO_VIEW_COUNT - 1)) / ORTHO_VIEW_COUNT;
+    if (ps < 60) ps = 60;
+
+    int total_h = ps * ORTHO_VIEW_COUNT + gap * (ORTHO_VIEW_COUNT - 1);
+    int start_y = screen_h - hud_bar_h - total_h - margin;
+
+    Color border_col, label_col, scale_col, cross_col;
+    if (view_mode == VIEW_1988) {
+        border_col = (Color){ 255, 20, 100, 120 };
+        label_col  = (Color){ 255, 20, 100, 200 };
+        scale_col  = (Color){ 255, 20, 100, 160 };
+        cross_col  = (Color){ 255, 20, 100, 60 };
+    } else if (view_mode == VIEW_REZ) {
+        border_col = (Color){ 0, 204, 218, 120 };
+        label_col  = (Color){ 0, 204, 218, 200 };
+        scale_col  = (Color){ 0, 204, 218, 160 };
+        cross_col  = (Color){ 0, 204, 218, 60 };
+    } else {
+        border_col = (Color){ 180, 180, 200, 120 };
+        label_col  = (Color){ 200, 200, 220, 200 };
+        scale_col  = (Color){ 180, 180, 200, 160 };
+        cross_col  = (Color){ 180, 180, 200, 60 };
+    }
+
+    // Match HUD scaling: powf(screen_h / 720.0f, 0.7f)
+    float s = powf(screen_h / 720.0f, 0.7f);
+    if (s < 1.0f) s = 1.0f;
+    float font_size = 12 * s;
+
+    for (int i = 0; i < ORTHO_VIEW_COUNT; i++) {
+        float x = (float)margin;
+        float y = (float)(start_y + i * (ps + gap));
+
+        // Background
+        DrawRectangle((int)x, (int)y, ps, ps, (Color){ 5, 5, 12, 200 });
+
+        // Render texture scaled to panel size (flip Y)
+        Rectangle src = { 0, (float)ORTHO_TEX_SIZE, (float)ORTHO_TEX_SIZE, (float)(-ORTHO_TEX_SIZE) };
+        Rectangle dst = { x, y, (float)ps, (float)ps };
+        DrawTexturePro(op->targets[i].texture, src, dst, (Vector2){0, 0}, 0.0f, WHITE);
+
+        // Border
+        DrawRectangleLines((int)x, (int)y, ps, ps, border_col);
+
+        // Center crosshair
+        draw_crosshair(x + ps / 2.0f, y + ps / 2.0f, 6.0f, cross_col);
+
+        // View label (top-center)
+        Vector2 ts = MeasureTextEx(font, view_labels[i], font_size, 0);
+        DrawTextEx(font, view_labels[i],
+            (Vector2){ x + ps / 2.0f - ts.x / 2.0f, y + 3 }, font_size, 0, label_col);
+
+        // Scale bar
+        draw_scale_bar(x, y, (float)ps, op->ortho_span, scale_col, font, font_size * 0.85f);
+    }
+}
+
+void ortho_panel_draw_fullscreen_label(int screen_w, int screen_h, int ortho_mode,
+                                       float ortho_span, int view_mode, Font font)
+{
+    if (ortho_mode == 0) return;  // ORTHO_NONE
+
+    static const char *names[] = { "", "TOP", "BOTTOM", "FRONT", "BACK", "LEFT", "RIGHT" };
+    const char *name = names[ortho_mode];
+
+    float s = powf(screen_h / 720.0f, 0.7f);
+    if (s < 1.0f) s = 1.0f;
+    float fs = 16 * s;
+
+    Color col;
+    if (view_mode == 2)       // VIEW_1988 (can't use enum directly due to header order)
+        col = (Color){ 255, 20, 100, 200 };
+    else if (view_mode == 1)  // VIEW_REZ
+        col = (Color){ 0, 204, 218, 200 };
+    else
+        col = (Color){ 200, 200, 220, 200 };
+
+    // View name top-right
+    Vector2 ts = MeasureTextEx(font, name, fs, 0);
+    DrawTextEx(font, name, (Vector2){ screen_w - ts.x - 12, 12 }, fs, 0, col);
+
+    // Scale bar in top-left area
+    float bar_span = ortho_span;
+    float meters_per_px = bar_span / (float)(screen_h < screen_w ? screen_h : screen_w);
+    float target_px = screen_w * 0.15f;
+    float target_m = target_px * meters_per_px;
+    float nice[] = { 1, 2, 5, 10, 20, 50, 100, 200, 500 };
+    float scale_m = nice[0];
+    for (int i = 0; i < 9; i++) {
+        if (nice[i] <= target_m) scale_m = nice[i];
+        else break;
+    }
+    float scale_px = scale_m / meters_per_px;
+
+    float sx = 12;
+    float sy = 12 + fs + 8;
+    Color scale_col = (Color){ col.r, col.g, col.b, (unsigned char)(col.a * 0.7f) };
+    DrawRectangle((int)sx, (int)sy, (int)scale_px, 2, scale_col);
+    DrawRectangle((int)sx, (int)(sy - 3), 1, 8, scale_col);
+    DrawRectangle((int)(sx + scale_px), (int)(sy - 3), 1, 8, scale_col);
+
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%.0fm", scale_m);
+    DrawTextEx(font, buf, (Vector2){ sx + scale_px + 6, sy - fs * 0.4f }, fs * 0.75f, 0, scale_col);
+
+    // Crosshair at center
+    Color cross = (Color){ col.r, col.g, col.b, 40 };
+    float cx = screen_w / 2.0f, cy = screen_h / 2.0f;
+    DrawLine((int)(cx - 10), (int)cy, (int)(cx + 10), (int)cy, cross);
+    DrawLine((int)cx, (int)(cy - 10), (int)cx, (int)(cy + 10), cross);
+}
+
+void ortho_panel_cleanup(ortho_panel_t *op) {
+    for (int i = 0; i < ORTHO_VIEW_COUNT; i++) {
+        UnloadRenderTexture(op->targets[i]);
+    }
+}

--- a/src/ortho_panel.h
+++ b/src/ortho_panel.h
@@ -1,0 +1,29 @@
+#ifndef ORTHO_PANEL_H
+#define ORTHO_PANEL_H
+
+#include "raylib.h"
+#include "vehicle.h"
+#include "scene.h"
+
+#define ORTHO_VIEW_COUNT 3
+#define ORTHO_TEX_SIZE 512   // max render texture size
+
+typedef struct {
+    RenderTexture2D targets[ORTHO_VIEW_COUNT]; // top, front, side
+    Camera3D cameras[ORTHO_VIEW_COUNT];
+    float ortho_span;   // world units visible in each view
+    bool visible;
+} ortho_panel_t;
+
+void ortho_panel_init(ortho_panel_t *op);
+void ortho_panel_update(ortho_panel_t *op, Vector3 vehicle_pos);
+void ortho_panel_render(ortho_panel_t *op, const scene_t *s,
+                        const vehicle_t *vehicles, int vehicle_count,
+                        int selected, view_mode_t view_mode);
+void ortho_panel_draw(const ortho_panel_t *op, int screen_h, int hud_bar_h,
+                      view_mode_t view_mode, Font font);
+void ortho_panel_draw_fullscreen_label(int screen_w, int screen_h, int ortho_mode,
+                                       float ortho_span, int view_mode, Font font);
+void ortho_panel_cleanup(ortho_panel_t *op);
+
+#endif

--- a/src/scene.c
+++ b/src/scene.c
@@ -38,6 +38,8 @@
 void scene_init(scene_t *s) {
     s->cam_mode = CAM_MODE_CHASE;
     s->view_mode = VIEW_GRID;
+    s->ortho_mode = ORTHO_NONE;
+    s->ortho_span = 60.0f;
     s->chase_distance = 3.0f;
     s->chase_yaw = 0.0f;
     s->chase_pitch = 0.4f;  // ~23° above horizontal
@@ -109,7 +111,54 @@ static void update_fpv_camera(scene_t *s, Vector3 pos, Quaternion rot) {
     s->camera.up = up;
 }
 
+static void update_ortho_camera(scene_t *s, Vector3 pos) {
+    float span = s->ortho_span;
+    s->camera.projection = CAMERA_ORTHOGRAPHIC;
+    s->camera.fovy = span;
+
+    switch (s->ortho_mode) {
+        case ORTHO_TOP:
+            s->camera.position = (Vector3){ pos.x, pos.y + 100.0f, pos.z };
+            s->camera.target = pos;
+            s->camera.up = (Vector3){ 0, 0, -1 };
+            break;
+        case ORTHO_BOTTOM:
+            s->camera.position = (Vector3){ pos.x, pos.y - 100.0f, pos.z };
+            s->camera.target = pos;
+            s->camera.up = (Vector3){ 0, 0, 1 };
+            break;
+        case ORTHO_FRONT:
+            s->camera.position = (Vector3){ pos.x, pos.y, pos.z - 100.0f };
+            s->camera.target = pos;
+            s->camera.up = (Vector3){ 0, 1, 0 };
+            break;
+        case ORTHO_BACK:
+            s->camera.position = (Vector3){ pos.x, pos.y, pos.z + 100.0f };
+            s->camera.target = pos;
+            s->camera.up = (Vector3){ 0, 1, 0 };
+            break;
+        case ORTHO_LEFT:
+            s->camera.position = (Vector3){ pos.x - 100.0f, pos.y, pos.z };
+            s->camera.target = pos;
+            s->camera.up = (Vector3){ 0, 1, 0 };
+            break;
+        case ORTHO_RIGHT:
+            s->camera.position = (Vector3){ pos.x + 100.0f, pos.y, pos.z };
+            s->camera.target = pos;
+            s->camera.up = (Vector3){ 0, 1, 0 };
+            break;
+        default:
+            break;
+    }
+}
+
 void scene_update_camera(scene_t *s, Vector3 vehicle_pos, Quaternion vehicle_rot) {
+    if (s->ortho_mode != ORTHO_NONE) {
+        update_ortho_camera(s, vehicle_pos);
+        return;
+    }
+
+    s->camera.projection = CAMERA_PERSPECTIVE;
     switch (s->cam_mode) {
         case CAM_MODE_CHASE:
             update_chase_camera(s, vehicle_pos);
@@ -123,7 +172,29 @@ void scene_update_camera(scene_t *s, Vector3 vehicle_pos, Quaternion vehicle_rot
 }
 
 void scene_handle_input(scene_t *s) {
+    // Alt+number: fullscreen ortho views
+    if (IsKeyDown(KEY_LEFT_ALT) || IsKeyDown(KEY_RIGHT_ALT)) {
+        static const int keys[] = { KEY_ONE, KEY_TWO, KEY_THREE, KEY_FOUR, KEY_FIVE, KEY_SIX, KEY_SEVEN };
+        static const ortho_mode_t modes[] = { ORTHO_NONE, ORTHO_TOP, ORTHO_FRONT, ORTHO_LEFT, ORTHO_RIGHT, ORTHO_BOTTOM, ORTHO_BACK };
+        static const char *names[] = { "Perspective", "Top", "Front", "Left", "Right", "Bottom", "Back" };
+        for (int i = 0; i < 7; i++) {
+            if (IsKeyPressed(keys[i])) {
+                s->ortho_mode = modes[i];
+                printf("View: %s\n", names[i]);
+                break;
+            }
+        }
+        // Alt+scroll to zoom ortho span
+        float wheel = GetMouseWheelMove();
+        if (wheel != 0.0f && s->ortho_mode != ORTHO_NONE) {
+            s->ortho_span -= wheel * 10.0f;
+            if (s->ortho_span < 10.0f) s->ortho_span = 10.0f;
+            if (s->ortho_span > 500.0f) s->ortho_span = 500.0f;
+        }
+    }
+
     if (IsKeyPressed(KEY_C)) {
+        s->ortho_mode = ORTHO_NONE;  // return to perspective on camera toggle
         s->cam_mode = (s->cam_mode + 1) % CAM_MODE_COUNT;
         const char *names[] = {"Chase", "FPV"};
         printf("Camera: %s\n", names[s->cam_mode]);
@@ -179,12 +250,23 @@ void scene_handle_input(scene_t *s) {
         }
     }
 
-    // Scroll wheel FOV zoom
-    float wheel = GetMouseWheelMove();
-    if (wheel != 0.0f) {
-        s->camera.fovy -= wheel * 5.0f;
-        if (s->camera.fovy < 10.0f) s->camera.fovy = 10.0f;
-        if (s->camera.fovy > 120.0f) s->camera.fovy = 120.0f;
+    // Scroll wheel FOV zoom (only in perspective mode, not when Alt held)
+    if (!IsKeyDown(KEY_LEFT_ALT) && !IsKeyDown(KEY_RIGHT_ALT) && s->ortho_mode == ORTHO_NONE) {
+        float wheel = GetMouseWheelMove();
+        if (wheel != 0.0f) {
+            s->camera.fovy -= wheel * 5.0f;
+            if (s->camera.fovy < 10.0f) s->camera.fovy = 10.0f;
+            if (s->camera.fovy > 120.0f) s->camera.fovy = 120.0f;
+        }
+    }
+    // Scroll wheel ortho span zoom (fullscreen ortho, no Alt needed)
+    if (s->ortho_mode != ORTHO_NONE && !IsKeyDown(KEY_LEFT_ALT) && !IsKeyDown(KEY_RIGHT_ALT)) {
+        float wheel = GetMouseWheelMove();
+        if (wheel != 0.0f) {
+            s->ortho_span -= wheel * 10.0f;
+            if (s->ortho_span < 10.0f) s->ortho_span = 10.0f;
+            if (s->ortho_span > 500.0f) s->ortho_span = 500.0f;
+        }
     }
 }
 
@@ -226,6 +308,93 @@ void scene_draw(const scene_t *s) {
         draw_shader_grid(s, REZ_GROUND, REZ_MINOR, REZ_MAJOR, REZ_AXIS_X, REZ_AXIS_Z);
     } else if (s->view_mode == VIEW_1988) {
         draw_shader_grid(s, SYNTH_GROUND, SYNTH_MINOR, SYNTH_MAJOR, SYNTH_AXIS_X, SYNTH_AXIS_Z);
+    }
+
+    // Fullscreen ortho: distance grid + ground line
+    if (s->ortho_mode != ORTHO_NONE) {
+        float ext = s->ortho_span * 2.0f;
+        float spacing = 10.0f;
+        if (s->ortho_span > 200.0f) spacing = 50.0f;
+        else if (s->ortho_span > 80.0f) spacing = 20.0f;
+        else if (s->ortho_span < 20.0f) spacing = 2.0f;
+
+        Color grid_minor = { 40, 40, 55, 60 };
+        Color grid_major = { 60, 60, 80, 100 };
+        Vector3 center = s->camera.target;
+
+        if (s->ortho_mode == ORTHO_TOP || s->ortho_mode == ORTHO_BOTTOM) {
+            float snap_x = floorf(center.x / spacing) * spacing;
+            float snap_z = floorf(center.z / spacing) * spacing;
+            for (float g = -ext; g <= ext; g += spacing) {
+                bool major = fabsf(fmodf(snap_x + g, spacing * 5)) < 0.1f;
+                DrawLine3D((Vector3){snap_x + g, 0.01f, center.z - ext},
+                           (Vector3){snap_x + g, 0.01f, center.z + ext}, major ? grid_major : grid_minor);
+            }
+            for (float g = -ext; g <= ext; g += spacing) {
+                bool major = fabsf(fmodf(snap_z + g, spacing * 5)) < 0.1f;
+                DrawLine3D((Vector3){center.x - ext, 0.01f, snap_z + g},
+                           (Vector3){center.x + ext, 0.01f, snap_z + g}, major ? grid_major : grid_minor);
+            }
+        } else if (s->ortho_mode == ORTHO_FRONT || s->ortho_mode == ORTHO_BACK) {
+            float snap_x = floorf(center.x / spacing) * spacing;
+            float snap_y = floorf(center.y / spacing) * spacing;
+            float z = center.z;
+            for (float g = -ext; g <= ext; g += spacing) {
+                bool major = fabsf(fmodf(snap_x + g, spacing * 5)) < 0.1f;
+                DrawLine3D((Vector3){snap_x + g, center.y - ext, z},
+                           (Vector3){snap_x + g, center.y + ext, z}, major ? grid_major : grid_minor);
+            }
+            for (float g = -ext; g <= ext; g += spacing) {
+                bool major = fabsf(fmodf(snap_y + g, spacing * 5)) < 0.1f;
+                DrawLine3D((Vector3){center.x - ext, snap_y + g, z},
+                           (Vector3){center.x + ext, snap_y + g, z}, major ? grid_major : grid_minor);
+            }
+        } else {
+            // Left / Right: ZY grid
+            float snap_z = floorf(center.z / spacing) * spacing;
+            float snap_y = floorf(center.y / spacing) * spacing;
+            float x = center.x;
+            for (float g = -ext; g <= ext; g += spacing) {
+                bool major = fabsf(fmodf(snap_z + g, spacing * 5)) < 0.1f;
+                DrawLine3D((Vector3){x, center.y - ext, snap_z + g},
+                           (Vector3){x, center.y + ext, snap_z + g}, major ? grid_major : grid_minor);
+            }
+            for (float g = -ext; g <= ext; g += spacing) {
+                bool major = fabsf(fmodf(snap_y + g, spacing * 5)) < 0.1f;
+                DrawLine3D((Vector3){x, snap_y + g, center.z - ext},
+                           (Vector3){x, snap_y + g, center.z + ext}, major ? grid_major : grid_minor);
+            }
+        }
+
+        // Ground line for side views (fill is drawn as 2D overlay after EndMode3D)
+        if (s->ortho_mode >= ORTHO_FRONT && s->ortho_mode <= ORTHO_RIGHT) {
+            Color gnd_line = { 120, 120, 150, 200 };
+            DrawLine3D((Vector3){-ext, 0, -ext}, (Vector3){ ext, 0, -ext}, gnd_line);
+            DrawLine3D((Vector3){-ext, 0,  ext}, (Vector3){ ext, 0,  ext}, gnd_line);
+            DrawLine3D((Vector3){-ext, 0, -ext}, (Vector3){-ext, 0,  ext}, gnd_line);
+            DrawLine3D((Vector3){ ext, 0, -ext}, (Vector3){ ext, 0,  ext}, gnd_line);
+        }
+    }
+}
+
+void scene_draw_ortho_ground(const scene_t *s, int screen_w, int screen_h) {
+    // Only for side ortho views (front/back/left/right)
+    if (s->ortho_mode < ORTHO_FRONT || s->ortho_mode > ORTHO_RIGHT) return;
+
+    // Project Y=0 world position to screen Y
+    Vector3 ground_pt = s->camera.target;
+    ground_pt.y = 0.0f;
+    Vector2 screen_pos = GetWorldToScreen(ground_pt, s->camera);
+    int ground_y = (int)screen_pos.y;
+
+    // Clamp to screen bounds
+    if (ground_y < 0) ground_y = 0;
+    if (ground_y > screen_h) ground_y = screen_h;
+
+    // Dark fill from just below ground line to bottom
+    int fill_h = screen_h - ground_y - 1;
+    if (fill_h > 0) {
+        DrawRectangle(0, ground_y + 1, screen_w, fill_h, (Color){ 2, 2, 6, 180 });
     }
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -10,6 +10,17 @@ typedef enum {
     CAM_MODE_COUNT
 } camera_mode_t;
 
+// Fullscreen orthographic views (0 = off/perspective)
+typedef enum {
+    ORTHO_NONE = 0,
+    ORTHO_TOP,      // Alt+2
+    ORTHO_BOTTOM,   // Alt+6
+    ORTHO_FRONT,    // Alt+3
+    ORTHO_BACK,     // Alt+7
+    ORTHO_LEFT,     // Alt+4
+    ORTHO_RIGHT,    // Alt+5
+} ortho_mode_t;
+
 typedef enum {
     VIEW_GRID = 0,
     VIEW_REZ,
@@ -39,6 +50,8 @@ typedef struct {
     int loc_matModel;
     Model grid_plane;    // separate ground plane for grid modes
     int seq_1988;        // key sequence tracker
+    ortho_mode_t ortho_mode; // fullscreen ortho view (0 = perspective)
+    float ortho_span;        // ortho view span in world units
 } scene_t;
 
 // Initialize scene (ground plane, sky, camera, lighting).
@@ -55,6 +68,9 @@ void scene_draw(const scene_t *s);
 
 // Draw sky background. Call before BeginMode3D.
 void scene_draw_sky(const scene_t *s);
+
+// Draw ground fill for ortho side views (call after EndMode3D).
+void scene_draw_ortho_ground(const scene_t *s, int screen_w, int screen_h);
 
 // Cleanup scene resources.
 void scene_cleanup(scene_t *s);


### PR DESCRIPTION
## Summary

- Add ortho side panel (`O` key) with three synchronized views (Top, Front, Right) rendered to off-screen textures, following the selected vehicle

<img width="2880" height="1694" alt="Ortho Demo 1" src="https://github.com/user-attachments/assets/9ed94753-ed32-4daa-b5e6-f34a7431959d" />

- Add fullscreen orthographic camera modes via `Alt+1`-`7` (Perspective, Top, Front, Left, Right, Bottom, Back)
- Distance grids with adaptive spacing (2m/10m/20m/50m based on zoom), ground plane fill in side views, scale bars, crosshairs, and view labels

<img width="2880" height="1696" alt="Ortho Demo 2" src="https://github.com/user-attachments/assets/bdd9cc2d-b84a-441e-b440-10128b5637fb" />

- Scroll wheel zooms ortho span; styling adapts to active view mode (Grid/Rez/1988)
- `hud_bar_height()` utility for layout coordination between HUD and panels
- README updated with new keyboard shortcuts

## Test plan

- [ ] Build on macOS, Linux, and Windows (standard C11, no platform-specific code)
- [ ] Press `O` to toggle ortho panel — verify Top/Front/Right views render correctly
- [ ] Press `Alt+2` through `Alt+7` to cycle fullscreen ortho views, `Alt+1` to return to perspective
- [ ] Scroll wheel adjusts zoom in both panel and fullscreen ortho modes
- [ ] Verify ground plane fill appears in Front/Back/Left/Right side views
- [ ] Verify distance grid adapts spacing when zooming in/out
- [ ] Press `C` while in ortho mode — should return to perspective chase/FPV
- [ ] Verify panel positions correctly above HUD bar at various window sizes
- [ ] Test with multi-vehicle (`-n 3`) to confirm ortho views track selected vehicle