### PR TITLE
fix: use HOME_POSITION for correct altitude on mid-flight connect

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,7 @@ int main(int argc, char *argv[]) {
             // Reset trail and origin on reconnect
             if (receivers[i].connected && !was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);
+                vehicle_set_type(&vehicles[i], receivers[i].mav_type);
                 if (!origin_specified && vehicle_count == 1) {
                     vehicles[i].origin_set = false;
                     vehicles[i].origin_wait_count = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -161,11 +161,12 @@ int main(int argc, char *argv[]) {
                 vehicle_reset_trail(&vehicles[i]);
                 if (!origin_specified && vehicle_count == 1) {
                     vehicles[i].origin_set = false;
+                    vehicles[i].origin_wait_count = 0;
                 }
             }
             was_connected[i] = receivers[i].connected;
 
-            vehicle_update(&vehicles[i], &receivers[i].state);
+            vehicle_update(&vehicles[i], &receivers[i].state, &receivers[i].home);
             vehicles[i].sysid = receivers[i].sysid;
 
             // Detect position jump (new SITL connecting before disconnect timeout)

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -40,7 +40,7 @@ static void request_home_position(mavlink_receiver_t *recv) {
 
     uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
     sendto(recv->sockfd, (char *)buf, len, 0,
-           (struct sockaddr *)&recv->sender_addr, sizeof(recv->sender_addr));
+           (struct sockaddr *)recv->sender_addr, sizeof(struct sockaddr_in));
     printf("Requested HOME_POSITION from system %u\n", recv->sysid);
 }
 
@@ -122,7 +122,7 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
         got_data = true;
 
         if (!recv->sender_known) {
-            recv->sender_addr = sender;
+            memcpy(recv->sender_addr, &sender, sizeof(struct sockaddr_in));
             recv->sender_known = true;
         }
 

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -137,14 +137,18 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
                 }
 
                 switch (msg.msgid) {
-                    case MAVLINK_MSG_ID_HEARTBEAT:
+                    case MAVLINK_MSG_ID_HEARTBEAT: {
+                        mavlink_heartbeat_t hb;
+                        mavlink_msg_heartbeat_decode(&msg, &hb);
+                        recv->mav_type = hb.type;
                         if (!recv->connected) {
                             recv->connected = true;
                             recv->sysid = msg.sysid;
-                            printf("Connected to system %u\n", msg.sysid);
+                            printf("Connected to system %u (type %u)\n", msg.sysid, hb.type);
                             request_home_position(recv);
                         }
                         break;
+                    }
 
                     case MAVLINK_MSG_ID_HOME_POSITION: {
                         mavlink_home_position_t hp;

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -25,6 +25,25 @@
 
 #define DISCONNECT_TIMEOUT_S 2.0
 
+static void request_home_position(mavlink_receiver_t *recv) {
+    if (!recv->sender_known) return;
+
+    mavlink_message_t msg;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+
+    mavlink_msg_command_long_pack(255, 0, &msg,
+        recv->sysid, 1,               // target system, component
+        MAV_CMD_REQUEST_MESSAGE,       // command 512
+        0,                             // confirmation
+        MAVLINK_MSG_ID_HOME_POSITION,  // param1: message id to request
+        0, 0, 0, 0, 0, 0);            // params 2-7 unused
+
+    uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
+    sendto(recv->sockfd, (char *)buf, len, 0,
+           (struct sockaddr *)&recv->sender_addr, sizeof(recv->sender_addr));
+    printf("Requested HOME_POSITION from system %u\n", recv->sysid);
+}
+
 static double get_wall_time(void) {
 #ifdef _WIN32
     LARGE_INTEGER freq, count;
@@ -101,6 +120,12 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
         if (n <= 0) break;
 
         got_data = true;
+
+        if (!recv->sender_known) {
+            recv->sender_addr = sender;
+            recv->sender_known = true;
+        }
+
         mavlink_message_t msg;
         mavlink_status_t status;
 
@@ -117,8 +142,21 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
                             recv->connected = true;
                             recv->sysid = msg.sysid;
                             printf("Connected to system %u\n", msg.sysid);
+                            request_home_position(recv);
                         }
                         break;
+
+                    case MAVLINK_MSG_ID_HOME_POSITION: {
+                        mavlink_home_position_t hp;
+                        mavlink_msg_home_position_decode(&msg, &hp);
+                        recv->home.lat = hp.latitude;
+                        recv->home.lon = hp.longitude;
+                        recv->home.alt = hp.altitude;
+                        recv->home.valid = true;
+                        printf("Home position: lat=%.7f lon=%.7f alt=%.1fm\n",
+                               hp.latitude * 1e-7, hp.longitude * 1e-7, hp.altitude * 1e-3);
+                        break;
+                    }
 
                     case MAVLINK_MSG_ID_HIL_STATE_QUATERNION: {
                         mavlink_hil_state_quaternion_t hil;
@@ -159,6 +197,8 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
         if (now - recv->last_msg_time > DISCONNECT_TIMEOUT_S) {
             recv->connected = false;
             recv->state.valid = false;
+            recv->home.valid = false;
+            recv->sender_known = false;
             printf("Disconnected from system %u\n", recv->sysid);
         }
     }

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -5,12 +5,6 @@
 #include <stdint.h>
 
 #ifdef _WIN32
-#include <ws2tcpip.h>
-#else
-#include <netinet/in.h>
-#endif
-
-#ifdef _WIN32
 typedef uintptr_t sock_t;
 #define SOCK_INVALID (~(sock_t)0)
 #else
@@ -48,7 +42,7 @@ typedef struct {
     hil_state_t state;
     home_position_t home;
     bool sender_known;           // true once we've seen a packet
-    struct sockaddr_in sender_addr; // address to send commands to
+    uint8_t sender_addr[16];     // sockaddr_in stored as opaque bytes
 } mavlink_receiver_t;
 
 // Initialize UDP socket on given port with MAVLink parse channel. Returns 0 on success.

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -38,6 +38,7 @@ typedef struct {
     bool connected;
     bool debug;
     uint8_t sysid;
+    uint8_t mav_type;            // MAV_TYPE from heartbeat
     double last_msg_time;        // wall-clock time of last received message
     hil_state_t state;
     home_position_t home;

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -5,6 +5,12 @@
 #include <stdint.h>
 
 #ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#endif
+
+#ifdef _WIN32
 typedef uintptr_t sock_t;
 #define SOCK_INVALID (~(sock_t)0)
 #else
@@ -25,6 +31,13 @@ typedef struct {
 } hil_state_t;
 
 typedef struct {
+    int32_t lat;         // degE7
+    int32_t lon;         // degE7
+    int32_t alt;         // mm (AMSL)
+    bool valid;
+} home_position_t;
+
+typedef struct {
     sock_t sockfd;
     uint16_t port;
     uint8_t channel;
@@ -33,6 +46,9 @@ typedef struct {
     uint8_t sysid;
     double last_msg_time;        // wall-clock time of last received message
     hil_state_t state;
+    home_position_t home;
+    bool sender_known;           // true once we've seen a packet
+    struct sockaddr_in sender_addr; // address to send commands to
 } mavlink_receiver_t;
 
 // Initialize UDP socket on given port with MAVLink parse channel. Returns 0 on success.

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -17,14 +17,14 @@
 // ── Model registry ──────────────────────────────────────────────────────────
 // To add a new model: append an entry here and increment nothing else.
 const vehicle_model_info_t vehicle_models[] = {
-    //  path                                name            scale  pitch    yaw
-    { "models/px4_quadrotor.obj",         "Quadrotor",    1.0f,    0.0f,   0.0f },
-    { "models/cessna.obj",                "Fixed-wing",   1.33f,   0.0f,  90.0f },
-    { "models/x_vert.obj",                "Tailsitter",   1.0f,  -90.0f,  90.0f },
-    { "models/fpv_quadrotor.obj",         "FPV Quad",     0.75f,   0.0f,   0.0f },
-    { "models/px4_hexarotor.obj",         "Hexarotor",    1.05f,   0.0f,   0.0f },
-    { "models/vtol_wing.obj",             "VTOL",         1.5f,    0.0f, 180.0f },
-    { "models/rover_4.obj",              "Rover",        1.0f,    0.0f,   0.0f },
+    //  path                                name            scale  pitch    yaw       group
+    { "models/px4_quadrotor.obj",         "Quadrotor",    1.0f,    0.0f,   0.0f,   GROUP_QUAD },
+    { "models/cessna.obj",                "Fixed-wing",   1.33f,   0.0f,  90.0f,   GROUP_FIXED_WING },
+    { "models/x_vert.obj",                "Tailsitter",   1.0f,  -90.0f,  90.0f,   GROUP_TAILSITTER },
+    { "models/fpv_quadrotor.obj",         "FPV Quad",     0.75f,   0.0f,   0.0f,   GROUP_QUAD },
+    { "models/px4_hexarotor.obj",         "Hexarotor",    1.05f,   0.0f,   0.0f,   GROUP_HEX },
+    { "models/vtol_wing.obj",             "VTOL",         1.5f,    0.0f, 180.0f,   GROUP_VTOL },
+    { "models/rover_4.obj",              "Rover",        1.0f,    0.0f,   0.0f,   GROUP_ROVER },
 };
 const int vehicle_model_count = sizeof(vehicle_models) / sizeof(vehicle_models[0]);
 
@@ -83,8 +83,61 @@ void vehicle_load_model(vehicle_t *v, int model_idx) {
 }
 
 void vehicle_cycle_model(vehicle_t *v) {
-    int next = (v->model_idx + 1) % vehicle_model_count;
-    vehicle_load_model(v, next);
+    model_group_t group = v->model_group;
+    int start = v->model_idx;
+    int next = start;
+    do {
+        next = (next + 1) % vehicle_model_count;
+    } while (vehicle_models[next].group != group && next != start);
+    if (next != start) {
+        vehicle_load_model(v, next);
+    }
+}
+
+void vehicle_set_type(vehicle_t *v, uint8_t mav_type) {
+    model_group_t group;
+    int default_model;
+
+    switch (mav_type) {
+        case 2:  // MAV_TYPE_QUADROTOR
+            group = GROUP_QUAD;
+            default_model = MODEL_QUADROTOR;
+            break;
+        case 13: // MAV_TYPE_HEXAROTOR
+        case 14: // MAV_TYPE_OCTOROTOR
+            group = GROUP_HEX;
+            default_model = MODEL_HEXAROTOR;
+            break;
+        case 1:  // MAV_TYPE_FIXED_WING
+            group = GROUP_FIXED_WING;
+            default_model = MODEL_FIXEDWING;
+            break;
+        case 19: // MAV_TYPE_VTOL_TAILSITTER_DUOROTOR
+        case 20: // MAV_TYPE_VTOL_TAILSITTER_QUADROTOR
+        case 23: // MAV_TYPE_VTOL_TAILSITTER
+            group = GROUP_TAILSITTER;
+            default_model = MODEL_TAILSITTER;
+            break;
+        case 21: // MAV_TYPE_VTOL_TILTROTOR
+        case 22: // MAV_TYPE_VTOL_FIXEDROTOR
+            group = GROUP_VTOL;
+            default_model = MODEL_VTOL;
+            break;
+        case 10: // MAV_TYPE_GROUND_ROVER
+        case 11: // MAV_TYPE_SURFACE_BOAT
+            group = GROUP_ROVER;
+            default_model = MODEL_ROVER;
+            break;
+        default:
+            group = GROUP_QUAD;
+            default_model = MODEL_QUADROTOR;
+            break;
+    }
+
+    v->model_group = group;
+    if (v->model_idx != default_model) {
+        vehicle_load_model(v, default_model);
+    }
 }
 
 // ── Thermal palette (per-theme) ─────────────────────────────────────────────

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -193,7 +193,7 @@ void vehicle_init(vehicle_t *v, int model_idx, Shader lighting_shader) {
     vehicle_load_model(v, model_idx);
 }
 
-void vehicle_update(vehicle_t *v, const hil_state_t *state) {
+void vehicle_update(vehicle_t *v, const hil_state_t *state, const home_position_t *home) {
     if (!state->valid) return;
 
     double lat = state->lat * 1e-7 * (M_PI / 180.0);
@@ -201,10 +201,29 @@ void vehicle_update(vehicle_t *v, const hil_state_t *state) {
     double alt = state->alt * 1e-3;
 
     if (!v->origin_set) {
-        v->lat0 = lat;
-        v->lon0 = lon;
-        v->alt0 = alt;
-        v->origin_set = true;
+        // Wait for HOME_POSITION so we get the correct ground altitude.
+        // Fall back to current altitude after ~1 second (20 HIL updates at 22Hz).
+        v->origin_wait_count++;
+        if (home && home->valid) {
+            double home_alt = home->alt * 1e-3;
+            v->lat0 = lat;
+            v->lon0 = lon;
+            // If vehicle is near home altitude, it's on the ground — use HIL alt
+            // to avoid the ~0.1m offset. If airborne, use home alt as ground ref.
+            if (fabs(alt - home_alt) < 1.0) {
+                v->alt0 = alt;
+            } else {
+                v->alt0 = home_alt;
+            }
+            v->origin_set = true;
+        } else if (v->origin_wait_count > 20) {
+            v->lat0 = lat;
+            v->lon0 = lon;
+            v->alt0 = alt;
+            v->origin_set = true;
+        } else {
+            return;  // skip this update, wait for home
+        }
     }
 
     v->active = true;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -5,6 +5,17 @@
 #include "mavlink_receiver.h"
 #include "scene.h"
 
+// Model group — determines which models M-key cycles through
+typedef enum {
+    GROUP_QUAD,
+    GROUP_HEX,
+    GROUP_FIXED_WING,
+    GROUP_VTOL,
+    GROUP_TAILSITTER,
+    GROUP_ROVER,
+    GROUP_COUNT,
+} model_group_t;
+
 // Model descriptor — add new entries to vehicle_models[] in vehicle.c
 typedef struct {
     const char *path;           // OBJ file path
@@ -12,6 +23,7 @@ typedef struct {
     float scale;
     float pitch_offset_deg;    // pitch correction (applied before yaw, after X-90 base)
     float yaw_offset_deg;      // yaw correction after Z-up → Y-up rotation
+    model_group_t group;       // which group this model belongs to
 } vehicle_model_info_t;
 
 extern const vehicle_model_info_t vehicle_models[];
@@ -31,6 +43,7 @@ typedef struct {
     Vector3 position;        // Raylib coords (Y-up, right-handed)
     Quaternion rotation;     // Raylib quaternion
     int model_idx;           // index into vehicle_models[]
+    model_group_t model_group; // active group for M-key cycling
     bool origin_set;
     int origin_wait_count;   // HIL updates received while waiting for HOME_POSITION
     bool active;             // has received data
@@ -70,8 +83,11 @@ void vehicle_init(vehicle_t *v, int model_idx, Shader lighting_shader);
 // Swap to a different model at runtime (unloads old, loads new).
 void vehicle_load_model(vehicle_t *v, int model_idx);
 
-// Cycle to the next model in the registry.
+// Cycle to the next model within the active group.
 void vehicle_cycle_model(vehicle_t *v);
+
+// Select model group and default model based on MAV_TYPE from heartbeat.
+void vehicle_set_type(vehicle_t *v, uint8_t mav_type);
 
 // Update position/rotation from HIL_STATE_QUATERNION data.
 // home may be NULL; if valid, its altitude is used as ground reference.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -32,6 +32,7 @@ typedef struct {
     Quaternion rotation;     // Raylib quaternion
     int model_idx;           // index into vehicle_models[]
     bool origin_set;
+    int origin_wait_count;   // HIL updates received while waiting for HOME_POSITION
     bool active;             // has received data
     double lat0;             // radians
     double lon0;             // radians
@@ -73,7 +74,8 @@ void vehicle_load_model(vehicle_t *v, int model_idx);
 void vehicle_cycle_model(vehicle_t *v);
 
 // Update position/rotation from HIL_STATE_QUATERNION data.
-void vehicle_update(vehicle_t *v, const hil_state_t *state);
+// home may be NULL; if valid, its altitude is used as ground reference.
+void vehicle_update(vehicle_t *v, const hil_state_t *state, const home_position_t *home);
 
 // trail_mode: 0=off, 1=normal trail, 2=speed ribbon
 void vehicle_draw(vehicle_t *v, view_mode_t view_mode, bool selected,


### PR DESCRIPTION
On connect, request HOME_POSITION from PX4 via MAV_CMD_REQUEST_MESSAGE and use its altitude as the NED origin ground reference. This fixes the vehicle appearing at floor level when the viewer connects to a SITL session where the vehicle is already airborne.

When on the ground (HIL alt within 1m of home), uses HIL altitude directly to avoid a small offset. Falls back to HIL altitude if HOME_POSITION isn't received within ~1s (non-PX4 systems).
