### PR TITLE
feat: auto-select vehicle model from MAV_TYPE

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,7 @@ int main(int argc, char *argv[]) {
             // Reset trail and origin on reconnect
             if (receivers[i].connected && !was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);
+                vehicle_set_type(&vehicles[i], receivers[i].mav_type);
                 if (!origin_specified && vehicle_count == 1) {
                     vehicles[i].origin_set = false;
                     vehicles[i].origin_wait_count = 0;

--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -137,14 +137,18 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
                 }
 
                 switch (msg.msgid) {
-                    case MAVLINK_MSG_ID_HEARTBEAT:
+                    case MAVLINK_MSG_ID_HEARTBEAT: {
+                        mavlink_heartbeat_t hb;
+                        mavlink_msg_heartbeat_decode(&msg, &hb);
+                        recv->mav_type = hb.type;
                         if (!recv->connected) {
                             recv->connected = true;
                             recv->sysid = msg.sysid;
-                            printf("Connected to system %u\n", msg.sysid);
+                            printf("Connected to system %u (type %u)\n", msg.sysid, hb.type);
                             request_home_position(recv);
                         }
                         break;
+                    }
 
                     case MAVLINK_MSG_ID_HOME_POSITION: {
                         mavlink_home_position_t hp;

--- a/src/mavlink_receiver.h
+++ b/src/mavlink_receiver.h
@@ -38,6 +38,7 @@ typedef struct {
     bool connected;
     bool debug;
     uint8_t sysid;
+    uint8_t mav_type;            // MAV_TYPE from heartbeat
     double last_msg_time;        // wall-clock time of last received message
     hil_state_t state;
     home_position_t home;

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -17,14 +17,14 @@
 // ── Model registry ──────────────────────────────────────────────────────────
 // To add a new model: append an entry here and increment nothing else.
 const vehicle_model_info_t vehicle_models[] = {
-    //  path                                name            scale  pitch    yaw
-    { "models/px4_quadrotor.obj",         "Quadrotor",    1.0f,    0.0f,   0.0f },
-    { "models/cessna.obj",                "Fixed-wing",   1.33f,   0.0f,  90.0f },
-    { "models/x_vert.obj",                "Tailsitter",   1.0f,  -90.0f,  90.0f },
-    { "models/fpv_quadrotor.obj",         "FPV Quad",     0.75f,   0.0f,   0.0f },
-    { "models/px4_hexarotor.obj",         "Hexarotor",    1.05f,   0.0f,   0.0f },
-    { "models/vtol_wing.obj",             "VTOL",         1.5f,    0.0f, 180.0f },
-    { "models/rover_4.obj",              "Rover",        1.0f,    0.0f,   0.0f },
+    //  path                                name            scale  pitch    yaw       group
+    { "models/px4_quadrotor.obj",         "Quadrotor",    1.0f,    0.0f,   0.0f,   GROUP_QUAD },
+    { "models/cessna.obj",                "Fixed-wing",   1.33f,   0.0f,  90.0f,   GROUP_FIXED_WING },
+    { "models/x_vert.obj",                "Tailsitter",   1.0f,  -90.0f,  90.0f,   GROUP_TAILSITTER },
+    { "models/fpv_quadrotor.obj",         "FPV Quad",     0.75f,   0.0f,   0.0f,   GROUP_QUAD },
+    { "models/px4_hexarotor.obj",         "Hexarotor",    1.05f,   0.0f,   0.0f,   GROUP_HEX },
+    { "models/vtol_wing.obj",             "VTOL",         1.5f,    0.0f, 180.0f,   GROUP_VTOL },
+    { "models/rover_4.obj",              "Rover",        1.0f,    0.0f,   0.0f,   GROUP_ROVER },
 };
 const int vehicle_model_count = sizeof(vehicle_models) / sizeof(vehicle_models[0]);
 
@@ -83,8 +83,61 @@ void vehicle_load_model(vehicle_t *v, int model_idx) {
 }
 
 void vehicle_cycle_model(vehicle_t *v) {
-    int next = (v->model_idx + 1) % vehicle_model_count;
-    vehicle_load_model(v, next);
+    model_group_t group = v->model_group;
+    int start = v->model_idx;
+    int next = start;
+    do {
+        next = (next + 1) % vehicle_model_count;
+    } while (vehicle_models[next].group != group && next != start);
+    if (next != start) {
+        vehicle_load_model(v, next);
+    }
+}
+
+void vehicle_set_type(vehicle_t *v, uint8_t mav_type) {
+    model_group_t group;
+    int default_model;
+
+    switch (mav_type) {
+        case 2:  // MAV_TYPE_QUADROTOR
+            group = GROUP_QUAD;
+            default_model = MODEL_QUADROTOR;
+            break;
+        case 13: // MAV_TYPE_HEXAROTOR
+        case 14: // MAV_TYPE_OCTOROTOR
+            group = GROUP_HEX;
+            default_model = MODEL_HEXAROTOR;
+            break;
+        case 1:  // MAV_TYPE_FIXED_WING
+            group = GROUP_FIXED_WING;
+            default_model = MODEL_FIXEDWING;
+            break;
+        case 19: // MAV_TYPE_VTOL_TAILSITTER_DUOROTOR
+        case 20: // MAV_TYPE_VTOL_TAILSITTER_QUADROTOR
+        case 23: // MAV_TYPE_VTOL_TAILSITTER
+            group = GROUP_TAILSITTER;
+            default_model = MODEL_TAILSITTER;
+            break;
+        case 21: // MAV_TYPE_VTOL_TILTROTOR
+        case 22: // MAV_TYPE_VTOL_FIXEDROTOR
+            group = GROUP_VTOL;
+            default_model = MODEL_VTOL;
+            break;
+        case 10: // MAV_TYPE_GROUND_ROVER
+        case 11: // MAV_TYPE_SURFACE_BOAT
+            group = GROUP_ROVER;
+            default_model = MODEL_ROVER;
+            break;
+        default:
+            group = GROUP_QUAD;
+            default_model = MODEL_QUADROTOR;
+            break;
+    }
+
+    v->model_group = group;
+    if (v->model_idx != default_model) {
+        vehicle_load_model(v, default_model);
+    }
 }
 
 // ── Thermal palette (per-theme) ─────────────────────────────────────────────

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -5,6 +5,17 @@
 #include "mavlink_receiver.h"
 #include "scene.h"
 
+// Model group — determines which models M-key cycles through
+typedef enum {
+    GROUP_QUAD,
+    GROUP_HEX,
+    GROUP_FIXED_WING,
+    GROUP_VTOL,
+    GROUP_TAILSITTER,
+    GROUP_ROVER,
+    GROUP_COUNT,
+} model_group_t;
+
 // Model descriptor — add new entries to vehicle_models[] in vehicle.c
 typedef struct {
     const char *path;           // OBJ file path
@@ -12,6 +23,7 @@ typedef struct {
     float scale;
     float pitch_offset_deg;    // pitch correction (applied before yaw, after X-90 base)
     float yaw_offset_deg;      // yaw correction after Z-up → Y-up rotation
+    model_group_t group;       // which group this model belongs to
 } vehicle_model_info_t;
 
 extern const vehicle_model_info_t vehicle_models[];
@@ -31,6 +43,7 @@ typedef struct {
     Vector3 position;        // Raylib coords (Y-up, right-handed)
     Quaternion rotation;     // Raylib quaternion
     int model_idx;           // index into vehicle_models[]
+    model_group_t model_group; // active group for M-key cycling
     bool origin_set;
     int origin_wait_count;   // HIL updates received while waiting for HOME_POSITION
     bool active;             // has received data
@@ -70,8 +83,11 @@ void vehicle_init(vehicle_t *v, int model_idx, Shader lighting_shader);
 // Swap to a different model at runtime (unloads old, loads new).
 void vehicle_load_model(vehicle_t *v, int model_idx);
 
-// Cycle to the next model in the registry.
+// Cycle to the next model within the active group.
 void vehicle_cycle_model(vehicle_t *v);
+
+// Select model group and default model based on MAV_TYPE from heartbeat.
+void vehicle_set_type(vehicle_t *v, uint8_t mav_type);
 
 // Update position/rotation from HIL_STATE_QUATERNION data.
 // home may be NULL; if valid, its altitude is used as ground reference.


### PR DESCRIPTION
Read MAV_TYPE from heartbeat and auto-load the matching model on connect. M key cycles within the type group instead of all models (e.g. quadrotor cycles between Quadrotor and FPV Quad).

Groups: quad, hex, fixed_wing, vtol, tailsitter, rover. Future models added to the registry just need a group tag.

Depends on #33.