### PR TITLE
feat: add Snow view mode for outdoor visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The test script accepts these options:
 | Key/Input | Action |
 |---|---|
 | `C` | Toggle camera mode (Chase / FPV) |
-| `V` | Cycle view mode (Grid / Rez) |
+| `V` | Cycle view mode (Grid / Rez / Snow) |
 | `H` | Toggle HUD visibility |
 | `M` | Cycle vehicle model |
 | `TAB` | Cycle to next vehicle |
@@ -126,6 +126,7 @@ The test script accepts these options:
 
 - **Grid** (default) — Debug grid with minor/major lines and colored axes
 - **Rez** — Teal grid on black ground with dark sky
+- **Snow** — High-contrast outdoor mode with bright white ground, dark grid lines, and black-outlined HUD for visibility on low-nit screens in sunlight
 
 ## Acknowledgments
 

--- a/src/hud.c
+++ b/src/hud.c
@@ -30,6 +30,13 @@
 #define SYNTH_BG (Color){ 5, 5, 16, 220 }
 #define SYNTH_BORDER (Color){ 255, 20, 100, 100 }
 
+// Snow HUD accent colors (dark on bright, black outlines)
+#define SNOW_ACCENT (Color){ 15, 15, 20, 255 }
+#define SNOW_ACCENT_DIM (Color){ 60, 65, 75, 200 }
+#define SNOW_ORANGE (Color){ 200, 40, 0, 255 }
+#define SNOW_BG (Color){ 248, 248, 250, 235 }
+#define SNOW_BORDER (Color){ 15, 15, 20, 140 }
+
 void hud_init(hud_t *h) {
     h->sim_time_s = 0.0f;
     h->pinned_count = 0;
@@ -62,13 +69,14 @@ void hud_update(hud_t *h, uint64_t time_usec, bool connected, float dt) {
 static void draw_compass(float cx, float cy, float radius, float heading_deg, view_mode_t vm, Font font_value) {
     bool rez = (vm == VIEW_REZ);
     bool synth = (vm == VIEW_1988);
-    Color bg = rez ? REZ_BG : synth ? SYNTH_BG : (Color){30, 30, 30, 220};
-    Color border = rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){100, 100, 100, 255};
-    Color tick_major = rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
-    Color tick_minor = rez ? REZ_ACCENT_DIM : synth ? (Color){ 10, 120, 160, 255 } : (Color){160, 160, 160, 255};
-    Color text_color = rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
-    Color north_color = rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
-    Color pointer_color = rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
+    bool snow = (vm == VIEW_SNOW);
+    Color bg = snow ? SNOW_BG : rez ? REZ_BG : synth ? SYNTH_BG : (Color){30, 30, 30, 220};
+    Color border = snow ? SNOW_BORDER : rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){100, 100, 100, 255};
+    Color tick_major = snow ? SNOW_ACCENT : rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
+    Color tick_minor = snow ? SNOW_ACCENT_DIM : rez ? REZ_ACCENT_DIM : synth ? (Color){ 10, 120, 160, 255 } : (Color){160, 160, 160, 255};
+    Color text_color = snow ? SNOW_ACCENT : rez ? REZ_ACCENT : synth ? SYNTH_HIGHLIGHT : WHITE;
+    Color north_color = snow ? SNOW_ORANGE : rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
+    Color pointer_color = snow ? SNOW_ORANGE : rez ? REZ_ORANGE : synth ? SYNTH_ACCENT : RED;
 
     DrawCircle((int)cx, (int)cy, radius, bg);
     DrawCircleLines((int)cx, (int)cy, radius, border);
@@ -110,14 +118,15 @@ static void draw_compass(float cx, float cy, float radius, float heading_deg, vi
 static void draw_attitude(float cx, float cy, float radius, float roll_deg, float pitch_deg, view_mode_t vm) {
     bool rez = (vm == VIEW_REZ);
     bool synth = (vm == VIEW_1988);
-    Color bg = rez ? REZ_BG : synth ? SYNTH_BG : (Color){30, 30, 30, 220};
-    Color border = rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){100, 100, 100, 255};
-    Color horizon_color = rez ? REZ_ACCENT : synth ? (Color){ 112, 40, 21, 255 } : WHITE;
-    Color pitch_bar_color = rez ? REZ_ACCENT_DIM : synth ? SYNTH_ACCENT_DIM : (Color){200, 200, 200, 160};
-    Color wing_color = rez ? REZ_ORANGE : synth ? SYNTH_HIGHLIGHT : YELLOW;
-    Color roll_tri_color = rez ? REZ_ACCENT : synth ? SYNTH_ACCENT : WHITE;
-    Color sky_color = rez ? (Color){ 0, 40, 45, 200 } : synth ? (Color){ 0, 4, 12, 200 } : (Color){ 80, 140, 200, 200 };
-    Color gnd_color = rez ? (Color){ 20, 10, 2, 200 } : synth ? (Color){ 251, 153, 54, 200 } : (Color){ 120, 85, 50, 200 };
+    bool snow = (vm == VIEW_SNOW);
+    Color bg = snow ? SNOW_BG : rez ? REZ_BG : synth ? SYNTH_BG : (Color){30, 30, 30, 220};
+    Color border = snow ? SNOW_BORDER : rez ? REZ_BORDER : synth ? SYNTH_BORDER : (Color){100, 100, 100, 255};
+    Color horizon_color = snow ? WHITE : rez ? REZ_ACCENT : synth ? (Color){ 112, 40, 21, 255 } : WHITE;
+    Color pitch_bar_color = snow ? (Color){ 80, 90, 110, 180 } : rez ? REZ_ACCENT_DIM : synth ? SYNTH_ACCENT_DIM : (Color){200, 200, 200, 160};
+    Color wing_color = snow ? SNOW_ORANGE : rez ? REZ_ORANGE : synth ? SYNTH_HIGHLIGHT : YELLOW;
+    Color roll_tri_color = snow ? SNOW_ACCENT : rez ? REZ_ACCENT : synth ? SYNTH_ACCENT : WHITE;
+    Color sky_color = snow ? (Color){ 160, 185, 215, 220 } : rez ? (Color){ 0, 40, 45, 200 } : synth ? (Color){ 0, 4, 12, 200 } : (Color){ 80, 140, 200, 200 };
+    Color gnd_color = snow ? (Color){ 20, 30, 55, 220 } : rez ? (Color){ 20, 10, 2, 200 } : synth ? (Color){ 251, 153, 54, 200 } : (Color){ 120, 85, 50, 200 };
 
     DrawCircle((int)cx, (int)cy, radius, bg);
 
@@ -270,7 +279,8 @@ static void draw_secondary_row(const hud_t *h, const vehicle_t *pv, int pidx,
                                 float nav_step, float energy_start, float energy_step,
                                 Font font_label, Font font_value,
                                 Color label_color_dim, Color value_color,
-                                Color warn_color, int secondary_h, float scale) {
+                                Color warn_color, Color climb_color,
+                                int secondary_h, float scale) {
     float fsl = 14 * scale;
     float fsv = 18 * scale;
     float label_val_gap = 34 * scale;  // gap between label and value on same line
@@ -324,7 +334,7 @@ static void draw_secondary_row(const hud_t *h, const vehicle_t *pv, int pidx,
 
     float vs_x = energy_start + energy_step * 3;
     DrawTextEx(font_label, "VS", (Vector2){vs_x, label_off_y}, fsl, 0.5f, label_color_dim);
-    Color vs_color = (pv->vertical_speed > 0.1f) ? GREEN :
+    Color vs_color = (pv->vertical_speed > 0.1f) ? climb_color :
                      (pv->vertical_speed < -0.1f) ? warn_color : value_color;
     const char *arrow = (pv->vertical_speed > 0.1f) ? "^" :
                         (pv->vertical_speed < -0.1f) ? "v" : "";
@@ -338,12 +348,17 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
 
     bool rez = (view_mode == VIEW_REZ);
     bool synth = (view_mode == VIEW_1988);
+    bool snow = (view_mode == VIEW_SNOW);
 
     // Semantic color variables
     Color accent, accent_dim, bg, border, warn;
     Color label_color, value_color, dim_color;
+    Color climb_color, connected_color;
 
-    if (rez) {
+    if (snow) {
+        accent = SNOW_ACCENT;  accent_dim = SNOW_ACCENT_DIM;
+        bg = SNOW_BG;  border = SNOW_BORDER;  warn = SNOW_ORANGE;
+    } else if (rez) {
         accent = REZ_ACCENT;  accent_dim = REZ_ACCENT_DIM;
         bg = REZ_BG;  border = REZ_BORDER;  warn = REZ_ORANGE;
     } else if (synth) {
@@ -357,9 +372,19 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         warn = (Color){255, 106, 0, 255};
     }
 
-    label_color = accent_dim;
-    value_color = (Color){200, 208, 218, 255};
-    dim_color = (Color){200, 208, 218, 100};
+    if (snow) {
+        label_color = SNOW_ACCENT_DIM;
+        value_color = (Color){10, 10, 15, 255};
+        dim_color = (Color){80, 85, 95, 160};
+        climb_color = (Color){ 0, 120, 50, 255 };
+        connected_color = (Color){ 0, 130, 60, 255 };
+    } else {
+        label_color = accent_dim;
+        value_color = (Color){200, 208, 218, 255};
+        dim_color = (Color){200, 208, 218, 100};
+        climb_color = GREEN;
+        connected_color = (Color){100, 200, 100, 255};
+    }
 
     // Scale factor: 1.0 at 720p, ~1.33 at 1080p, ~1.6 at 1440p
     float s = powf(screen_h / 720.0f, 0.7f);
@@ -517,7 +542,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         char b[16];
         float x = energy_start + energy_step * 3;
         DrawTextEx(h->font_label, "VS", (Vector2){x, (float)label_y}, fs_label, 0.5f, label_color);
-        Color vs_color = (v->vertical_speed > 0.1f) ? GREEN :
+        Color vs_color = (v->vertical_speed > 0.1f) ? climb_color :
                          (v->vertical_speed < -0.1f) ? warn : value_color;
         const char *arrow = (v->vertical_speed > 0.1f) ? "^" :
                             (v->vertical_speed < -0.1f) ? "v" : "";
@@ -560,7 +585,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         int status_y = bar_y + primary_h / 2 - (int)(12 * s);
 
         // Connection dot
-        Color dot_color = connected ? (Color){100, 200, 100, 255} : (Color){200, 60, 60, 255};
+        Color dot_color = connected ? connected_color : (Color){200, 60, 60, 255};
         DrawCircle((int)(status_x + 4 * s), status_y + (int)(6 * s), 4 * s, dot_color);
 
         // Status text
@@ -571,7 +596,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
             snprintf(status_buf, sizeof(status_buf), "Waiting...");
         }
         DrawTextEx(h->font_label, status_buf, (Vector2){status_x + 14 * s, (float)status_y}, fs_dim, 0.5f,
-                   connected ? (Color){100, 200, 100, 255} : dim_color);
+                   connected ? connected_color : dim_color);
 
         // FPS
         char fps_buf[16];
@@ -596,7 +621,8 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         draw_secondary_row(h, &vehicles[pidx], pidx, row_y, screen_w,
                            nav_start, nav_step, energy_start, energy_step,
                            h->font_label, h->font_value,
-                           dim_color, value_color, warn, secondary_h, s);
+                           dim_color, value_color, warn, climb_color,
+                           secondary_h, s);
     }
 
     // Help overlay
@@ -612,7 +638,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         typedef struct { const char *key; const char *action; } shortcut_entry_t;
         shortcut_entry_t entries[] = {
             {"C",           "Toggle camera mode (Chase / FPV)"},
-            {"V",           "Cycle view mode (Grid / Rez)"},
+            {"V",           "Cycle view mode (Grid / Rez / Snow)"},
             {"TAB",         "Cycle to next vehicle"},
             {"[ / ]",       "Previous / next vehicle"},
             {"1-9",         "Select vehicle directly"},

--- a/src/scene.c
+++ b/src/scene.c
@@ -27,6 +27,14 @@
 #define REZ_AXIS_X     (Color){ 0,  204, 218, 220 }  // teal, full
 #define REZ_AXIS_Z     (Color){ 0,  204, 218, 220 }  // teal, full
 
+// Snow mode colors (outdoor high-contrast)
+#define SNOW_SKY       (Color){ 240, 242, 245, 255 }
+#define SNOW_GROUND    (Color){ 228, 230, 233, 255 }
+#define SNOW_MINOR     (Color){ 155, 160, 168, 140 }
+#define SNOW_MAJOR     (Color){ 70,  75,  85, 200 }
+#define SNOW_AXIS_X    (Color){ 210,  30,  30, 230 }
+#define SNOW_AXIS_Z    (Color){ 30,   30, 210, 230 }
+
 // 1988 mode colors (synthwave)
 #define SYNTH_SKY      (Color){ 8,   8,  20, 255 }
 #define SYNTH_GROUND   (Color){ 5,   5,  16, 255 }
@@ -139,7 +147,7 @@ void scene_handle_input(scene_t *s) {
             s->view_mode = VIEW_GRID;
         else
             s->view_mode = (s->view_mode + 1) % VIEW_COUNT;
-        const char *names[] = {"Grid", "Rez"};
+        const char *names[] = {"Grid", "Rez", "Snow"};
         printf("View: %s\n", names[s->view_mode]);
     }
 
@@ -224,6 +232,8 @@ void scene_draw(const scene_t *s) {
         draw_shader_grid(s, GRID_GROUND, GRID_MINOR, GRID_MAJOR, GRID_AXIS_X, GRID_AXIS_Z);
     } else if (s->view_mode == VIEW_REZ) {
         draw_shader_grid(s, REZ_GROUND, REZ_MINOR, REZ_MAJOR, REZ_AXIS_X, REZ_AXIS_Z);
+    } else if (s->view_mode == VIEW_SNOW) {
+        draw_shader_grid(s, SNOW_GROUND, SNOW_MINOR, SNOW_MAJOR, SNOW_AXIS_X, SNOW_AXIS_Z);
     } else if (s->view_mode == VIEW_1988) {
         draw_shader_grid(s, SYNTH_GROUND, SYNTH_MINOR, SYNTH_MAJOR, SYNTH_AXIS_X, SYNTH_AXIS_Z);
     }
@@ -233,6 +243,7 @@ void scene_draw_sky(const scene_t *s) {
     switch (s->view_mode) {
         case VIEW_GRID: ClearBackground(GRID_SKY); break;
         case VIEW_REZ:  ClearBackground(REZ_SKY);   break;
+        case VIEW_SNOW: ClearBackground(SNOW_SKY); break;
         case VIEW_1988: ClearBackground(SYNTH_SKY); break;
         default:        ClearBackground(GRID_SKY); break;
     }

--- a/src/scene.h
+++ b/src/scene.h
@@ -13,6 +13,7 @@ typedef enum {
 typedef enum {
     VIEW_GRID = 0,
     VIEW_REZ,
+    VIEW_SNOW,
     VIEW_COUNT,     // public modes end here
     VIEW_1988,      // hidden mode (not in V cycle)
 } view_mode_t;

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -170,13 +170,15 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
 }
 
 void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
-    // In Rez/1988 mode, swap red arm color
+    // In Rez/1988/Snow mode, swap red arm color
     Color saved_red = {0};
-    if ((view_mode == VIEW_REZ || view_mode == VIEW_1988) && v->red_material_idx >= 0) {
+    if ((view_mode == VIEW_REZ || view_mode == VIEW_1988 || view_mode == VIEW_SNOW) && v->red_material_idx >= 0) {
         Color *c = &v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color;
         saved_red = *c;
         if (view_mode == VIEW_1988)
             *c = (Color){ 255, 20, 100, 255 }; // hot pink
+        else if (view_mode == VIEW_SNOW)
+            *c = (Color){ 200, 30, 30, 255 }; // bold red on white
         else
             *c = (Color){ 255, 106, 0, 255 }; // #ff6a00 orange
     }
@@ -203,7 +205,9 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
             ? 0
             : v->trail_head;
         Color trail_color;
-        if (view_mode == VIEW_1988)
+        if (view_mode == VIEW_SNOW)
+            trail_color = (Color){  20,  80, 200, 200 };  // bold blue
+        else if (view_mode == VIEW_1988)
             trail_color = (Color){ 21, 190, 254, 160 };   // teal
         else if (view_mode == VIEW_REZ)
             trail_color = (Color){ 255, 106, 0, 160 };    // orange
@@ -211,7 +215,13 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
             trail_color = (Color){ 255, 200, 50, 180 };   // yellow
         // Per-mode color palette
         Color col_back, col_up, col_down, col_roll_pos, col_roll_neg;
-        if (view_mode == VIEW_1988) {
+        if (view_mode == VIEW_SNOW) {
+            col_back     = (Color){ 140,  20, 200, 255 }; // purple
+            col_up       = (Color){   0, 150,  60, 255 }; // dark green
+            col_down     = (Color){ 200,  50,   0, 255 }; // dark red
+            col_roll_pos = (Color){  20, 160,  40, 255 }; // green
+            col_roll_neg = (Color){ 200,  20,  60, 255 }; // red
+        } else if (view_mode == VIEW_1988) {
             col_back     = (Color){ 255, 20, 100, 255 };  // pink
             col_up       = (Color){   0, 255, 140, 255 }; // mint green
             col_down     = (Color){ 255, 106,   0, 255 }; // orange
@@ -293,7 +303,7 @@ void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected) {
     }
 
     // Restore original color
-    if ((view_mode == VIEW_REZ || view_mode == VIEW_1988) && v->red_material_idx >= 0) {
+    if ((view_mode == VIEW_REZ || view_mode == VIEW_1988 || view_mode == VIEW_SNOW) && v->red_material_idx >= 0) {
         v->model.materials[v->red_material_idx].maps[MATERIAL_MAP_DIFFUSE].color = saved_red;
     }
 }


### PR DESCRIPTION
## Summary

Adds a **Snow** view mode designed for outdoor use on low-nit screens in direct sunlight. All UI elements use high-contrast colors with black outlines for maximum readability in bright ambient light.

<img width="2880" height="1700" alt="Snow Mode Demo" src="https://github.com/user-attachments/assets/acc9b80d-2465-415b-83c5-2193bba03e06" />

- Bright white sky and ground plane with dark grey grid lines and bold red/blue axes
- HUD: white background panels with dark text and black outlines
- Attitude indicator: grey-blue sky, dark navy ground, white horizon line
- Compass: black ticks and text, dark red north marker
- Trail colors: bold saturated blue with dark purple/green/red directional tints
- Vehicle arms: bold red for contrast on white
- VS/connection status: dark green instead of bright green

Cycles with `V` key: Grid → Rez → Snow → Grid.

## Changes

- `src/scene.h` — Added `VIEW_SNOW` to view mode enum
- `src/scene.c` — Snow sky/ground/grid color palette, sky clear, grid draw, V cycle name
- `src/hud.c` — Snow HUD colors (dark-on-bright), compass, attitude indicator, VS/connection status, help overlay text
- `src/vehicle.c` — Snow trail colors, vehicle arm color swap
- `README.md` — Updated controls table and view mode descriptions

## Test plan

- [ ] Build on macOS, Linux, Windows (standard C11 + Raylib, no platform-specific APIs)
- [ ] Press `V` to cycle through Grid → Rez → Snow → Grid
- [ ] Verify Snow mode: white sky/ground, dark grid, black-outlined HUD

- [ ] Verify HUD text is readable: dark labels, black values, dark green VS climb indicator
- [ ] Verify compass and attitude indicator themed correctly
- [ ] Verify trail colors are bold/saturated and visible on white background
- [ ] Verify no regression on Grid and Rez modes