### PR TITLE
feat: add release workflow with Homebrew and .deb packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,320 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Job 1: Create source tarball and draft release ─────────────────────────
+  source-tarball:
+    name: Source tarball
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tarball_sha256: ${{ steps.tarball.outputs.sha256 }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create source tarball
+        id: tarball
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          tar czf mavsim-viewer-${VERSION}.tar.gz \
+            --exclude='.git' \
+            --exclude='tests/fixtures/*.ulg' \
+            --exclude='build' \
+            --transform="s,^\.,mavsim-viewer-${VERSION}," \
+            .
+          SHA=$(sha256sum mavsim-viewer-${VERSION}.tar.gz | awk '{print $1}')
+          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Tarball SHA256: ${SHA}"
+
+      - name: Create draft release
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --draft \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload source tarball
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          gh release upload ${{ github.ref_name }} mavsim-viewer-${VERSION}.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Job 2a: macOS arm64 bottle ─────────────────────────────────────────────
+  bottle-arm64:
+    name: Bottle (arm64)
+    needs: source-tarball
+    runs-on: macos-14
+    outputs:
+      bottle_sha256: ${{ steps.bottle.outputs.sha256 }}
+      bottle_tag: ${{ steps.bottle.outputs.tag }}
+
+    steps:
+      - name: Set up tap with formula
+        env:
+          VERSION: ${{ needs.source-tarball.outputs.version }}
+          TARBALL_SHA: ${{ needs.source-tarball.outputs.tarball_sha256 }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          FORMULA_DIR="$(brew --repo)/Library/Taps/mavlink/homebrew-tap/Formula"
+          mkdir -p "$FORMULA_DIR"
+          python3 -c "
+          import os
+          formula = '''class MavsimViewer < Formula
+            desc \"3D MAVLink vehicle viewer for SITL simulation\"
+            homepage \"https://github.com/mavlink/mavsim-viewer\"
+            url \"https://github.com/mavlink/mavsim-viewer/releases/download/{tag}/mavsim-viewer-{version}.tar.gz\"
+            sha256 \"{sha}\"
+            license \"BSD-3-Clause\"
+
+            depends_on \"cmake\" => :build
+
+            def install
+              system \"cmake\", \"-S\", \".\", \"-B\", \"build\", \"-DCMAKE_BUILD_TYPE=Release\", *std_cmake_args
+              system \"cmake\", \"--build\", \"build\"
+              system \"cmake\", \"--install\", \"build\", \"--prefix\", prefix
+            end
+
+            test do
+              assert_predicate bin/\"mavsim-viewer\", :executable?
+            end
+          end
+          '''.format(
+              tag=os.environ['TAG'],
+              version=os.environ['VERSION'],
+              sha=os.environ['TARBALL_SHA'],
+          )
+          with open(os.environ['FORMULA_DIR'] + '/mavsim-viewer.rb', 'w') as f:
+              f.write(formula)
+          " FORMULA_DIR="$FORMULA_DIR"
+
+      - name: Build bottle
+        run: brew install --build-bottle mavlink/tap/mavsim-viewer
+
+      - name: Package bottle
+        id: bottle
+        run: |
+          TAG=${{ github.ref_name }}
+          brew bottle \
+            --json \
+            --root-url="https://github.com/mavlink/mavsim-viewer/releases/download/${TAG}" \
+            mavlink/tap/mavsim-viewer
+
+          BOTTLE_JSON=$(ls mavsim-viewer--*.bottle.json)
+          BOTTLE_FILE=$(ls mavsim-viewer--*.bottle.tar.gz)
+          CLEAN_NAME=$(echo "$BOTTLE_FILE" | sed 's/--/-/')
+          mv "$BOTTLE_FILE" "$CLEAN_NAME"
+
+          BOTTLE_SHA=$(python3 -c "
+          import json, sys
+          data = json.load(open(sys.argv[1]))
+          tags = data['mavsim-viewer']['bottle']['tags']
+          tag = list(tags.keys())[0]
+          print(tags[tag]['sha256'])
+          " "$BOTTLE_JSON")
+
+          BOTTLE_TAG=$(python3 -c "
+          import json, sys
+          data = json.load(open(sys.argv[1]))
+          tags = data['mavsim-viewer']['bottle']['tags']
+          print(list(tags.keys())[0])
+          " "$BOTTLE_JSON")
+
+          echo "sha256=${BOTTLE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "tag=${BOTTLE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "file=${CLEAN_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bottle to release
+        run: gh release upload ${{ github.ref_name }} ${{ steps.bottle.outputs.file }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Job 2b: macOS x86_64 bottle ───────────────────────────────────────────
+  bottle-x86_64:
+    name: Bottle (x86_64)
+    needs: source-tarball
+    runs-on: macos-13
+    outputs:
+      bottle_sha256: ${{ steps.bottle.outputs.sha256 }}
+      bottle_tag: ${{ steps.bottle.outputs.tag }}
+
+    steps:
+      - name: Set up tap with formula
+        env:
+          VERSION: ${{ needs.source-tarball.outputs.version }}
+          TARBALL_SHA: ${{ needs.source-tarball.outputs.tarball_sha256 }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          FORMULA_DIR="$(brew --repo)/Library/Taps/mavlink/homebrew-tap/Formula"
+          mkdir -p "$FORMULA_DIR"
+          python3 -c "
+          import os
+          formula = '''class MavsimViewer < Formula
+            desc \"3D MAVLink vehicle viewer for SITL simulation\"
+            homepage \"https://github.com/mavlink/mavsim-viewer\"
+            url \"https://github.com/mavlink/mavsim-viewer/releases/download/{tag}/mavsim-viewer-{version}.tar.gz\"
+            sha256 \"{sha}\"
+            license \"BSD-3-Clause\"
+
+            depends_on \"cmake\" => :build
+
+            def install
+              system \"cmake\", \"-S\", \".\", \"-B\", \"build\", \"-DCMAKE_BUILD_TYPE=Release\", *std_cmake_args
+              system \"cmake\", \"--build\", \"build\"
+              system \"cmake\", \"--install\", \"build\", \"--prefix\", prefix
+            end
+
+            test do
+              assert_predicate bin/\"mavsim-viewer\", :executable?
+            end
+          end
+          '''.format(
+              tag=os.environ['TAG'],
+              version=os.environ['VERSION'],
+              sha=os.environ['TARBALL_SHA'],
+          )
+          with open(os.environ['FORMULA_DIR'] + '/mavsim-viewer.rb', 'w') as f:
+              f.write(formula)
+          " FORMULA_DIR="$FORMULA_DIR"
+
+      - name: Build bottle
+        run: brew install --build-bottle mavlink/tap/mavsim-viewer
+
+      - name: Package bottle
+        id: bottle
+        run: |
+          TAG=${{ github.ref_name }}
+          brew bottle \
+            --json \
+            --root-url="https://github.com/mavlink/mavsim-viewer/releases/download/${TAG}" \
+            mavlink/tap/mavsim-viewer
+
+          BOTTLE_JSON=$(ls mavsim-viewer--*.bottle.json)
+          BOTTLE_FILE=$(ls mavsim-viewer--*.bottle.tar.gz)
+          CLEAN_NAME=$(echo "$BOTTLE_FILE" | sed 's/--/-/')
+          mv "$BOTTLE_FILE" "$CLEAN_NAME"
+
+          BOTTLE_SHA=$(python3 -c "
+          import json, sys
+          data = json.load(open(sys.argv[1]))
+          tags = data['mavsim-viewer']['bottle']['tags']
+          tag = list(tags.keys())[0]
+          print(tags[tag]['sha256'])
+          " "$BOTTLE_JSON")
+
+          BOTTLE_TAG=$(python3 -c "
+          import json, sys
+          data = json.load(open(sys.argv[1]))
+          tags = data['mavsim-viewer']['bottle']['tags']
+          print(list(tags.keys())[0])
+          " "$BOTTLE_JSON")
+
+          echo "sha256=${BOTTLE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "tag=${BOTTLE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "file=${CLEAN_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bottle to release
+        run: gh release upload ${{ github.ref_name }} ${{ steps.bottle.outputs.file }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Job 3: Publish the release ─────────────────────────────────────────────
+  publish-release:
+    name: Publish release
+    needs: [bottle-arm64, bottle-x86_64]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark release as published
+        run: |
+          gh release edit ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Job 4: Update Homebrew tap ─────────────────────────────────────────────
+  update-tap:
+    name: Update Homebrew tap
+    needs: [source-tarball, bottle-arm64, bottle-x86_64, publish-release]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update formula in tap
+        env:
+          VERSION: ${{ needs.source-tarball.outputs.version }}
+          TAG: ${{ github.ref_name }}
+          TARBALL_SHA: ${{ needs.source-tarball.outputs.tarball_sha256 }}
+          ARM64_SHA: ${{ needs.bottle-arm64.outputs.bottle_sha256 }}
+          ARM64_TAG: ${{ needs.bottle-arm64.outputs.bottle_tag }}
+          X86_SHA: ${{ needs.bottle-x86_64.outputs.bottle_sha256 }}
+          X86_TAG: ${{ needs.bottle-x86_64.outputs.bottle_tag }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone https://x-access-token:${TAP_TOKEN}@github.com/mavlink/homebrew-tap.git tap
+          mkdir -p tap/Formula
+
+          python3 -c "
+          import os
+          formula = '''class MavsimViewer < Formula
+            desc \"3D MAVLink vehicle viewer for SITL simulation\"
+            homepage \"https://github.com/mavlink/mavsim-viewer\"
+            url \"https://github.com/mavlink/mavsim-viewer/releases/download/{tag}/mavsim-viewer-{version}.tar.gz\"
+            sha256 \"{tarball_sha}\"
+            license \"BSD-3-Clause\"
+
+            bottle do
+              root_url \"https://github.com/mavlink/mavsim-viewer/releases/download/{tag}\"
+              sha256 cellar: :any_skip_relocation, {arm64_tag}: \"{arm64_sha}\"
+              sha256 cellar: :any_skip_relocation, {x86_tag}: \"{x86_sha}\"
+            end
+
+            depends_on \"cmake\" => :build
+
+            def install
+              system \"cmake\", \"-S\", \".\", \"-B\", \"build\",
+                     \"-DCMAKE_BUILD_TYPE=Release\",
+                     *std_cmake_args
+              system \"cmake\", \"--build\", \"build\"
+              system \"cmake\", \"--install\", \"build\", \"--prefix\", prefix
+            end
+
+            test do
+              assert_predicate bin/\"mavsim-viewer\", :executable?
+            end
+          end
+          '''.format(
+              tag=os.environ['TAG'],
+              version=os.environ['VERSION'],
+              tarball_sha=os.environ['TARBALL_SHA'],
+              arm64_sha=os.environ['ARM64_SHA'],
+              arm64_tag=os.environ['ARM64_TAG'],
+              x86_sha=os.environ['X86_SHA'],
+              x86_tag=os.environ['X86_TAG'],
+          )
+          with open('tap/Formula/mavsim-viewer.rb', 'w') as f:
+              f.write(formula)
+          "
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/mavsim-viewer.rb
+          git commit -m "mavsim-viewer ${VERSION}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,10 +234,53 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # ── Job 2c: Linux amd64 .deb ──────────────────────────────────────────────
+  deb-amd64:
+    name: Deb (amd64)
+    needs: source-tarball
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev \
+            libxinerama-dev libxcursor-dev libxi-dev
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DMAVSIM_VERSION=${{ needs.source-tarball.outputs.version }}
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Package .deb
+        run: cd build && cpack -G DEB
+
+      - name: Smoke test
+        run: |
+          sudo dpkg -i build/*.deb
+          which mavsim-viewer
+          ls /usr/share/mavsim-viewer/models/
+          ls /usr/share/mavsim-viewer/shaders/
+          ls /usr/share/mavsim-viewer/fonts/
+
+      - name: Upload .deb to release
+        run: gh release upload ${{ github.ref_name }} build/*.deb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # ── Job 3: Publish the release ─────────────────────────────────────────────
   publish-release:
     name: Publish release
-    needs: [bottle-arm64, bottle-x86_64]
+    needs: [bottle-arm64, bottle-x86_64, deb-amd64]
     runs-on: ubuntu-latest
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if(NOT BUILD_TESTING_ONLY)
         src/hud.c
         src/debug_panel.c
         src/ortho_panel.c
+        src/asset_path.c
     )
 
     target_include_directories(mavsim-viewer PRIVATE
@@ -85,4 +86,21 @@ if(NOT BUILD_TESTING_ONLY)
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_SOURCE_DIR}/textures $<TARGET_FILE_DIR:mavsim-viewer>/textures
     )
+
+    # Install rules
+    include(GNUInstallDirs)
+
+    target_compile_definitions(mavsim-viewer PRIVATE
+        MAVSIM_INSTALL_DATADIR="${CMAKE_INSTALL_FULL_DATADIR}/mavsim-viewer")
+
+    install(TARGETS mavsim-viewer RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(DIRECTORY models/ DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/models
+            FILES_MATCHING PATTERN "*.obj" PATTERN "*.mtl")
+    install(DIRECTORY shaders/ DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/shaders
+            FILES_MATCHING PATTERN "*.vs" PATTERN "*.fs")
+    install(DIRECTORY fonts/ DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/fonts
+            FILES_MATCHING PATTERN "*.ttf")
+    install(DIRECTORY textures/ DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/textures
+            FILES_MATCHING PATTERN "*.png")
+    install(FILES fonts/OFL.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/fonts)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,4 +103,18 @@ if(NOT BUILD_TESTING_ONLY)
     install(DIRECTORY textures/ DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/textures
             FILES_MATCHING PATTERN "*.png")
     install(FILES fonts/OFL.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/mavsim-viewer/fonts)
+
+    # CPack packaging
+    set(CPACK_PACKAGE_NAME "mavsim-viewer")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "3D MAVLink vehicle viewer for SITL simulation")
+    set(CPACK_PACKAGE_CONTACT "https://github.com/mavlink/mavsim-viewer")
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS
+        "libgl1, libx11-6, libxrandr2, libxinerama1, libxcursor1, libxi6")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "science")
+    set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+    if(DEFINED MAVSIM_VERSION)
+        set(CPACK_PACKAGE_VERSION "${MAVSIM_VERSION}")
+    endif()
+    include(CPack)
 endif()

--- a/Formula/mavsim-viewer.rb
+++ b/Formula/mavsim-viewer.rb
@@ -1,0 +1,23 @@
+# Reference template — the canonical formula lives in mavlink/homebrew-tap
+# and is automatically updated by .github/workflows/release.yml on each release.
+class MavsimViewer < Formula
+  desc "3D MAVLink vehicle viewer for SITL simulation"
+  homepage "https://github.com/mavlink/mavsim-viewer"
+  url "https://github.com/mavlink/mavsim-viewer/releases/download/vVERSION/mavsim-viewer-VERSION.tar.gz"
+  sha256 "TODO"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+           "-DCMAKE_BUILD_TYPE=Release",
+           *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build", "--prefix", prefix
+  end
+
+  test do
+    assert_predicate bin/"mavsim-viewer", :executable?
+  end
+end

--- a/src/asset_path.c
+++ b/src/asset_path.c
@@ -1,0 +1,123 @@
+#include "asset_path.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define mkdir_p(path) _mkdir(path)
+#else
+#include <unistd.h>
+#define mkdir_p(path) mkdir(path, 0755)
+#endif
+
+// Cached base directories (set once in asset_path_init)
+static char s_user_data[512];    // user-writable data dir
+static char s_install_data[512]; // system install dir (compile-time)
+
+static int file_exists(const char *path) {
+#ifdef _WIN32
+    struct _stat st;
+    return _stat(path, &st) == 0;
+#else
+    return access(path, R_OK) == 0;
+#endif
+}
+
+// Recursively create directories for a file path
+static void mkdirs_for_file(const char *filepath) {
+    char tmp[512];
+    snprintf(tmp, sizeof(tmp), "%s", filepath);
+
+    // Find last separator
+    char *last_sep = strrchr(tmp, '/');
+#ifdef _WIN32
+    char *last_bsep = strrchr(tmp, '\\');
+    if (last_bsep > last_sep) last_sep = last_bsep;
+#endif
+    if (!last_sep) return;
+    *last_sep = '\0';
+
+    // Create each directory component
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/'
+#ifdef _WIN32
+            || *p == '\\'
+#endif
+        ) {
+            *p = '\0';
+            mkdir_p(tmp);
+            *p = '/';
+        }
+    }
+    mkdir_p(tmp);
+}
+
+void asset_path_init(void) {
+    s_user_data[0] = '\0';
+    s_install_data[0] = '\0';
+
+#ifdef __APPLE__
+    const char *home = getenv("HOME");
+    if (home) {
+        snprintf(s_user_data, sizeof(s_user_data),
+                 "%s/Library/Application Support/mavsim-viewer", home);
+    }
+#elif !defined(_WIN32)
+    // Linux: XDG_DATA_HOME or ~/.local/share
+    const char *xdg = getenv("XDG_DATA_HOME");
+    if (xdg && xdg[0]) {
+        snprintf(s_user_data, sizeof(s_user_data),
+                 "%s/mavsim-viewer", xdg);
+    } else {
+        const char *home = getenv("HOME");
+        if (home) {
+            snprintf(s_user_data, sizeof(s_user_data),
+                     "%s/.local/share/mavsim-viewer", home);
+        }
+    }
+#endif
+
+    // Compile-time install prefix (set by CMake)
+#ifdef MAVSIM_INSTALL_DATADIR
+    snprintf(s_install_data, sizeof(s_install_data),
+             "%s", MAVSIM_INSTALL_DATADIR);
+#endif
+}
+
+void asset_path(const char *subpath, char *out, size_t out_size) {
+    char candidate[512];
+
+    // 1. User data directory
+    if (s_user_data[0]) {
+        snprintf(candidate, sizeof(candidate), "%s/%s", s_user_data, subpath);
+        if (file_exists(candidate)) {
+            snprintf(out, out_size, "%s", candidate);
+            return;
+        }
+    }
+
+    // 2. System install directory
+    if (s_install_data[0]) {
+        snprintf(candidate, sizeof(candidate), "%s/%s", s_install_data, subpath);
+        if (file_exists(candidate)) {
+            snprintf(out, out_size, "%s", candidate);
+            return;
+        }
+    }
+
+    // 3. Relative path (dev/build fallback)
+    snprintf(out, out_size, "%s", subpath);
+}
+
+void asset_write_path(const char *subpath, char *out, size_t out_size) {
+    if (s_user_data[0]) {
+        snprintf(out, out_size, "%s/%s", s_user_data, subpath);
+        mkdirs_for_file(out);
+    } else {
+        // Fallback to relative path
+        snprintf(out, out_size, "%s", subpath);
+    }
+}

--- a/src/asset_path.h
+++ b/src/asset_path.h
@@ -1,0 +1,23 @@
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+// Initialize asset path resolution. Call once at startup.
+void asset_path_init(void);
+
+// Resolve an asset subpath (e.g. "models/px4_quadrotor.obj") to a full path.
+// Writes into caller-provided buffer. Search order:
+//   macOS:  ~/Library/Application Support/mavsim-viewer/<subpath>
+//   Linux:  $XDG_DATA_HOME/mavsim-viewer/<subpath>
+//   Then:   MAVSIM_INSTALL_DATADIR/<subpath>  (compile-time install prefix)
+//   Then:   ./<subpath>                        (dev/build fallback)
+void asset_path(const char *subpath, char *out, size_t out_size);
+
+// Get a writable path for an asset (for generated files like terrain texture).
+// Always returns the user data directory path, creating directories as needed.
+//   macOS:  ~/Library/Application Support/mavsim-viewer/<subpath>
+//   Linux:  $XDG_DATA_HOME/mavsim-viewer/<subpath>
+void asset_write_path(const char *subpath, char *out, size_t out_size);
+
+#endif

--- a/src/hud.c
+++ b/src/hud.c
@@ -1,4 +1,5 @@
 #include "hud.h"
+#include "asset_path.h"
 #include "raylib.h"
 #include "raymath.h"
 
@@ -44,8 +45,11 @@ void hud_init(hud_t *h) {
     for (int i = 0; i < HUD_MAX_PINNED; i++)
         h->pinned[i] = -1;
 
-    h->font_value = LoadFontEx("fonts/JetBrainsMono-Medium.ttf", 64, NULL, 0);
-    h->font_label = LoadFontEx("fonts/Inter-Medium.ttf", 48, NULL, 0);
+    char font_path[512];
+    asset_path("fonts/JetBrainsMono-Medium.ttf", font_path, sizeof(font_path));
+    h->font_value = LoadFontEx(font_path, 64, NULL, 0);
+    asset_path("fonts/Inter-Medium.ttf", font_path, sizeof(font_path));
+    h->font_label = LoadFontEx(font_path, 48, NULL, 0);
 
     SetTextureFilter(h->font_value.texture, TEXTURE_FILTER_BILINEAR);
     SetTextureFilter(h->font_label.texture, TEXTURE_FILTER_BILINEAR);

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "hud.h"
 #include "debug_panel.h"
 #include "ortho_panel.h"
+#include "asset_path.h"
 
 #define MAX_VEHICLES 16
 
@@ -95,6 +96,8 @@ int main(int argc, char *argv[]) {
             return 0;
         }
     }
+
+    asset_path_init();
 
     // Init Raylib
     SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_WINDOW_RESIZABLE);

--- a/src/scene.c
+++ b/src/scene.c
@@ -1,4 +1,5 @@
 #include "scene.h"
+#include "asset_path.h"
 #include "raymath.h"
 #include "rlgl.h"
 #include <stdlib.h>
@@ -241,7 +242,10 @@ void scene_init(scene_t *s) {
     };
 
     // Grid shader and plane (100x100 subdivisions for fwidth() precision)
-    s->grid_shader = LoadShader("shaders/grid.vs", "shaders/grid.fs");
+    char vs_path[512], fs_path[512];
+    asset_path("shaders/grid.vs", vs_path, sizeof(vs_path));
+    asset_path("shaders/grid.fs", fs_path, sizeof(fs_path));
+    s->grid_shader = LoadShader(vs_path, fs_path);
     s->loc_colGround  = GetShaderLocation(s->grid_shader, "colGround");
     s->loc_colMinor   = GetShaderLocation(s->grid_shader, "colMinor");
     s->loc_colMajor   = GetShaderLocation(s->grid_shader, "colMajor");
@@ -259,13 +263,17 @@ void scene_init(scene_t *s) {
 
     // Load terrain texture from pre-baked PNG
     double t0 = GetTime();
-    Image terrain_img = LoadImage("textures/terrain.png");
+    char terrain_path[512];
+    asset_path("textures/terrain.png", terrain_path, sizeof(terrain_path));
+    Image terrain_img = LoadImage(terrain_path);
     if (terrain_img.data == NULL) {
-        // Fallback: generate procedurally and export
+        // Fallback: generate procedurally and export to user data dir
         printf("Generating terrain texture...\n");
         s->ground_tex = gen_ground_texture();
         Image export_img = LoadImageFromTexture(s->ground_tex);
-        ExportImage(export_img, "textures/terrain.png");
+        char terrain_write[512];
+        asset_write_path("textures/terrain.png", terrain_write, sizeof(terrain_write));
+        ExportImage(export_img, terrain_write);
         UnloadImage(export_img);
         printf("Terrain texture: %dx%d (%d tiles) exported to textures/terrain.png\n",
                GTEX_ATLAS_W, GTEX_ATLAS_H, GTEX_VARIANTS);
@@ -285,7 +293,9 @@ void scene_init(scene_t *s) {
     s->grid_plane.materials[0].shader = s->grid_shader;
 
     // Vehicle lighting shader — single directional light
-    s->lighting_shader = LoadShader("shaders/lighting.vs", "shaders/lighting.fs");
+    asset_path("shaders/lighting.vs", vs_path, sizeof(vs_path));
+    asset_path("shaders/lighting.fs", fs_path, sizeof(fs_path));
+    s->lighting_shader = LoadShader(vs_path, fs_path);
     s->loc_lightDir  = GetShaderLocation(s->lighting_shader, "lightDir");
     s->loc_ambient   = GetShaderLocation(s->lighting_shader, "ambient");
     s->loc_matNormal = GetShaderLocation(s->lighting_shader, "matNormal");

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -1,4 +1,5 @@
 #include "vehicle.h"
+#include "asset_path.h"
 #include "raymath.h"
 #include "rlgl.h"
 #ifdef _MSC_VER
@@ -74,7 +75,9 @@ void vehicle_load_model(vehicle_t *v, int model_idx) {
     v->pitch_offset_deg = info->pitch_offset_deg;
     v->yaw_offset_deg = info->yaw_offset_deg;
 
-    v->model = LoadModel(info->path);
+    char model_path[512];
+    asset_path(info->path, model_path, sizeof(model_path));
+    v->model = LoadModel(model_path);
     if (v->model.meshCount == 0)
         printf("Warning: failed to load model %s\n", info->path);
 


### PR DESCRIPTION
Add asset path resolution for installed builds and a tag-triggered release workflow.

**Asset path module (`src/asset_path.c`):**
- Resolves assets via user data dir → install prefix → relative fallback
- macOS: `~/Library/Application Support/mavsim-viewer/`
- Linux: `$XDG_DATA_HOME/mavsim-viewer/`
- Compile-time `MAVSIM_INSTALL_DATADIR` for system installs
- Dev builds unchanged (relative path fallback)

**Release workflow (`.github/workflows/release.yml`):**
- Triggered by version tags (`v*`)
- Creates source tarball with submodule baked in
- Builds Homebrew bottles for macOS arm64 (macos-14) and x86_64 (macos-13)
- Builds `.deb` for Linux amd64 with smoke test
- Publishes GitHub Release with all artifacts
- Updates `mavlink/homebrew-tap` formula with bottle hashes

**CMake install rules:**
- Binary → `bin/mavsim-viewer`
- Assets → `share/mavsim-viewer/{models,shaders,fonts,textures}/`
- CPack DEB config with runtime X11/GL dependencies

**Requires:** `HOMEBREW_TAP_TOKEN` secret (already configured)

Users install via:
```
brew install mavlink/tap/mavsim-viewer
```
or on Linux:
```
sudo dpkg -i mavsim-viewer_x.y.z_amd64.deb
```