### PR TITLE
feat: ULog replay with data source abstraction

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/fixtures/*.ulg filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,41 @@ jobs:
 
       - name: Build
         run: cmake --build build --config Release
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          lfs: true
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_TESTING_ONLY=ON
+
+      - name: Build tests
+        run: cmake --build build
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+  sanitizers:
+    name: ASan + UBSan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          lfs: true
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DBUILD_TESTING_ONLY=ON -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"
+
+      - name: Build tests
+        run: cmake --build build
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,60 +3,86 @@ project(mavsim-viewer C)
 
 set(CMAKE_C_STANDARD 11)
 
-# Raylib via FetchContent
-include(FetchContent)
-FetchContent_Declare(
-    raylib
-    GIT_REPOSITORY https://github.com/raysan5/raylib.git
-    GIT_TAG        5.5
-    GIT_SHALLOW    TRUE
-)
-set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(raylib)
+option(BUILD_TESTING "Build tests" OFF)
 
 # MAVLink c_library_v2 (header-only, submodule)
 set(MAVLINK_DIR ${CMAKE_SOURCE_DIR}/lib/c_library_v2)
 
-add_executable(mavsim-viewer
-    src/main.c
-    src/mavlink_receiver.c
-    src/vehicle.c
-    src/scene.c
-    src/hud.c
-    src/debug_panel.c
-    src/ortho_panel.c
+# Core library: ULog parser + replay (no raylib dependency)
+add_library(mavsim-core STATIC
+    src/ulog_parser.c
+    src/ulog_replay.c
+    src/data_source_ulog.c
 )
-
-target_include_directories(mavsim-viewer PRIVATE
+target_include_directories(mavsim-core PUBLIC src/)
+target_include_directories(mavsim-core PRIVATE
     ${MAVLINK_DIR}
     ${MAVLINK_DIR}/common
 )
-
-# Need 16 MAVLink parse channels for multi-vehicle support
-target_compile_definitions(mavsim-viewer PRIVATE MAVLINK_COMM_NUM_BUFFERS=16)
-
-target_link_libraries(mavsim-viewer PRIVATE raylib)
-
-if(APPLE)
-    target_link_libraries(mavsim-viewer PRIVATE
-        "-framework IOKit"
-        "-framework Cocoa"
-        "-framework OpenGL"
-    )
-elseif(WIN32)
-    target_link_libraries(mavsim-viewer PRIVATE ws2_32)
-elseif(UNIX)
-    target_link_libraries(mavsim-viewer PRIVATE m pthread dl)
+target_compile_definitions(mavsim-core PRIVATE MAVLINK_COMM_NUM_BUFFERS=16)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(mavsim-core PRIVATE m)
 endif()
 
-# Copy resources to build directory
-add_custom_command(TARGET mavsim-viewer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/models $<TARGET_FILE_DIR:mavsim-viewer>/models
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/shaders $<TARGET_FILE_DIR:mavsim-viewer>/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/fonts $<TARGET_FILE_DIR:mavsim-viewer>/fonts
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/textures $<TARGET_FILE_DIR:mavsim-viewer>/textures
-)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# Raylib via FetchContent (skip when only building tests)
+if(NOT BUILD_TESTING_ONLY)
+    include(FetchContent)
+    FetchContent_Declare(
+        raylib
+        GIT_REPOSITORY https://github.com/raysan5/raylib.git
+        GIT_TAG        5.5
+        GIT_SHALLOW    TRUE
+    )
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(raylib)
+
+    add_executable(mavsim-viewer
+        src/main.c
+        src/mavlink_receiver.c
+        src/data_source_mavlink.c
+        src/vehicle.c
+        src/scene.c
+        src/hud.c
+        src/debug_panel.c
+        src/ortho_panel.c
+    )
+
+    target_include_directories(mavsim-viewer PRIVATE
+        ${MAVLINK_DIR}
+        ${MAVLINK_DIR}/common
+    )
+
+    # Need 16 MAVLink parse channels for multi-vehicle support
+    target_compile_definitions(mavsim-viewer PRIVATE MAVLINK_COMM_NUM_BUFFERS=16)
+
+    target_link_libraries(mavsim-viewer PRIVATE raylib mavsim-core)
+
+    if(APPLE)
+        target_link_libraries(mavsim-viewer PRIVATE
+            "-framework IOKit"
+            "-framework Cocoa"
+            "-framework OpenGL"
+        )
+    elseif(WIN32)
+        target_link_libraries(mavsim-viewer PRIVATE ws2_32)
+    elseif(UNIX)
+        target_link_libraries(mavsim-viewer PRIVATE m pthread dl)
+    endif()
+
+    # Copy resources to build directory
+    add_custom_command(TARGET mavsim-viewer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/models $<TARGET_FILE_DIR:mavsim-viewer>/models
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/shaders $<TARGET_FILE_DIR:mavsim-viewer>/shaders
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/fonts $<TARGET_FILE_DIR:mavsim-viewer>/fonts
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/textures $<TARGET_FILE_DIR:mavsim-viewer>/textures
+    )
+endif()

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Built with [Raylib](https://www.raylib.com/) and [MAVLink](https://mavlink.io/).
 - Mouse orbit (left-drag) and FOV zoom (scroll wheel)
 - HUD with compass, telemetry readouts, vehicle selector indicator
 - Panoramic sky with ground texture
+- **ULog replay** — play back PX4 `.ulg` flight logs with transport controls and interpolation
 - Cross-platform: macOS, Linux, and Windows supported out of the box thanks to Raylib
 
 ## Requirements
@@ -50,6 +51,7 @@ make -j$(nproc)
 | `-ts` | Tailsitter model |
 | `-w <width>` | Window width (default: 1280) |
 | `-h <height>` | Window height (default: 720) |
+| `--replay <file.ulg>` | Replay a PX4 ULog flight log |
 | `-d` | Debug output |
 
 Each vehicle listens on its own UDP port: `base_port`, `base_port+1`, ..., `base_port+n-1`.
@@ -107,6 +109,18 @@ The test script accepts these options:
 
 **Note:** If vehicles appear in formation before running the test script, it's because `SIH_LOC_LON0` params were persisted from a previous run. Clear them with `rm -rf instance_*/parameters*.bson` in the PX4 build directory.
 
+### ULog Replay
+
+Replay PX4 `.ulg` flight logs directly in the viewer:
+
+```bash
+./mavsim-viewer --replay path/to/flight.ulg
+```
+
+The viewer parses `vehicle_attitude`, `vehicle_local_position`, and `vehicle_global_position` topics from the log. Vehicle type is auto-detected from `vehicle_status`. Logs without GPS data (e.g. indoor optical flow flights) fall back to local position with reference point conversion.
+
+Position data in ULog files is typically logged at 5-10 Hz. Dead-reckoning interpolation (toggled with `I`) smooths playback to the render frame rate using velocity data.
+
 ## Controls
 
 | Key/Input | Action |
@@ -127,6 +141,13 @@ The test script accepts these options:
 | `Shift+1`-`9` | Toggle pin/unpin vehicle to HUD |
 | Left-drag | Orbit camera (chase mode) |
 | Scroll wheel | Zoom FOV (perspective) or span (ortho) |
+| **Replay** | |
+| `Space` | Pause / resume (or restart after end) |
+| `+` / `-` | Increase / decrease playback speed |
+| `←` / `→` | Seek 5s backward / forward (Shift: 30s) |
+| `L` | Toggle loop |
+| `I` | Toggle interpolation |
+| `R` | Restart from beginning |
 
 ### View Modes
 

--- a/src/data_source.h
+++ b/src/data_source.h
@@ -1,0 +1,59 @@
+#ifndef DATA_SOURCE_H
+#define DATA_SOURCE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "mavlink_receiver.h"  // hil_state_t, home_position_t
+
+// Playback state (only meaningful for replay sources)
+typedef struct {
+    bool paused;
+    float speed;           // playback speed multiplier (1.0 = realtime)
+    bool looping;
+    bool interpolation;    // dead-reckoning interpolation between position samples
+    float progress;        // 0.0 to 1.0
+    float duration_s;      // total log duration in seconds
+    float position_s;      // current position in seconds
+} playback_state_t;
+
+typedef struct data_source data_source_t;
+
+// Vtable for polymorphic data sources
+typedef struct {
+    void (*poll)(data_source_t *ds, float dt);
+    void (*close)(data_source_t *ds);
+} data_source_ops_t;
+
+struct data_source {
+    const data_source_ops_t *ops;
+
+    // Shared state — both backends populate these
+    hil_state_t state;
+    home_position_t home;
+    bool connected;
+    uint8_t sysid;
+    uint8_t mav_type;
+    bool debug;
+
+    // Replay controls (ignored by MAVLink backend)
+    playback_state_t playback;
+
+    // Backend-specific opaque data
+    void *impl;
+};
+
+static inline void data_source_poll(data_source_t *ds, float dt) {
+    ds->ops->poll(ds, dt);
+}
+
+static inline void data_source_close(data_source_t *ds) {
+    ds->ops->close(ds);
+}
+
+// Create a live MAVLink data source. Returns 0 on success.
+int data_source_mavlink_create(data_source_t *ds, uint16_t port, uint8_t channel, bool debug_flag);
+
+// Create a ULog replay data source. Returns 0 on success.
+int data_source_ulog_create(data_source_t *ds, const char *filepath);
+
+#endif

--- a/src/data_source_mavlink.c
+++ b/src/data_source_mavlink.c
@@ -1,0 +1,52 @@
+#include "data_source.h"
+#include "mavlink_receiver.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void mavlink_poll(data_source_t *ds, float dt) {
+    (void)dt;
+    mavlink_receiver_t *recv = (mavlink_receiver_t *)ds->impl;
+    mavlink_receiver_poll(recv);
+
+    // Copy state up to data_source fields
+    ds->state = recv->state;
+    ds->home = recv->home;
+    ds->connected = recv->connected;
+    ds->sysid = recv->sysid;
+    ds->mav_type = recv->mav_type;
+}
+
+static void mavlink_close(data_source_t *ds) {
+    mavlink_receiver_t *recv = (mavlink_receiver_t *)ds->impl;
+    if (recv) {
+        mavlink_receiver_close(recv);
+        free(recv);
+        ds->impl = NULL;
+    }
+}
+
+static const data_source_ops_t mavlink_ops = {
+    .poll = mavlink_poll,
+    .close = mavlink_close,
+};
+
+int data_source_mavlink_create(data_source_t *ds, uint16_t port, uint8_t channel, bool debug_flag) {
+    memset(ds, 0, sizeof(*ds));
+    ds->ops = &mavlink_ops;
+
+    mavlink_receiver_t *recv = (mavlink_receiver_t *)calloc(1, sizeof(mavlink_receiver_t));
+    if (!recv) return -1;
+
+    recv->debug = debug_flag;
+    int ret = mavlink_receiver_init(recv, port, channel);
+    if (ret != 0) {
+        free(recv);
+        return ret;
+    }
+
+    ds->impl = recv;
+    ds->debug = debug_flag;
+    ds->playback.speed = 1.0f;
+    return 0;
+}

--- a/src/data_source_ulog.c
+++ b/src/data_source_ulog.c
@@ -1,0 +1,68 @@
+#include "data_source.h"
+#include "ulog_replay.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void ulog_poll(data_source_t *ds, float dt) {
+    ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)ds->impl;
+
+    if (!ds->playback.paused) {
+        bool still_playing = ulog_replay_advance(
+            ctx, dt, ds->playback.speed, ds->playback.looping,
+            ds->playback.interpolation);
+        ds->connected = still_playing || ds->playback.looping;
+    }
+
+    // Copy state (even when paused, so HUD shows frozen data)
+    ds->state = ctx->state;
+    ds->home = ctx->home;
+    ds->mav_type = ctx->vehicle_type;
+
+    // Update playback progress
+    uint64_t range = ctx->parser.end_timestamp - ctx->parser.start_timestamp;
+    if (range > 0) {
+        ds->playback.duration_s = (float)((double)range / 1e6);
+        ds->playback.position_s = (float)ctx->wall_accum;
+        if (ds->playback.position_s > ds->playback.duration_s)
+            ds->playback.position_s = ds->playback.duration_s;
+        ds->playback.progress = ds->playback.position_s / ds->playback.duration_s;
+    }
+}
+
+static void ulog_close(data_source_t *ds) {
+    ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)ds->impl;
+    if (ctx) {
+        ulog_replay_close(ctx);
+        free(ctx);
+        ds->impl = NULL;
+    }
+}
+
+static const data_source_ops_t ulog_ops = {
+    .poll = ulog_poll,
+    .close = ulog_close,
+};
+
+int data_source_ulog_create(data_source_t *ds, const char *filepath) {
+    memset(ds, 0, sizeof(*ds));
+    ds->ops = &ulog_ops;
+
+    ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)calloc(1, sizeof(ulog_replay_ctx_t));
+    if (!ctx) return -1;
+
+    int ret = ulog_replay_init(ctx, filepath);
+    if (ret != 0) {
+        free(ctx);
+        return ret;
+    }
+
+    ds->impl = ctx;
+    ds->connected = true;
+    ds->sysid = 1;
+    ds->playback.speed = 1.0f;
+    ds->playback.looping = false;
+    ds->playback.paused = false;
+    ds->playback.interpolation = true;
+    return 0;
+}

--- a/src/hud.c
+++ b/src/hud.c
@@ -222,7 +222,7 @@ static void draw_attitude(float cx, float cy, float radius, float roll_deg, floa
 }
 
 static void draw_numpad(const hud_t *h, const vehicle_t *vehicles,
-                        const mavlink_receiver_t *receivers, int vehicle_count,
+                        const data_source_t *sources, int vehicle_count,
                         int selected, float numpad_x, float numpad_y,
                         Font font_label, float btn_size, float gap, float scale) {
     float fs = 12 * scale;
@@ -233,7 +233,7 @@ static void draw_numpad(const hud_t *h, const vehicle_t *vehicles,
         float by = numpad_y + row * (btn_size + gap);
         int veh_idx = i;
 
-        bool is_connected = (veh_idx < vehicle_count) && receivers[veh_idx].connected;
+        bool is_connected = (veh_idx < vehicle_count) && sources[veh_idx].connected;
         bool is_primary = (veh_idx == selected);
         bool is_pinned = false;
         for (int p = 0; p < h->pinned_count; p++)
@@ -343,7 +343,7 @@ static void draw_secondary_row(const hud_t *h, const vehicle_t *pv, int pidx,
 }
 
 void hud_draw(const hud_t *h, const vehicle_t *vehicles,
-              const mavlink_receiver_t *receivers, int vehicle_count,
+              const data_source_t *sources, int vehicle_count,
               int selected, int screen_w, int screen_h, view_mode_t view_mode) {
 
     bool rez = (view_mode == VIEW_REZ);
@@ -401,14 +401,139 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     // Dynamic bar height
     int primary_h = (int)(120 * s);
     int secondary_h = (int)(38 * s);
-    int total_bar_h = primary_h + (h->pinned_count > 0 ? h->pinned_count * secondary_h + (int)(4 * s) : 0);
+    bool is_replay_source = sources[selected].playback.duration_s > 0.0f;
+    int transport_h = is_replay_source ? (int)(28 * s) : 0;
+    int total_bar_h = transport_h + primary_h + (h->pinned_count > 0 ? h->pinned_count * secondary_h + (int)(4 * s) : 0);
     int bar_y = screen_h - total_bar_h;
 
     const vehicle_t *v = &vehicles[selected];
 
-    // Bar background
+    // Bar background (full height including transport row)
     DrawRectangle(0, bar_y, screen_w, total_bar_h, bg);
     DrawLineEx((Vector2){0, (float)bar_y}, (Vector2){(float)screen_w, (float)bar_y}, 1.0f, border);
+
+    // Replay transport row (above the main HUD bar)
+    if (is_replay_source) {
+        const playback_state_t *pb = &sources[selected].playback;
+        bool connected = sources[selected].connected;
+        float tr_y = (float)bar_y;
+        float tr_cy = tr_y + transport_h / 2.0f;
+        float tr_pad = 12 * s;
+        float icon_sz = 8 * s;
+
+        // Separator line below transport row
+        DrawLineEx((Vector2){0, tr_y + transport_h},
+                   (Vector2){(float)screen_w, tr_y + transport_h},
+                   1.0f, (Color){accent.r, accent.g, accent.b, 30});
+
+        float cx = tr_pad;
+
+        // Play/Pause icon
+        if (pb->paused || !connected) {
+            // Play triangle
+            DrawTriangle(
+                (Vector2){cx, tr_cy - icon_sz * 0.5f},
+                (Vector2){cx, tr_cy + icon_sz * 0.5f},
+                (Vector2){cx + icon_sz * 0.7f, tr_cy},
+                connected ? accent : dim_color);
+        } else {
+            // Pause bars
+            float bw = icon_sz * 0.25f;
+            float bg_val = icon_sz * 0.12f;
+            DrawRectangle((int)(cx), (int)(tr_cy - icon_sz * 0.4f),
+                          (int)bw, (int)(icon_sz * 0.8f), accent);
+            DrawRectangle((int)(cx + bw + bg_val * 2), (int)(tr_cy - icon_sz * 0.4f),
+                          (int)bw, (int)(icon_sz * 0.8f), accent);
+        }
+        cx += icon_sz + 8 * s;
+
+        // Speed
+        char spd_buf[16];
+        snprintf(spd_buf, sizeof(spd_buf), "%.1fx", pb->speed);
+        DrawTextEx(h->font_value, spd_buf, (Vector2){cx, tr_cy - fs_dim * 0.45f},
+                   fs_dim, 0.5f, (pb->speed != 1.0f) ? accent : value_color);
+        Vector2 spd_w = MeasureTextEx(h->font_value, spd_buf, fs_dim, 0.5f);
+        cx += spd_w.x + 12 * s;
+
+        // Time (current)
+        int pos_s = (int)pb->position_s;
+        char pos_buf[16];
+        snprintf(pos_buf, sizeof(pos_buf), "%d:%02d", pos_s / 60, pos_s % 60);
+        DrawTextEx(h->font_value, pos_buf, (Vector2){cx, tr_cy - fs_dim * 0.45f},
+                   fs_dim, 0.5f, value_color);
+        Vector2 pos_w = MeasureTextEx(h->font_value, pos_buf, fs_dim, 0.5f);
+        cx += pos_w.x + 8 * s;
+
+        // Progress bar (stretches to fill available space)
+        int dur_s = (int)pb->duration_s;
+        char dur_buf[16];
+        snprintf(dur_buf, sizeof(dur_buf), "%d:%02d", dur_s / 60, dur_s % 60);
+        Vector2 dur_w = MeasureTextEx(h->font_value, dur_buf, fs_dim, 0.5f);
+
+        // Reserve space for: duration text + icons + right padding
+        float icons_w = (pb->looping ? 20 * s : 0) + 20 * s; // loop + interp
+        float right_reserved = dur_w.x + 8 * s + icons_w + tr_pad;
+        float prog_x = cx;
+        float prog_w = (float)screen_w - cx - right_reserved;
+        if (prog_w < 40 * s) prog_w = 40 * s;
+        float prog_h = 3 * s;
+        float prog_y = tr_cy - prog_h / 2.0f;
+
+        DrawRectangleRounded(
+            (Rectangle){prog_x, prog_y, prog_w, prog_h},
+            0.5f, 4, (Color){accent.r, accent.g, accent.b, 40});
+        if (pb->progress > 0.0f) {
+            float fill_w = prog_w * pb->progress;
+            if (fill_w < prog_h) fill_w = prog_h;
+            DrawRectangleRounded(
+                (Rectangle){prog_x, prog_y, fill_w, prog_h},
+                0.5f, 4, accent);
+        }
+        // Playhead dot
+        float dot_x = prog_x + prog_w * pb->progress;
+        DrawCircle((int)dot_x, (int)(prog_y + prog_h / 2.0f), 3 * s, accent);
+
+        cx = prog_x + prog_w + 8 * s;
+
+        // Duration
+        DrawTextEx(h->font_value, dur_buf, (Vector2){cx, tr_cy - fs_dim * 0.45f},
+                   fs_dim, 0.5f, dim_color);
+        cx += dur_w.x + 8 * s;
+
+        // Loop indicator
+        if (pb->looping) {
+            float lr = 5 * s;
+            float loop_cx = cx + lr;
+            // Circular arrow
+            for (int d = 0; d < 300; d += 15) {
+                float a1 = (float)d * DEG2RAD;
+                float a2 = (float)(d + 15) * DEG2RAD;
+                DrawLineEx(
+                    (Vector2){loop_cx + cosf(a1) * lr, tr_cy + sinf(a1) * lr},
+                    (Vector2){loop_cx + cosf(a2) * lr, tr_cy + sinf(a2) * lr},
+                    1.5f * s, accent);
+            }
+            float arrow_a = 300 * DEG2RAD;
+            float ax = loop_cx + cosf(arrow_a) * lr;
+            float ay = tr_cy + sinf(arrow_a) * lr;
+            DrawTriangle(
+                (Vector2){ax + 3 * s, ay - 2 * s},
+                (Vector2){ax - 1 * s, ay + 3 * s},
+                (Vector2){ax - 2 * s, ay - 3 * s},
+                accent);
+            cx += 14 * s;
+        }
+
+        // Interpolation indicator: "I" label
+        {
+            Color interp_color = pb->interpolation ? accent : dim_color;
+            DrawTextEx(h->font_value, "I", (Vector2){cx, tr_cy - fs_dim * 0.45f},
+                       fs_dim, 0.5f, interp_color);
+        }
+    }
+
+    // Offset the main HUD content below the transport row
+    bar_y += transport_h;
 
     // Primary color bar on left edge
     DrawRectangle(0, bar_y, (int)(3 * s), primary_h, v->color);
@@ -575,22 +700,30 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     // Numpad (only when vehicle_count > 1)
     if (vehicle_count > 1) {
         float np_y = bar_y + (primary_h / 2.0f) - (3 * (np_btn + np_gap)) / 2.0f;
-        draw_numpad(h, vehicles, receivers, vehicle_count, selected,
+        draw_numpad(h, vehicles, sources, vehicle_count, selected,
                     numpad_x, np_y, h->font_label, np_btn, np_gap, s);
     }
 
     // Status group (right edge)
     {
-        bool connected = receivers[selected].connected;
+        bool connected = sources[selected].connected;
+        bool is_replay = sources[selected].playback.duration_s > 0.0f;
         int status_y = bar_y + primary_h / 2 - (int)(12 * s);
 
         // Connection dot
         Color dot_color = connected ? connected_color : (Color){200, 60, 60, 255};
         DrawCircle((int)(status_x + 4 * s), status_y + (int)(6 * s), 4 * s, dot_color);
 
-        // Status text
-        char status_buf[32];
-        if (connected) {
+        // Status text — simple data source label
+        char status_buf[48];
+        if (is_replay) {
+            if (!connected)
+                snprintf(status_buf, sizeof(status_buf), "Replay ended");
+            else if (sources[selected].playback.paused)
+                snprintf(status_buf, sizeof(status_buf), "Replay paused");
+            else
+                snprintf(status_buf, sizeof(status_buf), "Replaying log...");
+        } else if (connected) {
             snprintf(status_buf, sizeof(status_buf), "MAVLink SYS %u", vehicles[selected].sysid);
         } else {
             snprintf(status_buf, sizeof(status_buf), "Waiting...");
@@ -648,6 +781,11 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
             {"Left-drag",   "Orbit camera (chase mode)"},
             {"Scroll",      "Zoom FOV"},
             {"?",           "Toggle this help"},
+            {"Space",       "Pause/resume replay"},
+            {"+/-",         "Replay speed"},
+            {"<-/->",       "Seek 5s (Shift: 30s)"},
+            {"L",           "Toggle replay loop"},
+            {"R",           "Restart replay"},
         };
         int entry_count = sizeof(entries) / sizeof(entries[0]);
 
@@ -697,7 +835,8 @@ int hud_bar_height(const hud_t *h, int screen_h) {
     if (s < 1.0f) s = 1.0f;
     int primary_h = (int)(120 * s);
     int secondary_h = (int)(38 * s);
-    return primary_h + (h->pinned_count > 0 ? h->pinned_count * secondary_h + (int)(4 * s) : 0);
+    int transport_h = h->is_replay ? (int)(28 * s) : 0;
+    return transport_h + primary_h + (h->pinned_count > 0 ? h->pinned_count * secondary_h + (int)(4 * s) : 0);
 }
 
 void hud_cleanup(hud_t *h) {

--- a/src/hud.h
+++ b/src/hud.h
@@ -2,7 +2,7 @@
 #define HUD_H
 
 #include "vehicle.h"
-#include "mavlink_receiver.h"
+#include "data_source.h"
 #include <stdbool.h>
 
 #define HUD_MAX_PINNED 15
@@ -12,6 +12,7 @@ typedef struct {
     int pinned[HUD_MAX_PINNED];   // indices of pinned vehicles (-1 = empty)
     int pinned_count;
     bool show_help;
+    bool is_replay;     // true when data source is ULog replay (affects layout)
     Font font_value;    // JetBrains Mono for telemetry numbers
     Font font_label;    // Inter for labels and status text
 } hud_t;
@@ -19,7 +20,7 @@ typedef struct {
 void hud_init(hud_t *h);
 void hud_update(hud_t *h, uint64_t time_usec, bool connected, float dt);
 void hud_draw(const hud_t *h, const vehicle_t *vehicles,
-              const mavlink_receiver_t *receivers, int vehicle_count,
+              const data_source_t *sources, int vehicle_count,
               int selected, int screen_w, int screen_h, view_mode_t view_mode);
 void hud_cleanup(hud_t *h);
 

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,8 @@
 
 #include "raylib.h"
 #include "raymath.h"
-#include "mavlink_receiver.h"
+#include "data_source.h"
+#include "ulog_replay.h"
 #include "vehicle.h"
 #include "scene.h"
 #include "hud.h"
@@ -44,6 +45,7 @@ static void print_usage(const char *prog) {
     printf("  -fw            Fixed-wing model\n");
     printf("  -ts            Tailsitter model\n");
     printf("  -origin <lat> <lon> <alt>  NED origin in degrees/meters (default: PX4 SIH)\n");
+    printf("  --replay <file.ulg>  Replay ULog file\n");
     printf("  -w <width>     Window width (default: 1280)\n");
     printf("  -h <height>    Window height (default: 720)\n");
 }
@@ -60,6 +62,7 @@ int main(int argc, char *argv[]) {
     double origin_lon = 8.545594;
     double origin_alt = 489.4;
     bool origin_specified = false;
+    const char *replay_file = NULL;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-udp") == 0 && i + 1 < argc) {
@@ -85,6 +88,8 @@ int main(int argc, char *argv[]) {
             win_w = atoi(argv[++i]);
         } else if (strcmp(argv[i], "-h") == 0 && i + 1 < argc) {
             win_h = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--replay") == 0 && i + 1 < argc) {
+            replay_file = argv[++i];
         } else if (strcmp(argv[i], "--help") == 0) {
             print_usage(argv[0]);
             return 0;
@@ -96,15 +101,25 @@ int main(int argc, char *argv[]) {
     InitWindow(win_w, win_h, "MAVSim Viewer");
     SetTargetFPS(60);
 
-    // Init MAVLink receivers
-    mavlink_receiver_t receivers[MAX_VEHICLES];
-    memset(receivers, 0, sizeof(receivers));
-    for (int i = 0; i < vehicle_count; i++) {
-        receivers[i].debug = debug;
-        if (mavlink_receiver_init(&receivers[i], base_port + i, (uint8_t)i) != 0) {
-            fprintf(stderr, "Failed to init MAVLink receiver on port %u\n", base_port + i);
+    // Init data sources
+    data_source_t sources[MAX_VEHICLES];
+    memset(sources, 0, sizeof(sources));
+    bool is_replay = (replay_file != NULL);
+
+    if (is_replay) {
+        vehicle_count = 1;  // single vehicle replay (multi-file is future scope)
+        if (data_source_ulog_create(&sources[0], replay_file) != 0) {
+            fprintf(stderr, "Failed to open ULog: %s\n", replay_file);
             CloseWindow();
             return 1;
+        }
+    } else {
+        for (int i = 0; i < vehicle_count; i++) {
+            if (data_source_mavlink_create(&sources[i], base_port + i, (uint8_t)i, debug) != 0) {
+                fprintf(stderr, "Failed to init MAVLink receiver on port %u\n", base_port + i);
+                CloseWindow();
+                return 1;
+            }
         }
     }
 
@@ -134,6 +149,7 @@ int main(int argc, char *argv[]) {
 
     hud_t hud;
     hud_init(&hud);
+    hud.is_replay = is_replay;
 
     debug_panel_t dbg_panel;
     debug_panel_init(&dbg_panel);
@@ -152,23 +168,24 @@ int main(int argc, char *argv[]) {
 
     // Main loop
     while (!WindowShouldClose()) {
-        // Poll all MAVLink receivers and update vehicles
+        // Poll all data sources and update vehicles
         for (int i = 0; i < vehicle_count; i++) {
-            mavlink_receiver_poll(&receivers[i]);
+            data_source_poll(&sources[i], GetFrameTime());
 
             // Reset trail and origin on reconnect
-            if (receivers[i].connected && !was_connected[i]) {
+            if (sources[i].connected && !was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);
-                vehicle_set_type(&vehicles[i], receivers[i].mav_type);
+                if (sources[i].mav_type != 0)
+                    vehicle_set_type(&vehicles[i], sources[i].mav_type);
                 if (!origin_specified && vehicle_count == 1) {
                     vehicles[i].origin_set = false;
                     vehicles[i].origin_wait_count = 0;
                 }
             }
-            was_connected[i] = receivers[i].connected;
+            was_connected[i] = sources[i].connected;
 
-            vehicle_update(&vehicles[i], &receivers[i].state, &receivers[i].home);
-            vehicles[i].sysid = receivers[i].sysid;
+            vehicle_update(&vehicles[i], &sources[i].state, &sources[i].home);
+            vehicles[i].sysid = sources[i].sysid;
 
             // Detect position jump (new SITL connecting before disconnect timeout)
             if (vehicles[i].active && vehicles[i].trail_count > 0) {
@@ -180,15 +197,15 @@ int main(int argc, char *argv[]) {
             last_pos[i] = vehicles[i].position;
         }
 
-        // Check if any receiver is connected (for HUD)
+        // Check if any source is connected (for HUD)
         bool any_connected = false;
         for (int i = 0; i < vehicle_count; i++) {
-            if (receivers[i].connected) { any_connected = true; break; }
+            if (sources[i].connected) { any_connected = true; break; }
         }
 
         // Update HUD sim time from selected vehicle
-        hud_update(&hud, receivers[selected].state.time_usec,
-                   receivers[selected].connected, GetFrameTime());
+        hud_update(&hud, sources[selected].state.time_usec,
+                   sources[selected].connected, GetFrameTime());
 
         // Handle input
         scene_handle_input(&scene);
@@ -234,7 +251,7 @@ int main(int argc, char *argv[]) {
                 // Cycle to next connected vehicle, clear pins
                 for (int j = 1; j <= vehicle_count; j++) {
                     int next = (selected + j) % vehicle_count;
-                    if (receivers[next].connected) { selected = next; break; }
+                    if (sources[next].connected) { selected = next; break; }
                 }
                 hud.pinned_count = 0;
                 memset(hud.pinned, -1, sizeof(hud.pinned));
@@ -242,7 +259,7 @@ int main(int argc, char *argv[]) {
             if (IsKeyPressed(KEY_LEFT_BRACKET)) {
                 for (int j = 1; j <= vehicle_count; j++) {
                     int prev = (selected - j + vehicle_count) % vehicle_count;
-                    if (receivers[prev].connected) { selected = prev; break; }
+                    if (sources[prev].connected) { selected = prev; break; }
                 }
                 hud.pinned_count = 0;
                 memset(hud.pinned, -1, sizeof(hud.pinned));
@@ -250,7 +267,7 @@ int main(int argc, char *argv[]) {
             if (IsKeyPressed(KEY_RIGHT_BRACKET)) {
                 for (int j = 1; j <= vehicle_count; j++) {
                     int next = (selected + j) % vehicle_count;
-                    if (receivers[next].connected) { selected = next; break; }
+                    if (sources[next].connected) { selected = next; break; }
                 }
                 hud.pinned_count = 0;
                 memset(hud.pinned, -1, sizeof(hud.pinned));
@@ -291,6 +308,76 @@ int main(int argc, char *argv[]) {
             }
         }
 
+        // Replay playback controls
+        if (is_replay) {
+            if (IsKeyPressed(KEY_SPACE)) {
+                if (!sources[0].connected) {
+                    // Replay ended — restart from beginning
+                    ulog_replay_ctx_t *rctx = (ulog_replay_ctx_t *)sources[0].impl;
+                    ulog_replay_seek(rctx, 0.0f);
+                    sources[0].connected = true;
+                    sources[0].playback.paused = false;
+                    vehicle_reset_trail(&vehicles[0]);
+                    vehicles[0].origin_set = false;
+                    vehicles[0].origin_wait_count = 0;
+                } else {
+                    sources[0].playback.paused = !sources[0].playback.paused;
+                }
+            }
+            if (IsKeyPressed(KEY_L)) {
+                sources[0].playback.looping = !sources[0].playback.looping;
+            }
+            if (IsKeyPressed(KEY_I)) {
+                sources[0].playback.interpolation = !sources[0].playback.interpolation;
+                printf("Interpolation: %s\n", sources[0].playback.interpolation ? "ON" : "OFF");
+            }
+            if (IsKeyPressed(KEY_EQUAL)) {
+                float *spd = &sources[0].playback.speed;
+                if (*spd < 0.5f) *spd = 0.5f;
+                else if (*spd < 1.0f) *spd = 1.0f;
+                else if (*spd < 2.0f) *spd = 2.0f;
+                else if (*spd < 4.0f) *spd = 4.0f;
+                else if (*spd < 8.0f) *spd = 8.0f;
+                else *spd = 16.0f;
+            }
+            if (IsKeyPressed(KEY_MINUS)) {
+                float *spd = &sources[0].playback.speed;
+                if (*spd > 8.0f) *spd = 8.0f;
+                else if (*spd > 4.0f) *spd = 4.0f;
+                else if (*spd > 2.0f) *spd = 2.0f;
+                else if (*spd > 1.0f) *spd = 1.0f;
+                else if (*spd > 0.5f) *spd = 0.5f;
+                else *spd = 0.25f;
+            }
+            if (IsKeyPressed(KEY_R)) {
+                ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)sources[0].impl;
+                ulog_replay_seek(ctx, 0.0f);
+                sources[0].connected = true;
+                sources[0].playback.paused = false;
+                vehicle_reset_trail(&vehicles[0]);
+                vehicles[0].origin_set = false;
+                vehicles[0].origin_wait_count = 0;
+            }
+            if (IsKeyPressed(KEY_RIGHT)) {
+                ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)sources[0].impl;
+                float step = (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT)) ? 30.0f : 5.0f;
+                ulog_replay_seek(ctx, sources[0].playback.position_s + step);
+                sources[0].playback.position_s = (float)ctx->wall_accum;
+                vehicle_reset_trail(&vehicles[0]);
+            }
+            if (IsKeyPressed(KEY_LEFT)) {
+                ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)sources[0].impl;
+                float step = (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT)) ? 30.0f : 5.0f;
+                float target = sources[0].playback.position_s - step;
+                if (target < 0.0f) target = 0.0f;
+                ulog_replay_seek(ctx, target);
+                sources[0].playback.position_s = (float)ctx->wall_accum;
+                vehicle_reset_trail(&vehicles[0]);
+                vehicles[0].origin_set = false;
+                vehicles[0].origin_wait_count = 0;
+            }
+        }
+
         // Update debug panel
         debug_panel_update(&dbg_panel, GetFrameTime());
 
@@ -325,7 +412,7 @@ int main(int argc, char *argv[]) {
 
             // HUD
             if (show_hud) {
-                hud_draw(&hud, vehicles, receivers, vehicle_count,
+                hud_draw(&hud, vehicles, sources, vehicle_count,
                          selected, GetScreenWidth(), GetScreenHeight(),
                          scene.view_mode);
             }
@@ -359,7 +446,7 @@ int main(int argc, char *argv[]) {
     hud_cleanup(&hud);
     for (int i = 0; i < vehicle_count; i++) {
         vehicle_cleanup(&vehicles[i]);
-        mavlink_receiver_close(&receivers[i]);
+        data_source_close(&sources[i]);
     }
     scene_cleanup(&scene);
     CloseWindow();

--- a/src/ulog_parser.c
+++ b/src/ulog_parser.c
@@ -1,0 +1,439 @@
+#include "ulog_parser.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#define ULOG_HEADER_SIZE     16   // 7 magic + 1 version + 8 timestamp
+#define ULOG_MSG_HEADER_SIZE 3    // 2 size + 1 type
+#define READ_BUF_INITIAL     4096
+#define INDEX_INTERVAL_USEC  1000000  // 1 second between index entries
+
+static const uint8_t ULOG_MAGIC[7] = { 'U', 'L', 'o', 'g', 0x01, 0x12, 0x35 };
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
+
+static ulog_field_type_t parse_type_str(const char *s) {
+    if (strcmp(s, "float") == 0)    return ULOG_FIELD_FLOAT;
+    if (strcmp(s, "double") == 0)   return ULOG_FIELD_DOUBLE;
+    if (strcmp(s, "uint8_t") == 0)  return ULOG_FIELD_UINT8;
+    if (strcmp(s, "int8_t") == 0)   return ULOG_FIELD_INT8;
+    if (strcmp(s, "uint16_t") == 0) return ULOG_FIELD_UINT16;
+    if (strcmp(s, "int16_t") == 0)  return ULOG_FIELD_INT16;
+    if (strcmp(s, "uint32_t") == 0) return ULOG_FIELD_UINT32;
+    if (strcmp(s, "int32_t") == 0)  return ULOG_FIELD_INT32;
+    if (strcmp(s, "uint64_t") == 0) return ULOG_FIELD_UINT64;
+    if (strcmp(s, "int64_t") == 0)  return ULOG_FIELD_INT64;
+    if (strcmp(s, "bool") == 0)     return ULOG_FIELD_BOOL;
+    if (strcmp(s, "char") == 0)     return ULOG_FIELD_CHAR;
+    return ULOG_FIELD_UNKNOWN;
+}
+
+static int field_elem_size(ulog_field_type_t t) {
+    switch (t) {
+        case ULOG_FIELD_UINT8:  case ULOG_FIELD_INT8:
+        case ULOG_FIELD_BOOL:   case ULOG_FIELD_CHAR:   return 1;
+        case ULOG_FIELD_UINT16: case ULOG_FIELD_INT16:  return 2;
+        case ULOG_FIELD_UINT32: case ULOG_FIELD_INT32:
+        case ULOG_FIELD_FLOAT:                           return 4;
+        case ULOG_FIELD_UINT64: case ULOG_FIELD_INT64:
+        case ULOG_FIELD_DOUBLE:                          return 8;
+        default: return 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Format string parser
+// ---------------------------------------------------------------------------
+
+// Parse "topic_name:type1 field1;type2[N] field2;..."
+static int parse_format(const char *fmt_str, ulog_format_t *fmt) {
+    memset(fmt, 0, sizeof(*fmt));
+
+    const char *colon = strchr(fmt_str, ':');
+    if (!colon) return -1;
+
+    int name_len = (int)(colon - fmt_str);
+    if (name_len >= (int)sizeof(fmt->name)) name_len = (int)sizeof(fmt->name) - 1;
+    memcpy(fmt->name, fmt_str, name_len);
+    fmt->name[name_len] = '\0';
+
+    const char *p = colon + 1;
+    int offset = 0;
+
+    while (*p && fmt->field_count < ULOG_MAX_FIELDS) {
+        // Skip whitespace
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\0' || *p == ';') { if (*p) p++; continue; }
+
+        // Find the space separating type from name
+        const char *space = strchr(p, ' ');
+        if (!space) break;
+
+        // Extract type string (may contain [N])
+        char type_buf[64];
+        int type_len = (int)(space - p);
+        if (type_len >= (int)sizeof(type_buf)) type_len = (int)sizeof(type_buf) - 1;
+        memcpy(type_buf, p, type_len);
+        type_buf[type_len] = '\0';
+
+        // Extract field name (until ; or end)
+        const char *name_start = space + 1;
+        const char *semi = strchr(name_start, ';');
+        const char *name_end = semi ? semi : name_start + strlen(name_start);
+
+        ulog_field_t *f = &fmt->fields[fmt->field_count];
+        int fname_len = (int)(name_end - name_start);
+        if (fname_len >= (int)sizeof(f->name)) fname_len = (int)sizeof(f->name) - 1;
+        memcpy(f->name, name_start, fname_len);
+        f->name[fname_len] = '\0';
+
+        // Parse array size from type (e.g. "float[4]")
+        f->array_size = 1;
+        char base_type[64];
+        char *bracket = strchr(type_buf, '[');
+        if (bracket) {
+            int base_len = (int)(bracket - type_buf);
+            memcpy(base_type, type_buf, base_len);
+            base_type[base_len] = '\0';
+            f->array_size = atoi(bracket + 1);
+            if (f->array_size < 1) f->array_size = 1;
+        } else {
+            strcpy(base_type, type_buf);
+        }
+
+        f->type = parse_type_str(base_type);
+        int elem_sz = field_elem_size(f->type);
+
+        // Skip unknown/nested types but still account for padding-like fields
+        if (elem_sz == 0) {
+            // Can't compute size — skip this field
+            p = semi ? semi + 1 : name_end;
+            continue;
+        }
+
+        f->offset = offset;
+        offset += elem_sz * f->array_size;
+        fmt->field_count++;
+
+        p = semi ? semi + 1 : name_end;
+    }
+
+    fmt->size = offset;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Index management
+// ---------------------------------------------------------------------------
+
+static void index_add(ulog_parser_t *p, uint64_t timestamp, long file_offset) {
+    if (p->index_count >= p->index_capacity) {
+        int new_cap = p->index_capacity ? p->index_capacity * 2 : 256;
+        ulog_index_entry_t *new_idx = realloc(p->index, new_cap * sizeof(ulog_index_entry_t));
+        if (!new_idx) return;
+        p->index = new_idx;
+        p->index_capacity = new_cap;
+    }
+    p->index[p->index_count].timestamp = timestamp;
+    p->index[p->index_count].file_offset = file_offset;
+    p->index_count++;
+}
+
+// ---------------------------------------------------------------------------
+// Buffer management
+// ---------------------------------------------------------------------------
+
+static int ensure_buf(ulog_parser_t *p, int needed) {
+    if (needed <= p->read_buf_size) return 0;
+    int new_size = p->read_buf_size ? p->read_buf_size : READ_BUF_INITIAL;
+    while (new_size < needed) new_size *= 2;
+    uint8_t *new_buf = realloc(p->read_buf, new_size);
+    if (!new_buf) return -1;
+    p->read_buf = new_buf;
+    p->read_buf_size = new_size;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Process an ADD_LOGGED_MSG payload (shared by Pass 1, Pass 2, and playback)
+// ---------------------------------------------------------------------------
+
+static void process_add_logged(ulog_parser_t *p, const uint8_t *buf, uint16_t msg_size) {
+    if (p->sub_count >= ULOG_MAX_SUBSCRIPTIONS) return;
+    if (msg_size < 3) return;
+    ulog_subscription_t *sub = &p->subs[p->sub_count];
+    sub->multi_id = buf[0];
+    sub->msg_id = buf[1] | (buf[2] << 8);
+    int name_len = msg_size - 3;
+    if (name_len >= (int)sizeof(sub->message_name))
+        name_len = (int)sizeof(sub->message_name) - 1;
+    memcpy(sub->message_name, buf + 3, name_len);
+    sub->message_name[name_len] = '\0';
+
+    // Match to format by name
+    sub->format_idx = -1;
+    for (int i = 0; i < p->format_count; i++) {
+        if (strcmp(p->formats[i].name, sub->message_name) == 0) {
+            sub->format_idx = i;
+            break;
+        }
+    }
+    p->sub_count++;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+int ulog_parser_open(ulog_parser_t *p, const char *filepath) {
+    memset(p, 0, sizeof(*p));
+
+    p->fp = fopen(filepath, "rb");
+    if (!p->fp) {
+        fprintf(stderr, "ulog_parser: cannot open %s\n", filepath);
+        return -1;
+    }
+
+    // Validate header
+    uint8_t header[ULOG_HEADER_SIZE];
+    if (fread(header, 1, ULOG_HEADER_SIZE, p->fp) != ULOG_HEADER_SIZE) {
+        fprintf(stderr, "ulog_parser: file too short\n");
+        fclose(p->fp); p->fp = NULL;
+        return -1;
+    }
+    if (memcmp(header, ULOG_MAGIC, 7) != 0) {
+        fprintf(stderr, "ulog_parser: invalid magic\n");
+        fclose(p->fp); p->fp = NULL;
+        return -1;
+    }
+
+    // Pass 1: read definition section (FORMAT messages only before data section)
+    // ADD_LOGGED_MSG messages can appear both here and in the data section
+    bool in_data_section = false;
+    while (!in_data_section) {
+        uint8_t msg_hdr[ULOG_MSG_HEADER_SIZE];
+        if (fread(msg_hdr, 1, ULOG_MSG_HEADER_SIZE, p->fp) != ULOG_MSG_HEADER_SIZE) break;
+
+        uint16_t msg_size = msg_hdr[0] | (msg_hdr[1] << 8);
+        uint8_t msg_type = msg_hdr[2];
+
+        if (ensure_buf(p, msg_size) != 0) break;
+        if (fread(p->read_buf, 1, msg_size, p->fp) != msg_size) break;
+
+        switch ((char)msg_type) {
+            case ULOG_MSG_FORMAT: {
+                if (p->format_count >= ULOG_MAX_SUBSCRIPTIONS) break;
+                char fmt_str[2048];
+                int len = msg_size < (int)sizeof(fmt_str) - 1 ? msg_size : (int)sizeof(fmt_str) - 1;
+                memcpy(fmt_str, p->read_buf, len);
+                fmt_str[len] = '\0';
+                parse_format(fmt_str, &p->formats[p->format_count]);
+                p->format_count++;
+                break;
+            }
+
+            case ULOG_MSG_ADD_LOGGED: {
+                process_add_logged(p, p->read_buf, msg_size);
+                break;
+            }
+
+            case ULOG_MSG_DATA: {
+                // We've hit the data section — back up and record offset
+                p->data_start_offset = ftell(p->fp) - ULOG_MSG_HEADER_SIZE - msg_size;
+                in_data_section = true;
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    if (p->data_start_offset == 0) {
+        fprintf(stderr, "ulog_parser: no data section found\n");
+        fclose(p->fp); p->fp = NULL;
+        return -1;
+    }
+
+    // Pass 2: scan data section to build timestamp index
+    // Also pick up ADD_LOGGED_MSG messages that appear in the data section
+    fseek(p->fp, p->data_start_offset, SEEK_SET);
+    uint64_t last_indexed = 0;
+    bool first = true;
+
+    for (;;) {
+        long msg_offset = ftell(p->fp);
+        uint8_t msg_hdr[ULOG_MSG_HEADER_SIZE];
+        if (fread(msg_hdr, 1, ULOG_MSG_HEADER_SIZE, p->fp) != ULOG_MSG_HEADER_SIZE) break;
+
+        uint16_t msg_size = msg_hdr[0] | (msg_hdr[1] << 8);
+        uint8_t msg_type = msg_hdr[2];
+
+        if ((char)msg_type == ULOG_MSG_ADD_LOGGED) {
+            // Process ADD_LOGGED messages in the data section
+            if (ensure_buf(p, msg_size) != 0) break;
+            if (fread(p->read_buf, 1, msg_size, p->fp) != msg_size) break;
+            process_add_logged(p, p->read_buf, msg_size);
+        } else if ((char)msg_type == ULOG_MSG_DATA && msg_size >= 10) {
+            // Read msg_id (2) + timestamp (8) = 10 bytes
+            uint8_t ts_buf[10];
+            if (fread(ts_buf, 1, 10, p->fp) != 10) break;
+
+            uint64_t ts;
+            memcpy(&ts, ts_buf + 2, 8);
+
+            if (first) {
+                p->start_timestamp = ts;
+                last_indexed = ts;
+                index_add(p, ts, msg_offset);
+            }
+
+            if (first || ts >= last_indexed + INDEX_INTERVAL_USEC) {
+                if (!first) index_add(p, ts, msg_offset);
+                last_indexed = ts;
+                first = false;
+            }
+
+            p->end_timestamp = ts;
+
+            // Skip remaining payload
+            int remaining = msg_size - 10;
+            if (remaining > 0) fseek(p->fp, remaining, SEEK_CUR);
+        } else {
+            // Skip non-DATA message
+            fseek(p->fp, msg_size, SEEK_CUR);
+        }
+    }
+
+    // Seek back to data start for playback
+    fseek(p->fp, p->data_start_offset, SEEK_SET);
+    p->eof = false;
+
+    return 0;
+}
+
+bool ulog_parser_next(ulog_parser_t *p, ulog_data_msg_t *out) {
+    for (;;) {
+        uint8_t msg_hdr[ULOG_MSG_HEADER_SIZE];
+        if (fread(msg_hdr, 1, ULOG_MSG_HEADER_SIZE, p->fp) != ULOG_MSG_HEADER_SIZE) {
+            p->eof = true;
+            return false;
+        }
+
+        uint16_t msg_size = msg_hdr[0] | (msg_hdr[1] << 8);
+        uint8_t msg_type = msg_hdr[2];
+
+        if (ensure_buf(p, msg_size) != 0) {
+            p->eof = true;
+            return false;
+        }
+
+        if (fread(p->read_buf, 1, msg_size, p->fp) != msg_size) {
+            p->eof = true;
+            return false;
+        }
+
+        if ((char)msg_type == ULOG_MSG_DATA && msg_size >= 10) {
+            out->msg_id = p->read_buf[0] | (p->read_buf[1] << 8);
+            memcpy(&out->timestamp, p->read_buf + 2, 8);
+            out->data = p->read_buf + 2;  // skip msg_id, include timestamp
+            out->data_len = msg_size - 2;
+            return true;
+        }
+        // Skip non-DATA messages (DROPOUT, LOGGING, etc.)
+    }
+}
+
+void ulog_parser_rewind(ulog_parser_t *p) {
+    fseek(p->fp, p->data_start_offset, SEEK_SET);
+    p->eof = false;
+}
+
+int ulog_parser_seek(ulog_parser_t *p, uint64_t target_usec) {
+    if (p->index_count == 0) {
+        ulog_parser_rewind(p);
+        return 0;
+    }
+
+    // Binary search for largest entry with timestamp <= target
+    int lo = 0, hi = p->index_count - 1;
+    int best = 0;
+    while (lo <= hi) {
+        int mid = (lo + hi) / 2;
+        if (p->index[mid].timestamp <= target_usec) {
+            best = mid;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    fseek(p->fp, p->index[best].file_offset, SEEK_SET);
+    p->eof = false;
+    return 0;
+}
+
+int ulog_parser_find_subscription(const ulog_parser_t *p, const char *name) {
+    for (int i = 0; i < p->sub_count; i++) {
+        if (strcmp(p->subs[i].message_name, name) == 0 && p->subs[i].multi_id == 0)
+            return i;
+    }
+    return -1;
+}
+
+int ulog_parser_find_field(const ulog_parser_t *p, int format_idx, const char *name) {
+    if (format_idx < 0 || format_idx >= p->format_count) return -1;
+    const ulog_format_t *fmt = &p->formats[format_idx];
+    for (int i = 0; i < fmt->field_count; i++) {
+        if (strcmp(fmt->fields[i].name, name) == 0)
+            return fmt->fields[i].offset;
+    }
+    return -1;
+}
+
+// Field accessors — use memcpy for safe unaligned reads
+
+float ulog_parser_get_float(const ulog_data_msg_t *msg, int offset) {
+    float v;
+    memcpy(&v, msg->data + offset, sizeof(v));
+    return v;
+}
+
+double ulog_parser_get_double(const ulog_data_msg_t *msg, int offset) {
+    double v;
+    memcpy(&v, msg->data + offset, sizeof(v));
+    return v;
+}
+
+int32_t ulog_parser_get_int32(const ulog_data_msg_t *msg, int offset) {
+    int32_t v;
+    memcpy(&v, msg->data + offset, sizeof(v));
+    return v;
+}
+
+uint8_t ulog_parser_get_uint8(const ulog_data_msg_t *msg, int offset) {
+    return msg->data[offset];
+}
+
+uint64_t ulog_parser_get_uint64(const ulog_data_msg_t *msg, int offset) {
+    uint64_t v;
+    memcpy(&v, msg->data + offset, sizeof(v));
+    return v;
+}
+
+void ulog_parser_close(ulog_parser_t *p) {
+    if (p->fp) {
+        fclose(p->fp);
+        p->fp = NULL;
+    }
+    free(p->read_buf);
+    p->read_buf = NULL;
+    p->read_buf_size = 0;
+    free(p->index);
+    p->index = NULL;
+    p->index_count = 0;
+    p->index_capacity = 0;
+}

--- a/src/ulog_parser.h
+++ b/src/ulog_parser.h
@@ -1,0 +1,126 @@
+#ifndef ULOG_PARSER_H
+#define ULOG_PARSER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#define ULOG_MAX_SUBSCRIPTIONS 256
+#define ULOG_MAX_FIELDS        64
+
+// ULog message types
+#define ULOG_MSG_FLAG_BITS    'B'
+#define ULOG_MSG_FORMAT       'F'
+#define ULOG_MSG_INFO         'I'
+#define ULOG_MSG_PARAMETER    'P'
+#define ULOG_MSG_ADD_LOGGED   'A'
+#define ULOG_MSG_DROPOUT      'O'
+#define ULOG_MSG_DATA         'D'
+#define ULOG_MSG_LOGGING      'L'
+#define ULOG_MSG_SYNC         'S'
+#define ULOG_MSG_INFO_MULTI   'M'
+#define ULOG_MSG_PARAM_DEF    'Q'
+
+typedef enum {
+    ULOG_FIELD_UINT8,
+    ULOG_FIELD_INT8,
+    ULOG_FIELD_UINT16,
+    ULOG_FIELD_INT16,
+    ULOG_FIELD_UINT32,
+    ULOG_FIELD_INT32,
+    ULOG_FIELD_UINT64,
+    ULOG_FIELD_INT64,
+    ULOG_FIELD_FLOAT,
+    ULOG_FIELD_DOUBLE,
+    ULOG_FIELD_BOOL,
+    ULOG_FIELD_CHAR,
+    ULOG_FIELD_UNKNOWN,
+} ulog_field_type_t;
+
+typedef struct {
+    char name[64];
+    ulog_field_type_t type;
+    int array_size;       // 1 for scalar, >1 for arrays (e.g. q[4] -> 4)
+    int offset;           // byte offset within data payload (after msg_id)
+} ulog_field_t;
+
+typedef struct {
+    char name[64];
+    ulog_field_t fields[ULOG_MAX_FIELDS];
+    int field_count;
+    int size;             // total payload bytes
+} ulog_format_t;
+
+typedef struct {
+    uint16_t msg_id;
+    uint8_t multi_id;
+    char message_name[64];
+    int format_idx;       // index into formats[]
+} ulog_subscription_t;
+
+typedef struct {
+    uint16_t msg_id;
+    uint64_t timestamp;
+    const uint8_t *data;  // payload after msg_id, valid until next read
+    int data_len;
+} ulog_data_msg_t;
+
+// Timestamp index entry for seeking
+typedef struct {
+    uint64_t timestamp;
+    long file_offset;     // fseek offset to the message header
+} ulog_index_entry_t;
+
+typedef struct {
+    FILE *fp;
+    long data_start_offset;
+
+    ulog_format_t formats[ULOG_MAX_SUBSCRIPTIONS];
+    int format_count;
+
+    ulog_subscription_t subs[ULOG_MAX_SUBSCRIPTIONS];
+    int sub_count;
+
+    uint8_t *read_buf;
+    int read_buf_size;
+
+    // Timestamp index for seeking (~1 entry per second of log)
+    ulog_index_entry_t *index;
+    int index_count;
+    int index_capacity;
+
+    uint64_t start_timestamp;
+    uint64_t end_timestamp;
+
+    bool eof;
+} ulog_parser_t;
+
+// Open and parse ULog header + definitions, build seek index. Returns 0 on success.
+int ulog_parser_open(ulog_parser_t *p, const char *filepath);
+
+// Read next data message. Returns true if a message was read.
+bool ulog_parser_next(ulog_parser_t *p, ulog_data_msg_t *out);
+
+// Seek to the beginning of the data section.
+void ulog_parser_rewind(ulog_parser_t *p);
+
+// Seek to nearest index entry at or before target timestamp.
+int ulog_parser_seek(ulog_parser_t *p, uint64_t target_usec);
+
+// Find subscription index by topic name. Returns -1 if not found.
+int ulog_parser_find_subscription(const ulog_parser_t *p, const char *name);
+
+// Find field byte offset within a format. Returns -1 if not found.
+int ulog_parser_find_field(const ulog_parser_t *p, int format_idx, const char *name);
+
+// Type-safe field accessors (read from data at given byte offset)
+float    ulog_parser_get_float(const ulog_data_msg_t *msg, int offset);
+double   ulog_parser_get_double(const ulog_data_msg_t *msg, int offset);
+int32_t  ulog_parser_get_int32(const ulog_data_msg_t *msg, int offset);
+uint8_t  ulog_parser_get_uint8(const ulog_data_msg_t *msg, int offset);
+uint64_t ulog_parser_get_uint64(const ulog_data_msg_t *msg, int offset);
+
+// Close file and free resources.
+void ulog_parser_close(ulog_parser_t *p);
+
+#endif

--- a/src/ulog_replay.c
+++ b/src/ulog_replay.c
@@ -1,0 +1,404 @@
+#include "ulog_replay.h"
+
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+// Approximate meters-per-degree at a given latitude
+#define DEG_TO_RAD (3.14159265358979323846 / 180.0)
+static void local_to_global(double ref_lat, double ref_lon, float ref_alt,
+                            float x, float y, float z,
+                            int32_t *lat_e7, int32_t *lon_e7, int32_t *alt_mm) {
+    // x = North, y = East, z = Down (NED)
+    double meters_per_deg_lat = 111132.92;
+    double meters_per_deg_lon = 111132.92 * cos(ref_lat * DEG_TO_RAD);
+    if (meters_per_deg_lon < 1.0) meters_per_deg_lon = 1.0;
+
+    double lat = ref_lat + (double)x / meters_per_deg_lat;
+    double lon = ref_lon + (double)y / meters_per_deg_lon;
+    float alt = ref_alt - z;  // NED z is down, alt is up
+
+    *lat_e7 = (int32_t)(lat * 1e7);
+    *lon_e7 = (int32_t)(lon * 1e7);
+    *alt_mm = (int32_t)(alt * 1000.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Process a single data message — dispatch by subscription
+// ---------------------------------------------------------------------------
+
+static void process_message(ulog_replay_ctx_t *ctx, const ulog_data_msg_t *dmsg) {
+    // Find which subscription this msg_id belongs to
+    int sub_idx = -1;
+    for (int i = 0; i < ctx->parser.sub_count; i++) {
+        if (ctx->parser.subs[i].msg_id == dmsg->msg_id) {
+            sub_idx = i;
+            break;
+        }
+    }
+    if (sub_idx < 0) return;
+
+    ctx->state.time_usec = dmsg->timestamp;
+    // Only mark state valid once we have position data (not just attitude)
+    if (ctx->first_pos_set)
+        ctx->state.valid = true;
+
+    if (sub_idx == ctx->sub_attitude) {
+        // float[4] q — NED quaternion (w,x,y,z) — direct copy
+        int off = ctx->cache.att_q_offset;
+        ctx->state.quaternion[0] = ulog_parser_get_float(dmsg, off + 0);
+        ctx->state.quaternion[1] = ulog_parser_get_float(dmsg, off + 4);
+        ctx->state.quaternion[2] = ulog_parser_get_float(dmsg, off + 8);
+        ctx->state.quaternion[3] = ulog_parser_get_float(dmsg, off + 12);
+    }
+    else if (ctx->sub_global_pos >= 0 && sub_idx == ctx->sub_global_pos) {
+        // lat/lon: double (degrees) -> int32_t (degE7)
+        // alt: float (meters) -> int32_t (mm)
+        double lat = ulog_parser_get_double(dmsg, ctx->cache.gpos_lat_offset);
+        double lon = ulog_parser_get_double(dmsg, ctx->cache.gpos_lon_offset);
+        float alt = ulog_parser_get_float(dmsg, ctx->cache.gpos_alt_offset);
+
+        ctx->state.lat = (int32_t)(lat * 1e7);
+        ctx->state.lon = (int32_t)(lon * 1e7);
+        ctx->state.alt = (int32_t)(alt * 1000.0f);
+
+        // Derive velocity from consecutive GPOS samples (GPOS has no velocity fields)
+        if (ctx->prev_gpos_usec > 0 && dmsg->timestamp > ctx->prev_gpos_usec) {
+            double dt_gpos = (double)(dmsg->timestamp - ctx->prev_gpos_usec) / 1e6;
+            if (dt_gpos > 0.01 && dt_gpos < 5.0) {
+                double meters_per_deg_lat = 111132.92;
+                double meters_per_deg_lon = 111132.92 * cos(lat * DEG_TO_RAD);
+                if (meters_per_deg_lon < 1.0) meters_per_deg_lon = 1.0;
+                ctx->gpos_vx = (float)((lat - ctx->prev_lat_deg) * meters_per_deg_lat / dt_gpos);
+                ctx->gpos_vy = (float)((lon - ctx->prev_lon_deg) * meters_per_deg_lon / dt_gpos);
+                ctx->gpos_vz = (float)(-(alt - ctx->prev_alt_m) / dt_gpos); // alt up, z down
+            }
+        }
+        ctx->prev_lat_deg = lat;
+        ctx->prev_lon_deg = lon;
+        ctx->prev_alt_m = alt;
+        ctx->prev_gpos_usec = dmsg->timestamp;
+
+        ctx->has_global_pos = true;
+
+        // Store for dead-reckoning interpolation
+        ctx->last_lat_deg = lat;
+        ctx->last_lon_deg = lon;
+        ctx->last_alt_m = alt;
+        ctx->last_pos_usec = dmsg->timestamp;
+
+        if (!ctx->first_pos_set) {
+            ctx->home.lat = ctx->state.lat;
+            ctx->home.lon = ctx->state.lon;
+            ctx->home.alt = ctx->state.alt;
+            ctx->home.valid = true;
+            ctx->first_pos_set = true;
+            ctx->state.valid = true;
+        }
+    }
+    else if (sub_idx == ctx->sub_local_pos) {
+        // vx/vy/vz: float (m/s NED) -> int16_t (cm/s)
+        float vx = ulog_parser_get_float(dmsg, ctx->cache.lpos_vx_offset);
+        float vy = ulog_parser_get_float(dmsg, ctx->cache.lpos_vy_offset);
+        float vz = ulog_parser_get_float(dmsg, ctx->cache.lpos_vz_offset);
+        ctx->state.vx = (int16_t)(vx * 100.0f);
+        ctx->state.vy = (int16_t)(vy * 100.0f);
+        ctx->state.vz = (int16_t)(vz * 100.0f);
+
+        // Store velocity and local position for dead-reckoning
+        ctx->last_vx = vx;
+        ctx->last_vy = vy;
+        ctx->last_vz = vz;
+
+        float x = ulog_parser_get_float(dmsg, ctx->cache.lpos_x_offset);
+        float y = ulog_parser_get_float(dmsg, ctx->cache.lpos_y_offset);
+        float z = ulog_parser_get_float(dmsg, ctx->cache.lpos_z_offset);
+        ctx->last_x = x;
+        ctx->last_y = y;
+        ctx->last_z = z;
+
+        if (!ctx->has_global_pos) {
+            ctx->last_pos_usec = dmsg->timestamp;
+
+            // Try to get reference point from local position if not yet set
+            if (!ctx->ref_set && ctx->cache.lpos_xy_global_offset >= 0) {
+                uint8_t xy_global = ulog_parser_get_uint8(dmsg, ctx->cache.lpos_xy_global_offset);
+                if (xy_global) {
+                    ctx->ref_lat = ulog_parser_get_double(dmsg, ctx->cache.lpos_ref_lat_offset);
+                    ctx->ref_lon = ulog_parser_get_double(dmsg, ctx->cache.lpos_ref_lon_offset);
+                    if (ctx->cache.lpos_z_global_offset >= 0 &&
+                        ulog_parser_get_uint8(dmsg, ctx->cache.lpos_z_global_offset)) {
+                        ctx->ref_alt = ulog_parser_get_float(dmsg, ctx->cache.lpos_ref_alt_offset);
+                    }
+                    ctx->ref_set = true;
+                }
+            }
+
+            // Don't set home/position from LPOS if data is all zeros (no valid position)
+            bool has_pos = (x != 0.0f || y != 0.0f || z != 0.0f) || ctx->ref_set;
+
+            if (has_pos) {
+                local_to_global(ctx->ref_lat, ctx->ref_lon, ctx->ref_alt,
+                                x, y, z,
+                                &ctx->state.lat, &ctx->state.lon, &ctx->state.alt);
+
+                if (!ctx->first_pos_set) {
+                    ctx->home.lat = ctx->state.lat;
+                    ctx->home.lon = ctx->state.lon;
+                    ctx->home.alt = ctx->state.alt;
+                    ctx->home.valid = true;
+                    ctx->first_pos_set = true;
+                    ctx->state.valid = true;
+                }
+            }
+        }
+    }
+    else if (ctx->sub_airspeed >= 0 && sub_idx == ctx->sub_airspeed) {
+        // float (m/s) -> uint16_t (cm/s)
+        float ias = ulog_parser_get_float(dmsg, ctx->cache.aspd_ias_offset);
+        float tas = ulog_parser_get_float(dmsg, ctx->cache.aspd_tas_offset);
+        ctx->state.ind_airspeed = (uint16_t)(ias * 100.0f);
+        ctx->state.true_airspeed = (uint16_t)(tas * 100.0f);
+    }
+    else if (ctx->sub_vehicle_status >= 0 && sub_idx == ctx->sub_vehicle_status) {
+        // PX4 vehicle_type enum → MAVLink MAV_TYPE
+        uint8_t px4_type = ulog_parser_get_uint8(dmsg, ctx->cache.vstatus_type_offset);
+        bool is_vtol = ctx->cache.vstatus_is_vtol_offset >= 0 &&
+                       ulog_parser_get_uint8(dmsg, ctx->cache.vstatus_is_vtol_offset);
+        if (is_vtol) {
+            ctx->vehicle_type = 22; // MAV_TYPE_VTOL_FIXEDROTOR
+        } else {
+            switch (px4_type) {
+                case 1: ctx->vehicle_type = 2;  break; // ROTARY_WING → MAV_TYPE_QUADROTOR
+                case 2: ctx->vehicle_type = 1;  break; // FIXED_WING  → MAV_TYPE_FIXED_WING
+                case 3: ctx->vehicle_type = 10; break; // ROVER       → MAV_TYPE_GROUND_ROVER
+                default: ctx->vehicle_type = 2; break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+int ulog_replay_init(ulog_replay_ctx_t *ctx, const char *filepath) {
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->sub_attitude = -1;
+    ctx->sub_global_pos = -1;
+    ctx->sub_local_pos = -1;
+    ctx->sub_airspeed = -1;
+    ctx->sub_vehicle_status = -1;
+
+    int ret = ulog_parser_open(&ctx->parser, filepath);
+    if (ret != 0) return ret;
+
+    // Find subscriptions
+    ctx->sub_attitude = ulog_parser_find_subscription(&ctx->parser, "vehicle_attitude");
+    ctx->sub_global_pos = ulog_parser_find_subscription(&ctx->parser, "vehicle_global_position");
+    ctx->sub_local_pos = ulog_parser_find_subscription(&ctx->parser, "vehicle_local_position");
+    ctx->sub_airspeed = ulog_parser_find_subscription(&ctx->parser, "airspeed_validated");
+    ctx->sub_vehicle_status = ulog_parser_find_subscription(&ctx->parser, "vehicle_status");
+
+    // Required topics
+    if (ctx->sub_attitude < 0) {
+        fprintf(stderr, "ulog_replay: vehicle_attitude topic not found\n");
+        ulog_parser_close(&ctx->parser);
+        return -1;
+    }
+    if (ctx->sub_local_pos < 0) {
+        fprintf(stderr, "ulog_replay: vehicle_local_position topic not found\n");
+        ulog_parser_close(&ctx->parser);
+        return -1;
+    }
+
+    // has_global_pos starts false and gets set to true when first gpos DATA arrives
+    ctx->has_global_pos = false;
+
+    // Cache field offsets for vehicle_attitude
+    int att_fmt = ctx->parser.subs[ctx->sub_attitude].format_idx;
+    ctx->cache.att_q_offset = ulog_parser_find_field(&ctx->parser, att_fmt, "q");
+
+    // Cache field offsets for vehicle_global_position (if subscription exists)
+    if (ctx->sub_global_pos >= 0) {
+        int gpos_fmt = ctx->parser.subs[ctx->sub_global_pos].format_idx;
+        ctx->cache.gpos_lat_offset = ulog_parser_find_field(&ctx->parser, gpos_fmt, "lat");
+        ctx->cache.gpos_lon_offset = ulog_parser_find_field(&ctx->parser, gpos_fmt, "lon");
+        ctx->cache.gpos_alt_offset = ulog_parser_find_field(&ctx->parser, gpos_fmt, "alt");
+    }
+
+    // Cache field offsets for vehicle_local_position
+    int lpos_fmt = ctx->parser.subs[ctx->sub_local_pos].format_idx;
+    ctx->cache.lpos_x_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "x");
+    ctx->cache.lpos_y_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "y");
+    ctx->cache.lpos_z_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "z");
+    ctx->cache.lpos_vx_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "vx");
+    ctx->cache.lpos_vy_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "vy");
+    ctx->cache.lpos_vz_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "vz");
+    ctx->cache.lpos_ref_lat_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "ref_lat");
+    ctx->cache.lpos_ref_lon_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "ref_lon");
+    ctx->cache.lpos_ref_alt_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "ref_alt");
+    ctx->cache.lpos_xy_global_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "xy_global");
+    ctx->cache.lpos_z_global_offset = ulog_parser_find_field(&ctx->parser, lpos_fmt, "z_global");
+
+    // Optional: airspeed
+    if (ctx->sub_airspeed >= 0) {
+        int aspd_fmt = ctx->parser.subs[ctx->sub_airspeed].format_idx;
+        ctx->cache.aspd_ias_offset = ulog_parser_find_field(&ctx->parser, aspd_fmt, "indicated_airspeed_m_s");
+        ctx->cache.aspd_tas_offset = ulog_parser_find_field(&ctx->parser, aspd_fmt, "true_airspeed_m_s");
+    }
+
+    // Optional: vehicle_status
+    if (ctx->sub_vehicle_status >= 0) {
+        int vs_fmt = ctx->parser.subs[ctx->sub_vehicle_status].format_idx;
+        ctx->cache.vstatus_type_offset = ulog_parser_find_field(&ctx->parser, vs_fmt, "vehicle_type");
+        ctx->cache.vstatus_is_vtol_offset = ulog_parser_find_field(&ctx->parser, vs_fmt, "is_vtol");
+    }
+
+    // Pre-scan for vehicle_type so the correct model shows from the start
+    ctx->vehicle_type = 2;  // default MAV_TYPE_QUADROTOR
+    if (ctx->sub_vehicle_status >= 0) {
+        ulog_data_msg_t scan_msg;
+        while (ulog_parser_next(&ctx->parser, &scan_msg)) {
+            if (scan_msg.msg_id == ctx->parser.subs[ctx->sub_vehicle_status].msg_id) {
+                uint8_t px4_type = ulog_parser_get_uint8(&scan_msg, ctx->cache.vstatus_type_offset);
+                bool is_vtol = ctx->cache.vstatus_is_vtol_offset >= 0 &&
+                               ulog_parser_get_uint8(&scan_msg, ctx->cache.vstatus_is_vtol_offset);
+                if (is_vtol) {
+                    ctx->vehicle_type = 22;
+                } else {
+                    switch (px4_type) {
+                        case 1: ctx->vehicle_type = 2;  break;
+                        case 2: ctx->vehicle_type = 1;  break;
+                        case 3: ctx->vehicle_type = 10; break;
+                        default: ctx->vehicle_type = 2; break;
+                    }
+                }
+                break;
+            }
+        }
+        ulog_parser_rewind(&ctx->parser);
+    }
+
+    float dur = (float)((double)(ctx->parser.end_timestamp - ctx->parser.start_timestamp) / 1e6);
+    printf("ULog replay: %s (%.1fs, %d index entries)\n", filepath, dur, ctx->parser.index_count);
+    if (ctx->sub_global_pos < 0) printf("  Note: vehicle_global_position not found (using local position)\n");
+    if (ctx->sub_airspeed < 0) printf("  Note: airspeed_validated not found (no airspeed data)\n");
+    if (ctx->sub_vehicle_status < 0) printf("  Note: vehicle_status not found (defaulting to quadrotor)\n");
+
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Advance playback
+// ---------------------------------------------------------------------------
+
+bool ulog_replay_advance(ulog_replay_ctx_t *ctx, float dt, float speed, bool looping, bool interpolation) {
+    ctx->wall_accum += (double)dt * speed;
+    uint64_t target = ctx->parser.start_timestamp + (uint64_t)(ctx->wall_accum * 1e6);
+
+    // Clamp to end
+    if (target > ctx->parser.end_timestamp) {
+        if (looping) {
+            ulog_parser_rewind(&ctx->parser);
+            ctx->wall_accum = 0.0;
+            ctx->first_pos_set = false;
+            ctx->has_global_pos = false;
+            ctx->prev_gpos_usec = 0;
+            ctx->last_pos_usec = 0;
+            ctx->gpos_vx = ctx->gpos_vy = ctx->gpos_vz = 0.0f;
+            return true;
+        }
+        return false;
+    }
+
+    // Read all messages up to target timestamp
+    ulog_data_msg_t dmsg;
+    while (ulog_parser_next(&ctx->parser, &dmsg)) {
+        process_message(ctx, &dmsg);
+        if (dmsg.timestamp >= target) break;
+    }
+
+    // Dead-reckon position forward from last sample using velocity.
+    // This smooths the 5-10 Hz position updates to match the render rate.
+    if (interpolation && ctx->last_pos_usec > 0 && target > ctx->last_pos_usec) {
+        float dt_pos = (float)((double)(target - ctx->last_pos_usec) / 1e6);
+        // Clamp extrapolation to avoid runaway if data is stale
+        if (dt_pos > 0.5f) dt_pos = 0.5f;
+
+        if (ctx->has_global_pos) {
+            // Dead-reckon in global coords using velocity.
+            // Prefer LPOS velocity if non-zero, otherwise use GPOS-derived velocity.
+            float vx = ctx->last_vx, vy = ctx->last_vy, vz = ctx->last_vz;
+            if (vx == 0.0f && vy == 0.0f && vz == 0.0f) {
+                vx = ctx->gpos_vx;
+                vy = ctx->gpos_vy;
+                vz = ctx->gpos_vz;
+            }
+
+            double meters_per_deg_lat = 111132.92;
+            double meters_per_deg_lon = 111132.92 * cos(ctx->last_lat_deg * DEG_TO_RAD);
+            if (meters_per_deg_lon < 1.0) meters_per_deg_lon = 1.0;
+
+            double lat = ctx->last_lat_deg + (double)(vx * dt_pos) / meters_per_deg_lat;
+            double lon = ctx->last_lon_deg + (double)(vy * dt_pos) / meters_per_deg_lon;
+            float alt = ctx->last_alt_m - vz * dt_pos;
+
+            ctx->state.lat = (int32_t)(lat * 1e7);
+            ctx->state.lon = (int32_t)(lon * 1e7);
+            ctx->state.alt = (int32_t)(alt * 1000.0f);
+        } else {
+            // Dead-reckon in local NED, then convert
+            float x = ctx->last_x + ctx->last_vx * dt_pos;
+            float y = ctx->last_y + ctx->last_vy * dt_pos;
+            float z = ctx->last_z + ctx->last_vz * dt_pos;
+
+            local_to_global(ctx->ref_lat, ctx->ref_lon, ctx->ref_alt,
+                            x, y, z,
+                            &ctx->state.lat, &ctx->state.lon, &ctx->state.alt);
+        }
+    }
+
+    if (ctx->parser.eof) {
+        if (looping) {
+            ulog_parser_rewind(&ctx->parser);
+            ctx->wall_accum = 0.0;
+            ctx->first_pos_set = false;
+            return true;
+        }
+        return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Seek
+// ---------------------------------------------------------------------------
+
+void ulog_replay_seek(ulog_replay_ctx_t *ctx, float target_s) {
+    if (target_s < 0.0f) target_s = 0.0f;
+
+    float max_s = (float)((double)(ctx->parser.end_timestamp -
+                                    ctx->parser.start_timestamp) / 1e6);
+    if (target_s > max_s) target_s = max_s;
+
+    uint64_t target_usec = ctx->parser.start_timestamp +
+                           (uint64_t)(target_s * 1e6);
+    ulog_parser_seek(&ctx->parser, target_usec);
+    ctx->wall_accum = (double)target_s;
+
+    // Read forward to populate state at the seek point
+    ulog_data_msg_t dmsg;
+    for (int i = 0; i < 2000 && ulog_parser_next(&ctx->parser, &dmsg); i++) {
+        process_message(ctx, &dmsg);
+        if (dmsg.timestamp >= target_usec) break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+
+void ulog_replay_close(ulog_replay_ctx_t *ctx) {
+    ulog_parser_close(&ctx->parser);
+}

--- a/src/ulog_replay.h
+++ b/src/ulog_replay.h
@@ -1,0 +1,97 @@
+#ifndef ULOG_REPLAY_H
+#define ULOG_REPLAY_H
+
+#include "ulog_parser.h"
+#include "mavlink_receiver.h"  // hil_state_t, home_position_t
+#include <stdbool.h>
+
+// Cached field offsets for fast extraction (resolved once on init)
+typedef struct {
+    int att_q_offset;           // vehicle_attitude: q[4]
+
+    int gpos_lat_offset;        // vehicle_global_position: lat (double, deg)
+    int gpos_lon_offset;        // lon (double, deg)
+    int gpos_alt_offset;        // alt (float, m)
+
+    int lpos_x_offset;          // vehicle_local_position: x (float, m NED)
+    int lpos_y_offset;
+    int lpos_z_offset;
+    int lpos_vx_offset;         // vx (float, m/s NED)
+    int lpos_vy_offset;
+    int lpos_vz_offset;
+    int lpos_ref_lat_offset;    // ref_lat (double, deg)
+    int lpos_ref_lon_offset;    // ref_lon (double, deg)
+    int lpos_ref_alt_offset;    // ref_alt (float, m)
+    int lpos_xy_global_offset;  // xy_global (bool)
+    int lpos_z_global_offset;   // z_global (bool)
+
+    int aspd_ias_offset;        // airspeed_validated: indicated_airspeed_m_s
+    int aspd_tas_offset;        // true_airspeed_m_s
+
+    int vstatus_type_offset;    // vehicle_status: vehicle_type
+    int vstatus_is_vtol_offset; // vehicle_status: is_vtol
+} ulog_field_cache_t;
+
+typedef struct {
+    ulog_parser_t parser;
+
+    // Subscription indices (-1 if topic not found in log)
+    int sub_attitude;
+    int sub_global_pos;
+    int sub_local_pos;
+    int sub_airspeed;
+    int sub_vehicle_status;
+
+    ulog_field_cache_t cache;
+
+    // Current output state
+    hil_state_t state;
+    home_position_t home;
+    uint8_t vehicle_type;
+
+    // Timing
+    double wall_accum;          // accumulated playback time in seconds
+
+    // Position mode: true if vehicle_global_position has data,
+    // false means we derive lat/lon/alt from local position
+    bool has_global_pos;
+
+    // Reference point for local→global conversion (from vehicle_local_position)
+    double ref_lat;             // degrees
+    double ref_lon;             // degrees
+    float ref_alt;              // meters
+    bool ref_set;
+
+    // Last position sample for dead-reckoning interpolation
+    uint64_t last_pos_usec;     // timestamp of last position update
+    float last_x, last_y, last_z;   // local NED position (m)
+    float last_vx, last_vy, last_vz; // local NED velocity (m/s)
+    // For gpos mode: last known lat/lon/alt and derived velocity
+    double last_lat_deg, last_lon_deg;
+    float last_alt_m;
+    double prev_lat_deg, prev_lon_deg; // previous GPOS sample for velocity derivation
+    float prev_alt_m;
+    uint64_t prev_gpos_usec;
+    float gpos_vx, gpos_vy, gpos_vz; // velocity derived from consecutive GPOS samples (m/s NED)
+
+    // First valid position becomes home
+    bool first_pos_set;
+} ulog_replay_ctx_t;
+
+// Initialize replay context, parse file, build index. Returns 0 on success.
+int ulog_replay_init(ulog_replay_ctx_t *ctx, const char *filepath);
+
+// Advance replay by dt seconds at given speed. Returns true if still playing.
+bool ulog_replay_advance(ulog_replay_ctx_t *ctx, float dt, float speed, bool looping, bool interpolation);
+
+// Seek to a specific position in seconds from log start.
+void ulog_replay_seek(ulog_replay_ctx_t *ctx, float target_s);
+
+// Close and free resources.
+void ulog_replay_close(ulog_replay_ctx_t *ctx);
+
+// Future scope: multi-file swarm replay with time synchronization.
+// Each vehicle would get its own ulog_replay_ctx_t with a time_offset
+// to align different log start times to a common playback clock.
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(FIXTURES_DIR ${CMAKE_SOURCE_DIR}/tests/fixtures)
+
+# ULog parser tests
+add_executable(test_ulog_parser test_ulog_parser.c)
+target_link_libraries(test_ulog_parser PRIVATE mavsim-core)
+target_compile_definitions(test_ulog_parser PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
+add_test(NAME ulog_parser COMMAND test_ulog_parser)
+
+# ULog replay tests
+add_executable(test_ulog_replay test_ulog_replay.c)
+target_link_libraries(test_ulog_replay PRIVATE mavsim-core)
+target_compile_definitions(test_ulog_replay PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
+add_test(NAME ulog_replay COMMAND test_ulog_replay)
+
+# Data source integration tests
+add_executable(test_data_source test_data_source.c)
+target_link_libraries(test_data_source PRIVATE mavsim-core)
+target_compile_definitions(test_data_source PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
+add_test(NAME data_source COMMAND test_data_source)

--- a/tests/fixtures/1040ff85-42ce-493a-a281-fa3fdebff96e.ulg
+++ b/tests/fixtures/1040ff85-42ce-493a-a281-fa3fdebff96e.ulg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2165edea301533f833de3c5af3a391b157debabe100972d1775e88007d546610
+size 53026959

--- a/tests/fixtures/6dfd8372-8bb9-4827-8c43-8895f3fe7e7a.ulg
+++ b/tests/fixtures/6dfd8372-8bb9-4827-8c43-8895f3fe7e7a.ulg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e11ef2439b01088aed7b9c5f9b69e537b463b26c3de337d5d671f79b3f4d972
+size 26044769

--- a/tests/fixtures/c83373e1-ee62-4e7e-850b-69316e8641a9.ulg
+++ b/tests/fixtures/c83373e1-ee62-4e7e-850b-69316e8641a9.ulg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dafcfe5a8acfc9571b2746688a5220d77a3d9f1408f143f8b405e8be142b434
+size 6395904

--- a/tests/fixtures/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg
+++ b/tests/fixtures/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93dfd1f09642a556917a8a6da0b888e79df39f9c5d8518044e6e5d3aed22d86a
+size 3856099

--- a/tests/test_data_source.c
+++ b/tests/test_data_source.c
@@ -1,0 +1,97 @@
+#include "data_source.h"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define QUAD_LOG  FIXTURES_DIR "/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg"
+#define FW_LOG    FIXTURES_DIR "/6dfd8372-8bb9-4827-8c43-8895f3fe7e7a.ulg"
+
+static void test_create(void) {
+    data_source_t ds;
+    int ret = data_source_ulog_create(&ds, QUAD_LOG);
+    assert(ret == 0);
+    assert(ds.connected);
+    assert(ds.impl != NULL);
+    data_source_close(&ds);
+    printf("  PASS create\n");
+}
+
+static void test_defaults(void) {
+    data_source_t ds;
+    assert(data_source_ulog_create(&ds, QUAD_LOG) == 0);
+    assert(ds.playback.speed == 1.0f);
+    assert(!ds.playback.paused);
+    assert(!ds.playback.looping);
+    assert(ds.playback.interpolation);
+    data_source_close(&ds);
+    printf("  PASS defaults\n");
+}
+
+static void test_duration(void) {
+    data_source_t ds;
+    assert(data_source_ulog_create(&ds, QUAD_LOG) == 0);
+    data_source_poll(&ds, 0.1f);
+    assert(ds.playback.duration_s > 0.0f);
+    data_source_close(&ds);
+    printf("  PASS duration (%.1fs)\n", ds.playback.duration_s);
+}
+
+static void test_progress_advances(void) {
+    data_source_t ds;
+    assert(data_source_ulog_create(&ds, QUAD_LOG) == 0);
+
+    data_source_poll(&ds, 0.1f);
+    float p1 = ds.playback.progress;
+    data_source_poll(&ds, 0.5f);
+    float p2 = ds.playback.progress;
+    assert(p2 > p1);
+
+    data_source_close(&ds);
+    printf("  PASS progress_advances (%.4f -> %.4f)\n", p1, p2);
+}
+
+static void test_state_propagated(void) {
+    data_source_t ds;
+    assert(data_source_ulog_create(&ds, QUAD_LOG) == 0);
+
+    for (int i = 0; i < 500; i++) {
+        data_source_poll(&ds, 0.05f);
+        if (ds.state.valid) break;
+    }
+    assert(ds.state.valid);
+
+    data_source_close(&ds);
+    printf("  PASS state_propagated\n");
+}
+
+static void test_mav_type_propagated(void) {
+    data_source_t ds;
+    assert(data_source_ulog_create(&ds, FW_LOG) == 0);
+    data_source_poll(&ds, 0.1f);
+    assert(ds.mav_type == 1); // MAV_TYPE_FIXED_WING
+    data_source_close(&ds);
+    printf("  PASS mav_type_propagated\n");
+}
+
+static void test_close(void) {
+    data_source_t ds;
+    assert(data_source_ulog_create(&ds, QUAD_LOG) == 0);
+    data_source_poll(&ds, 0.1f);
+    data_source_close(&ds);
+    assert(ds.impl == NULL);
+    printf("  PASS close\n");
+}
+
+int main(void) {
+    printf("test_data_source:\n");
+    test_create();
+    test_defaults();
+    test_duration();
+    test_progress_advances();
+    test_state_propagated();
+    test_mav_type_propagated();
+    test_close();
+    printf("All tests passed.\n");
+    return 0;
+}

--- a/tests/test_ulog_parser.c
+++ b/tests/test_ulog_parser.c
@@ -1,0 +1,238 @@
+#include "ulog_parser.h"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define QUAD_LOG   FIXTURES_DIR "/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg"
+#define FW_LOG     FIXTURES_DIR "/6dfd8372-8bb9-4827-8c43-8895f3fe7e7a.ulg"
+#define TRUNC_LOG  FIXTURES_DIR "/c83373e1-ee62-4e7e-850b-69316e8641a9.ulg"
+
+static void test_open_valid(void) {
+    ulog_parser_t p;
+    int ret = ulog_parser_open(&p, QUAD_LOG);
+    assert(ret == 0);
+    ulog_parser_close(&p);
+    printf("  PASS open_valid\n");
+}
+
+static void test_open_invalid(void) {
+    ulog_parser_t p;
+    int ret = ulog_parser_open(&p, "/nonexistent/file.ulg");
+    assert(ret != 0);
+    printf("  PASS open_invalid\n");
+}
+
+static void test_format_count(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    assert(p.format_count > 0);
+    ulog_parser_close(&p);
+    printf("  PASS format_count (%d formats)\n", p.format_count);
+}
+
+static void test_sub_count(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    assert(p.sub_count > 0);
+    ulog_parser_close(&p);
+    printf("  PASS sub_count (%d subscriptions)\n", p.sub_count);
+}
+
+static void test_find_subscription(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    int idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
+    assert(idx >= 0);
+    assert(strcmp(p.subs[idx].message_name, "vehicle_attitude") == 0);
+    ulog_parser_close(&p);
+    printf("  PASS find_subscription\n");
+}
+
+static void test_find_subscription_missing(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    int idx = ulog_parser_find_subscription(&p, "nonexistent_topic");
+    assert(idx == -1);
+    ulog_parser_close(&p);
+    printf("  PASS find_subscription_missing\n");
+}
+
+static void test_find_field(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    int sub_idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
+    assert(sub_idx >= 0);
+    int fmt_idx = p.subs[sub_idx].format_idx;
+    assert(fmt_idx >= 0);
+    int offset = ulog_parser_find_field(&p, fmt_idx, "q");
+    assert(offset >= 0);
+    ulog_parser_close(&p);
+    printf("  PASS find_field (q offset=%d)\n", offset);
+}
+
+static void test_find_field_missing(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    int sub_idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
+    int fmt_idx = p.subs[sub_idx].format_idx;
+    int offset = ulog_parser_find_field(&p, fmt_idx, "nonexistent_field");
+    assert(offset == -1);
+    ulog_parser_close(&p);
+    printf("  PASS find_field_missing\n");
+}
+
+static void test_timestamp_range(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    assert(p.start_timestamp > 0);
+    assert(p.end_timestamp > 0);
+    assert(p.end_timestamp > p.start_timestamp);
+    ulog_parser_close(&p);
+    printf("  PASS timestamp_range\n");
+}
+
+static void test_index_built(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    assert(p.index_count > 0);
+    // Verify monotonically increasing timestamps
+    for (int i = 1; i < p.index_count; i++) {
+        assert(p.index[i].timestamp >= p.index[i - 1].timestamp);
+    }
+    ulog_parser_close(&p);
+    printf("  PASS index_built (%d entries)\n", p.index_count);
+}
+
+static void test_iterate_first(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    ulog_data_msg_t msg;
+    bool ok = ulog_parser_next(&p, &msg);
+    assert(ok);
+    assert(msg.timestamp > 0);
+    assert(msg.data != NULL);
+    assert(msg.data_len > 0);
+    ulog_parser_close(&p);
+    printf("  PASS iterate_first\n");
+}
+
+static void test_rewind(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+
+    // Read first message
+    ulog_data_msg_t first;
+    assert(ulog_parser_next(&p, &first));
+    uint64_t first_ts = first.timestamp;
+
+    // Read a few more
+    ulog_data_msg_t msg;
+    for (int i = 0; i < 100; i++) ulog_parser_next(&p, &msg);
+
+    // Rewind and verify first message matches
+    ulog_parser_rewind(&p);
+    assert(ulog_parser_next(&p, &msg));
+    assert(msg.timestamp == first_ts);
+
+    ulog_parser_close(&p);
+    printf("  PASS rewind\n");
+}
+
+static void test_seek_midpoint(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+
+    uint64_t mid = (p.start_timestamp + p.end_timestamp) / 2;
+    ulog_parser_seek(&p, mid);
+
+    ulog_data_msg_t msg;
+    assert(ulog_parser_next(&p, &msg));
+    // Should be within ~2 seconds of the target
+    int64_t diff = (int64_t)(msg.timestamp - mid);
+    if (diff < 0) diff = -diff;
+    assert(diff < 2000000); // 2 seconds in microseconds
+
+    ulog_parser_close(&p);
+    printf("  PASS seek_midpoint\n");
+}
+
+static void test_truncated_file(void) {
+    ulog_parser_t p;
+    int ret = ulog_parser_open(&p, TRUNC_LOG);
+    assert(ret == 0);
+
+    // Iterate through all messages — should hit EOF gracefully
+    ulog_data_msg_t msg;
+    int count = 0;
+    while (ulog_parser_next(&p, &msg)) count++;
+    assert(count > 0);
+    assert(p.eof);
+
+    ulog_parser_close(&p);
+    printf("  PASS truncated_file (%d messages)\n", count);
+}
+
+static void test_field_accessors(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+
+    int sub_idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
+    int fmt_idx = p.subs[sub_idx].format_idx;
+    int q_offset = ulog_parser_find_field(&p, fmt_idx, "q");
+    uint16_t att_msg_id = p.subs[sub_idx].msg_id;
+
+    // Find first attitude message
+    ulog_data_msg_t msg;
+    bool found = false;
+    while (ulog_parser_next(&p, &msg)) {
+        if (msg.msg_id == att_msg_id) {
+            found = true;
+            break;
+        }
+    }
+    assert(found);
+
+    // Read quaternion — should be normalized (w²+x²+y²+z² ≈ 1.0)
+    float w = ulog_parser_get_float(&msg, q_offset + 0);
+    float x = ulog_parser_get_float(&msg, q_offset + 4);
+    float y = ulog_parser_get_float(&msg, q_offset + 8);
+    float z = ulog_parser_get_float(&msg, q_offset + 12);
+    float norm = w * w + x * x + y * y + z * z;
+    assert(!isnan(norm));
+    assert(fabs(norm - 1.0f) < 0.01f);
+
+    ulog_parser_close(&p);
+    printf("  PASS field_accessors (q norm=%.4f)\n", norm);
+}
+
+static void test_fixedwing_subscriptions(void) {
+    ulog_parser_t p;
+    assert(ulog_parser_open(&p, FW_LOG) == 0);
+    int idx = ulog_parser_find_subscription(&p, "airspeed_validated");
+    assert(idx >= 0);
+    ulog_parser_close(&p);
+    printf("  PASS fixedwing_subscriptions\n");
+}
+
+int main(void) {
+    printf("test_ulog_parser:\n");
+    test_open_valid();
+    test_open_invalid();
+    test_format_count();
+    test_sub_count();
+    test_find_subscription();
+    test_find_subscription_missing();
+    test_find_field();
+    test_find_field_missing();
+    test_timestamp_range();
+    test_index_built();
+    test_iterate_first();
+    test_rewind();
+    test_seek_midpoint();
+    test_truncated_file();
+    test_field_accessors();
+    test_fixedwing_subscriptions();
+    printf("All tests passed.\n");
+    return 0;
+}

--- a/tests/test_ulog_replay.c
+++ b/tests/test_ulog_replay.c
@@ -1,0 +1,220 @@
+#include "ulog_replay.h"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define QUAD_LOG   FIXTURES_DIR "/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg"
+#define FW_LOG     FIXTURES_DIR "/6dfd8372-8bb9-4827-8c43-8895f3fe7e7a.ulg"
+
+static void test_init_quadrotor(void) {
+    ulog_replay_ctx_t ctx;
+    int ret = ulog_replay_init(&ctx, QUAD_LOG);
+    assert(ret == 0);
+    assert(ctx.vehicle_type == 2); // MAV_TYPE_QUADROTOR
+    ulog_replay_close(&ctx);
+    printf("  PASS init_quadrotor\n");
+}
+
+static void test_init_fixedwing(void) {
+    ulog_replay_ctx_t ctx;
+    int ret = ulog_replay_init(&ctx, FW_LOG);
+    assert(ret == 0);
+    assert(ctx.vehicle_type == 1); // MAV_TYPE_FIXED_WING
+    ulog_replay_close(&ctx);
+    printf("  PASS init_fixedwing\n");
+}
+
+static void test_state_valid_after_advance(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+
+    // Advance until state becomes valid (may take a few iterations
+    // for position data to arrive)
+    for (int i = 0; i < 500; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.state.valid) break;
+    }
+    assert(ctx.state.valid);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS state_valid_after_advance\n");
+}
+
+static void test_quaternion_normalized(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+
+    for (int i = 0; i < 500; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.state.valid) break;
+    }
+    assert(ctx.state.valid);
+
+    float w = ctx.state.quaternion[0];
+    float x = ctx.state.quaternion[1];
+    float y = ctx.state.quaternion[2];
+    float z = ctx.state.quaternion[3];
+    float norm = w * w + x * x + y * y + z * z;
+    assert(!isnan(norm));
+    assert(fabs(norm - 1.0f) < 0.01f);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS quaternion_normalized (norm=%.4f)\n", norm);
+}
+
+static void test_gps_path(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+
+    for (int i = 0; i < 1000; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.has_global_pos && ctx.state.valid) break;
+    }
+    assert(ctx.has_global_pos);
+    assert(ctx.state.lat != 0 || ctx.state.lon != 0);
+    assert(ctx.state.alt != 0);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS gps_path (lat=%d lon=%d alt=%d)\n",
+           ctx.state.lat, ctx.state.lon, ctx.state.alt);
+}
+
+static void test_local_pos_path(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+
+    for (int i = 0; i < 500; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.state.valid) break;
+    }
+    assert(ctx.state.valid);
+    // Quad log uses local position, not GPS
+    assert(!ctx.has_global_pos);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS local_pos_path\n");
+}
+
+static void test_home_valid(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+
+    for (int i = 0; i < 1000; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.home.valid) break;
+    }
+    assert(ctx.home.valid);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS home_valid\n");
+}
+
+static void test_seek_and_advance(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+
+    float duration = (float)((double)(ctx.parser.end_timestamp -
+                                       ctx.parser.start_timestamp) / 1e6);
+    float target = duration * 0.5f;
+    ulog_replay_seek(&ctx, target);
+
+    // wall_accum should be near the seek target
+    assert(fabs(ctx.wall_accum - target) < 2.0);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS seek_and_advance (target=%.1f, accum=%.1f)\n",
+           target, (float)ctx.wall_accum);
+}
+
+static void test_loop_resets(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+
+    float duration = (float)((double)(ctx.parser.end_timestamp -
+                                       ctx.parser.start_timestamp) / 1e6);
+
+    // Seek near the end and advance past it with looping
+    ulog_replay_seek(&ctx, duration - 0.5f);
+    bool playing = ulog_replay_advance(&ctx, 2.0f, 1.0f, true, true);
+    assert(playing);
+    assert(ctx.wall_accum < 2.0); // should have looped back near 0
+
+    ulog_replay_close(&ctx);
+    printf("  PASS loop_resets (accum=%.2f)\n", (float)ctx.wall_accum);
+}
+
+static void test_end_returns_false(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+
+    float duration = (float)((double)(ctx.parser.end_timestamp -
+                                       ctx.parser.start_timestamp) / 1e6);
+
+    ulog_replay_seek(&ctx, duration - 0.1f);
+    bool playing = true;
+    for (int i = 0; i < 100 && playing; i++) {
+        playing = ulog_replay_advance(&ctx, 0.1f, 1.0f, false, true);
+    }
+    assert(!playing);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS end_returns_false\n");
+}
+
+static void test_airspeed(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+
+    bool found_airspeed = false;
+    for (int i = 0; i < 5000; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.state.ind_airspeed > 0) {
+            found_airspeed = true;
+            break;
+        }
+    }
+    assert(found_airspeed);
+
+    ulog_replay_close(&ctx);
+    printf("  PASS airspeed (ias=%u cm/s)\n", ctx.state.ind_airspeed);
+}
+
+static void test_velocity(void) {
+    ulog_replay_ctx_t ctx;
+    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+
+    for (int i = 0; i < 1000; i++) {
+        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
+        if (ctx.state.valid) break;
+    }
+    assert(ctx.state.valid);
+
+    // Velocity should be within plausible range for an aircraft
+    float vx = ctx.state.vx / 100.0f;
+    float vy = ctx.state.vy / 100.0f;
+    float vz = ctx.state.vz / 100.0f;
+    float speed = sqrtf(vx * vx + vy * vy + vz * vz);
+    assert(speed < 200.0f); // less than 200 m/s
+
+    ulog_replay_close(&ctx);
+    printf("  PASS velocity (speed=%.1f m/s)\n", speed);
+}
+
+int main(void) {
+    printf("test_ulog_replay:\n");
+    test_init_quadrotor();
+    test_init_fixedwing();
+    test_state_valid_after_advance();
+    test_quaternion_normalized();
+    test_gps_path();
+    test_local_pos_path();
+    test_home_valid();
+    test_seek_and_advance();
+    test_loop_resets();
+    test_end_returns_false();
+    test_airspeed();
+    test_velocity();
+    printf("All tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
ULog parser reads PX4 flight logs and replays vehicle state with dead-reckoning interpolation between position samples. Data source layer abstracts live MAVLink vs file replay behind a common interface.

- `--replay <file.ulg>` flag to load a ULog file
- Playback controls: pause/resume (Space), speed (←/→), seek (Shift+←/→), loop (L), interpolation toggle (I)
- GPOS-derived velocity fallback when LPOS has zero data
- 34 CI tests (parser, replay, data source) with ASan/UBSan sanitizer job
- 4 fixture logs covering quadrotor, fixed-wing, optical flow, GPS, and truncated files