### PR TITLE
fix: heap-allocate ulog structs in tests to fix Windows stack overflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
         run: make BUILD_TYPE=${{ matrix.build_type }}
 
       - name: Test
-        if: runner.os != 'Windows'
         run: make test BUILD_TYPE=${{ matrix.build_type }}
 
   test:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,40 +2,43 @@ set(FIXTURES_DIR ${CMAKE_SOURCE_DIR}/tests/fixtures)
 
 # Tests use assert() for both setup and checks — ensure NDEBUG is never set
 # so asserts are always active, even in Release builds.
-remove_definitions(-DNDEBUG)
+# remove_definitions is a no-op on per-target flags added by CMake, so we
+# strip them from the Release flags directly.
+if(MSVC)
+    string(REPLACE "/DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+    string(REPLACE "/DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+else()
+    string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+    string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+endif()
 
 # ULog parser tests
 add_executable(test_ulog_parser test_ulog_parser.c)
 target_link_libraries(test_ulog_parser PRIVATE mavsim-core)
 target_compile_definitions(test_ulog_parser PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
-target_compile_options(test_ulog_parser PRIVATE -UNDEBUG)
 add_test(NAME ulog_parser COMMAND test_ulog_parser)
 
 # ULog replay tests
 add_executable(test_ulog_replay test_ulog_replay.c)
 target_link_libraries(test_ulog_replay PRIVATE mavsim-core)
 target_compile_definitions(test_ulog_replay PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
-target_compile_options(test_ulog_replay PRIVATE -UNDEBUG)
 add_test(NAME ulog_replay COMMAND test_ulog_replay)
 
 # Data source integration tests
 add_executable(test_data_source test_data_source.c)
 target_link_libraries(test_data_source PRIVATE mavsim-core)
 target_compile_definitions(test_data_source PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
-target_compile_options(test_data_source PRIVATE -UNDEBUG)
 add_test(NAME data_source COMMAND test_data_source)
 
 # Algorithm tests (CUSUM takeoff detection, Pearson correlation, home tier)
 add_executable(test_algorithms test_algorithms.c)
 target_link_libraries(test_algorithms PRIVATE mavsim-core)
 target_compile_definitions(test_algorithms PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
-target_compile_options(test_algorithms PRIVATE -UNDEBUG)
 add_test(NAME algorithms COMMAND test_algorithms)
 
 # UI logic tests (vehicle selection, edge-indicator math — no Raylib needed)
 add_executable(test_ui_logic test_ui_logic.c)
 target_include_directories(test_ui_logic PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_compile_options(test_ui_logic PRIVATE -UNDEBUG)
 if(UNIX AND NOT APPLE)
     target_link_libraries(test_ui_logic PRIVATE m)
 endif()
@@ -52,6 +55,5 @@ if(TARGET raylib)
     target_include_directories(test_theme PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_link_libraries(test_theme PRIVATE raylib)
     target_compile_definitions(test_theme PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")
-    target_compile_options(test_theme PRIVATE -UNDEBUG)
     add_test(NAME theme COMMAND test_theme)
 endif()

--- a/tests/test_algorithms.c
+++ b/tests/test_algorithms.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define QUAD_LOG   FIXTURES_DIR "/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg"
@@ -14,90 +15,102 @@
 // ── CUSUM takeoff detection tests ───────────────────────────────────────────
 
 static void test_cusum_quad_takeoff_detected(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
-    assert(ctx.takeoff_detected);
-    assert(ctx.takeoff_time_s > 0.0f);
+    assert(ctx->takeoff_detected);
+    assert(ctx->takeoff_time_s > 0.0f);
 
-    float duration = (float)((double)(ctx.parser.end_timestamp -
-                                       ctx.parser.start_timestamp) / 1e6);
-    assert(ctx.takeoff_time_s < duration);
+    float duration = (float)((double)(ctx->parser.end_timestamp -
+                                       ctx->parser.start_timestamp) / 1e6);
+    assert(ctx->takeoff_time_s < duration);
 
-    ulog_replay_close(&ctx);
+    float t = ctx->takeoff_time_s;
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS cusum_quad_takeoff_detected (t=%.1fs within %.1fs log)\n",
-           ctx.takeoff_time_s, duration);
+           t, duration);
 }
 
 static void test_cusum_confidence_range(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
-    assert(ctx.takeoff_conf >= 0.0f);
-    assert(ctx.takeoff_conf <= 1.0f);
+    assert(ctx->takeoff_conf >= 0.0f);
+    assert(ctx->takeoff_conf <= 1.0f);
     // CUSUM alone gives at least 0.3 when triggered
-    assert(ctx.takeoff_conf >= 0.3f);
+    assert(ctx->takeoff_conf >= 0.3f);
 
-    ulog_replay_close(&ctx);
-    printf("  PASS cusum_confidence_range (conf=%.0f%%)\n", ctx.takeoff_conf * 100);
+    float conf = ctx->takeoff_conf;
+    ulog_replay_close(ctx);
+    free(ctx);
+    printf("  PASS cusum_confidence_range (conf=%.0f%%)\n", conf * 100);
 }
 
 static void test_cusum_fw_takeoff_detected(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, FW_LOG) == 0);
 
     // Fixed-wing log should also have a detectable takeoff
     // (if not, the test documents the actual behavior)
-    if (ctx.takeoff_detected) {
-        assert(ctx.takeoff_time_s > 0.0f);
-        assert(ctx.takeoff_conf >= 0.3f);
-        assert(ctx.takeoff_conf <= 1.0f);
+    if (ctx->takeoff_detected) {
+        assert(ctx->takeoff_time_s > 0.0f);
+        assert(ctx->takeoff_conf >= 0.3f);
+        assert(ctx->takeoff_conf <= 1.0f);
         printf("  PASS cusum_fw_takeoff_detected (t=%.1fs, conf=%.0f%%)\n",
-               ctx.takeoff_time_s, ctx.takeoff_conf * 100);
+               ctx->takeoff_time_s, ctx->takeoff_conf * 100);
     } else {
         // Not detected is acceptable for some logs (already airborne at log start)
-        assert(ctx.takeoff_time_s == 0.0f);
+        assert(ctx->takeoff_time_s == 0.0f);
         printf("  PASS cusum_fw_takeoff_detected (not detected, conf=%.0f%%)\n",
-               ctx.takeoff_conf * 100);
+               ctx->takeoff_conf * 100);
     }
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
 }
 
 // ── Home position tier resolution tests ─────────────────────────────────────
 
 static void test_home_tier_fw(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, FW_LOG) == 0);
 
     // FW log with GPS should have a valid home from either Tier 1 or Tier 2
-    assert(ctx.home.valid);
+    assert(ctx->home.valid);
     // Position should be non-zero
-    assert(ctx.home.lat != 0 || ctx.home.lon != 0);
+    assert(ctx->home.lat != 0 || ctx->home.lon != 0);
 
     printf("  PASS home_tier_fw (valid=%d, from_topic=%d, rejected=%d, "
            "lat=%d, lon=%d)\n",
-           ctx.home.valid, ctx.home_from_topic, ctx.home_rejected,
-           ctx.home.lat, ctx.home.lon);
-    ulog_replay_close(&ctx);
+           ctx->home.valid, ctx->home_from_topic, ctx->home_rejected,
+           ctx->home.lat, ctx->home.lon);
+    ulog_replay_close(ctx);
+    free(ctx);
 }
 
 static void test_home_tier_quad(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
     // Document the quad log's home resolution behavior.
     // Indoor/local-only logs may have home rejected (no GPOS).
-    if (ctx.home.valid) {
-        assert(ctx.home.lat != 0 || ctx.home.lon != 0);
+    if (ctx->home.valid) {
+        assert(ctx->home.lat != 0 || ctx->home.lon != 0);
         printf("  PASS home_tier_quad (valid, from_topic=%d)\n",
-               ctx.home_from_topic);
+               ctx->home_from_topic);
     } else {
         printf("  PASS home_tier_quad (no valid home, rejected=%d)\n",
-               ctx.home_rejected);
+               ctx->home_rejected);
     }
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
 }
 
 // ── Correlation computation tests ───────────────────────────────────────────

--- a/tests/test_ulog_parser.c
+++ b/tests/test_ulog_parser.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define QUAD_LOG   FIXTURES_DIR "/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg"
@@ -9,183 +10,215 @@
 #define TRUNC_LOG  FIXTURES_DIR "/c83373e1-ee62-4e7e-850b-69316e8641a9.ulg"
 
 static void test_open_valid(void) {
-    ulog_parser_t p;
-    int ret = ulog_parser_open(&p, QUAD_LOG);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    int ret = ulog_parser_open(p, QUAD_LOG);
     assert(ret == 0);
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS open_valid\n");
 }
 
 static void test_open_invalid(void) {
-    ulog_parser_t p;
-    int ret = ulog_parser_open(&p, "/nonexistent/file.ulg");
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    int ret = ulog_parser_open(p, "/nonexistent/file.ulg");
     assert(ret != 0);
+    free(p);
     printf("  PASS open_invalid\n");
 }
 
 static void test_format_count(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    assert(p.format_count > 0);
-    ulog_parser_close(&p);
-    printf("  PASS format_count (%d formats)\n", p.format_count);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    assert(p->format_count > 0);
+    int fc = p->format_count;
+    ulog_parser_close(p);
+    free(p);
+    printf("  PASS format_count (%d formats)\n", fc);
 }
 
 static void test_sub_count(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    assert(p.sub_count > 0);
-    ulog_parser_close(&p);
-    printf("  PASS sub_count (%d subscriptions)\n", p.sub_count);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    assert(p->sub_count > 0);
+    int sc = p->sub_count;
+    ulog_parser_close(p);
+    free(p);
+    printf("  PASS sub_count (%d subscriptions)\n", sc);
 }
 
 static void test_find_subscription(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    int idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    int idx = ulog_parser_find_subscription(p, "vehicle_attitude");
     assert(idx >= 0);
-    assert(strcmp(p.subs[idx].message_name, "vehicle_attitude") == 0);
-    ulog_parser_close(&p);
+    assert(strcmp(p->subs[idx].message_name, "vehicle_attitude") == 0);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS find_subscription\n");
 }
 
 static void test_find_subscription_missing(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    int idx = ulog_parser_find_subscription(&p, "nonexistent_topic");
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    int idx = ulog_parser_find_subscription(p, "nonexistent_topic");
     assert(idx == -1);
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS find_subscription_missing\n");
 }
 
 static void test_find_field(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    int sub_idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    int sub_idx = ulog_parser_find_subscription(p, "vehicle_attitude");
     assert(sub_idx >= 0);
-    int fmt_idx = p.subs[sub_idx].format_idx;
+    int fmt_idx = p->subs[sub_idx].format_idx;
     assert(fmt_idx >= 0);
-    int offset = ulog_parser_find_field(&p, fmt_idx, "q");
+    int offset = ulog_parser_find_field(p, fmt_idx, "q");
     assert(offset >= 0);
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS find_field (q offset=%d)\n", offset);
 }
 
 static void test_find_field_missing(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    int sub_idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
-    int fmt_idx = p.subs[sub_idx].format_idx;
-    int offset = ulog_parser_find_field(&p, fmt_idx, "nonexistent_field");
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    int sub_idx = ulog_parser_find_subscription(p, "vehicle_attitude");
+    int fmt_idx = p->subs[sub_idx].format_idx;
+    int offset = ulog_parser_find_field(p, fmt_idx, "nonexistent_field");
     assert(offset == -1);
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS find_field_missing\n");
 }
 
 static void test_timestamp_range(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    assert(p.start_timestamp > 0);
-    assert(p.end_timestamp > 0);
-    assert(p.end_timestamp > p.start_timestamp);
-    ulog_parser_close(&p);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    assert(p->start_timestamp > 0);
+    assert(p->end_timestamp > 0);
+    assert(p->end_timestamp > p->start_timestamp);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS timestamp_range\n");
 }
 
 static void test_index_built(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
-    assert(p.index_count > 0);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
+    assert(p->index_count > 0);
     // Verify monotonically increasing timestamps
-    for (int i = 1; i < p.index_count; i++) {
-        assert(p.index[i].timestamp >= p.index[i - 1].timestamp);
+    for (int i = 1; i < p->index_count; i++) {
+        assert(p->index[i].timestamp >= p->index[i - 1].timestamp);
     }
-    ulog_parser_close(&p);
-    printf("  PASS index_built (%d entries)\n", p.index_count);
+    int ic = p->index_count;
+    ulog_parser_close(p);
+    free(p);
+    printf("  PASS index_built (%d entries)\n", ic);
 }
 
 static void test_iterate_first(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
     ulog_data_msg_t msg;
-    bool ok = ulog_parser_next(&p, &msg);
+    bool ok = ulog_parser_next(p, &msg);
     assert(ok);
     assert(msg.timestamp > 0);
     assert(msg.data != NULL);
     assert(msg.data_len > 0);
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS iterate_first\n");
 }
 
 static void test_rewind(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
 
     // Read first message
     ulog_data_msg_t first;
-    assert(ulog_parser_next(&p, &first));
+    assert(ulog_parser_next(p, &first));
     uint64_t first_ts = first.timestamp;
 
     // Read a few more
     ulog_data_msg_t msg;
-    for (int i = 0; i < 100; i++) ulog_parser_next(&p, &msg);
+    for (int i = 0; i < 100; i++) ulog_parser_next(p, &msg);
 
     // Rewind and verify first message matches
-    ulog_parser_rewind(&p);
-    assert(ulog_parser_next(&p, &msg));
+    ulog_parser_rewind(p);
+    assert(ulog_parser_next(p, &msg));
     assert(msg.timestamp == first_ts);
 
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS rewind\n");
 }
 
 static void test_seek_midpoint(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
 
-    uint64_t mid = (p.start_timestamp + p.end_timestamp) / 2;
-    ulog_parser_seek(&p, mid);
+    uint64_t mid = (p->start_timestamp + p->end_timestamp) / 2;
+    ulog_parser_seek(p, mid);
 
     ulog_data_msg_t msg;
-    assert(ulog_parser_next(&p, &msg));
+    assert(ulog_parser_next(p, &msg));
     // Should be within ~2 seconds of the target
     int64_t diff = (int64_t)(msg.timestamp - mid);
     if (diff < 0) diff = -diff;
     assert(diff < 2000000); // 2 seconds in microseconds
 
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS seek_midpoint\n");
 }
 
 static void test_truncated_file(void) {
-    ulog_parser_t p;
-    int ret = ulog_parser_open(&p, TRUNC_LOG);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    int ret = ulog_parser_open(p, TRUNC_LOG);
     assert(ret == 0);
 
     // Iterate through all messages — should hit EOF gracefully
     ulog_data_msg_t msg;
     int count = 0;
-    while (ulog_parser_next(&p, &msg)) count++;
+    while (ulog_parser_next(p, &msg)) count++;
     assert(count > 0);
-    assert(p.eof);
+    assert(p->eof);
 
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS truncated_file (%d messages)\n", count);
 }
 
 static void test_field_accessors(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, QUAD_LOG) == 0);
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, QUAD_LOG) == 0);
 
-    int sub_idx = ulog_parser_find_subscription(&p, "vehicle_attitude");
-    int fmt_idx = p.subs[sub_idx].format_idx;
-    int q_offset = ulog_parser_find_field(&p, fmt_idx, "q");
-    uint16_t att_msg_id = p.subs[sub_idx].msg_id;
+    int sub_idx = ulog_parser_find_subscription(p, "vehicle_attitude");
+    int fmt_idx = p->subs[sub_idx].format_idx;
+    int q_offset = ulog_parser_find_field(p, fmt_idx, "q");
+    uint16_t att_msg_id = p->subs[sub_idx].msg_id;
 
     // Find first attitude message
     ulog_data_msg_t msg;
     bool found = false;
-    while (ulog_parser_next(&p, &msg)) {
+    while (ulog_parser_next(p, &msg)) {
         if (msg.msg_id == att_msg_id) {
             found = true;
             break;
@@ -202,16 +235,19 @@ static void test_field_accessors(void) {
     assert(!isnan(norm));
     assert(fabs(norm - 1.0f) < 0.01f);
 
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS field_accessors (q norm=%.4f)\n", norm);
 }
 
 static void test_fixedwing_subscriptions(void) {
-    ulog_parser_t p;
-    assert(ulog_parser_open(&p, FW_LOG) == 0);
-    int idx = ulog_parser_find_subscription(&p, "airspeed_validated");
+    ulog_parser_t *p = malloc(sizeof(*p));
+    assert(p);
+    assert(ulog_parser_open(p, FW_LOG) == 0);
+    int idx = ulog_parser_find_subscription(p, "airspeed_validated");
     assert(idx >= 0);
-    ulog_parser_close(&p);
+    ulog_parser_close(p);
+    free(p);
     printf("  PASS fixedwing_subscriptions\n");
 }
 

--- a/tests/test_ulog_replay.c
+++ b/tests/test_ulog_replay.c
@@ -2,202 +2,230 @@
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define QUAD_LOG   FIXTURES_DIR "/dde9a24c-34c5-4868-b09c-bd3481ed1029.ulg"
 #define FW_LOG     FIXTURES_DIR "/6dfd8372-8bb9-4827-8c43-8895f3fe7e7a.ulg"
 
 static void test_init_quadrotor(void) {
-    ulog_replay_ctx_t ctx;
-    int ret = ulog_replay_init(&ctx, QUAD_LOG);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    int ret = ulog_replay_init(ctx, QUAD_LOG);
     assert(ret == 0);
-    assert(ctx.vehicle_type == 2); // MAV_TYPE_QUADROTOR
-    ulog_replay_close(&ctx);
+    assert(ctx->vehicle_type == 2); // MAV_TYPE_QUADROTOR
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS init_quadrotor\n");
 }
 
 static void test_init_fixedwing(void) {
-    ulog_replay_ctx_t ctx;
-    int ret = ulog_replay_init(&ctx, FW_LOG);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    int ret = ulog_replay_init(ctx, FW_LOG);
     assert(ret == 0);
-    assert(ctx.vehicle_type == 1); // MAV_TYPE_FIXED_WING
-    ulog_replay_close(&ctx);
+    assert(ctx->vehicle_type == 1); // MAV_TYPE_FIXED_WING
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS init_fixedwing\n");
 }
 
 static void test_state_valid_after_advance(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
     // Advance until state becomes valid (may take a few iterations
     // for position data to arrive)
     for (int i = 0; i < 500; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.state.valid) break;
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->state.valid) break;
     }
-    assert(ctx.state.valid);
+    assert(ctx->state.valid);
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS state_valid_after_advance\n");
 }
 
 static void test_quaternion_normalized(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
     for (int i = 0; i < 500; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.state.valid) break;
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->state.valid) break;
     }
-    assert(ctx.state.valid);
+    assert(ctx->state.valid);
 
-    float w = ctx.state.quaternion[0];
-    float x = ctx.state.quaternion[1];
-    float y = ctx.state.quaternion[2];
-    float z = ctx.state.quaternion[3];
+    float w = ctx->state.quaternion[0];
+    float x = ctx->state.quaternion[1];
+    float y = ctx->state.quaternion[2];
+    float z = ctx->state.quaternion[3];
     float norm = w * w + x * x + y * y + z * z;
     assert(!isnan(norm));
     assert(fabs(norm - 1.0f) < 0.01f);
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS quaternion_normalized (norm=%.4f)\n", norm);
 }
 
 static void test_gps_path(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, FW_LOG) == 0);
 
     for (int i = 0; i < 1000; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.has_global_pos && ctx.state.valid) break;
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->has_global_pos && ctx->state.valid) break;
     }
-    assert(ctx.has_global_pos);
-    assert(ctx.state.lat != 0 || ctx.state.lon != 0);
-    assert(ctx.state.alt != 0);
+    assert(ctx->has_global_pos);
+    assert(ctx->state.lat != 0 || ctx->state.lon != 0);
+    assert(ctx->state.alt != 0);
 
-    ulog_replay_close(&ctx);
-    printf("  PASS gps_path (lat=%d lon=%d alt=%d)\n",
-           ctx.state.lat, ctx.state.lon, ctx.state.alt);
+    int lat = ctx->state.lat, lon = ctx->state.lon, alt = ctx->state.alt;
+    ulog_replay_close(ctx);
+    free(ctx);
+    printf("  PASS gps_path (lat=%d lon=%d alt=%d)\n", lat, lon, alt);
 }
 
 static void test_local_pos_path(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
     for (int i = 0; i < 500; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.state.valid) break;
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->state.valid) break;
     }
-    assert(ctx.state.valid);
+    assert(ctx->state.valid);
     // Quad log uses local position, not GPS
-    assert(!ctx.has_global_pos);
+    assert(!ctx->has_global_pos);
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS local_pos_path\n");
 }
 
 static void test_home_valid(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, FW_LOG) == 0);
 
     for (int i = 0; i < 1000; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.home.valid) break;
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->home.valid) break;
     }
-    assert(ctx.home.valid);
+    assert(ctx->home.valid);
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS home_valid\n");
 }
 
 static void test_seek_and_advance(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
-    float duration = (float)((double)(ctx.parser.end_timestamp -
-                                       ctx.parser.start_timestamp) / 1e6);
+    float duration = (float)((double)(ctx->parser.end_timestamp -
+                                       ctx->parser.start_timestamp) / 1e6);
     float target = duration * 0.5f;
-    ulog_replay_seek(&ctx, target);
+    ulog_replay_seek(ctx, target);
 
     // wall_accum should be near the seek target
-    assert(fabs(ctx.wall_accum - target) < 2.0);
+    assert(fabs(ctx->wall_accum - target) < 2.0);
 
-    ulog_replay_close(&ctx);
+    float accum = (float)ctx->wall_accum;
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS seek_and_advance (target=%.1f, accum=%.1f)\n",
-           target, (float)ctx.wall_accum);
+           target, accum);
 }
 
 static void test_loop_resets(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
-    float duration = (float)((double)(ctx.parser.end_timestamp -
-                                       ctx.parser.start_timestamp) / 1e6);
+    float duration = (float)((double)(ctx->parser.end_timestamp -
+                                       ctx->parser.start_timestamp) / 1e6);
 
     // Seek near the end and advance past it with looping
-    ulog_replay_seek(&ctx, duration - 0.5f);
-    bool playing = ulog_replay_advance(&ctx, 2.0f, 1.0f, true, true);
+    ulog_replay_seek(ctx, duration - 0.5f);
+    bool playing = ulog_replay_advance(ctx, 2.0f, 1.0f, true, true);
     assert(playing);
-    assert(ctx.wall_accum < 2.0); // should have looped back near 0
+    assert(ctx->wall_accum < 2.0); // should have looped back near 0
 
-    ulog_replay_close(&ctx);
-    printf("  PASS loop_resets (accum=%.2f)\n", (float)ctx.wall_accum);
+    float accum = (float)ctx->wall_accum;
+    ulog_replay_close(ctx);
+    free(ctx);
+    printf("  PASS loop_resets (accum=%.2f)\n", accum);
 }
 
 static void test_end_returns_false(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, QUAD_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, QUAD_LOG) == 0);
 
-    float duration = (float)((double)(ctx.parser.end_timestamp -
-                                       ctx.parser.start_timestamp) / 1e6);
+    float duration = (float)((double)(ctx->parser.end_timestamp -
+                                       ctx->parser.start_timestamp) / 1e6);
 
-    ulog_replay_seek(&ctx, duration - 0.1f);
+    ulog_replay_seek(ctx, duration - 0.1f);
     bool playing = true;
     for (int i = 0; i < 100 && playing; i++) {
-        playing = ulog_replay_advance(&ctx, 0.1f, 1.0f, false, true);
+        playing = ulog_replay_advance(ctx, 0.1f, 1.0f, false, true);
     }
     assert(!playing);
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS end_returns_false\n");
 }
 
 static void test_airspeed(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, FW_LOG) == 0);
 
     bool found_airspeed = false;
     for (int i = 0; i < 5000; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.state.ind_airspeed > 0) {
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->state.ind_airspeed > 0) {
             found_airspeed = true;
             break;
         }
     }
     assert(found_airspeed);
 
-    ulog_replay_close(&ctx);
-    printf("  PASS airspeed (ias=%u cm/s)\n", ctx.state.ind_airspeed);
+    unsigned ias = ctx->state.ind_airspeed;
+    ulog_replay_close(ctx);
+    free(ctx);
+    printf("  PASS airspeed (ias=%u cm/s)\n", ias);
 }
 
 static void test_velocity(void) {
-    ulog_replay_ctx_t ctx;
-    assert(ulog_replay_init(&ctx, FW_LOG) == 0);
+    ulog_replay_ctx_t *ctx = malloc(sizeof(*ctx));
+    assert(ctx);
+    assert(ulog_replay_init(ctx, FW_LOG) == 0);
 
     for (int i = 0; i < 1000; i++) {
-        ulog_replay_advance(&ctx, 0.05f, 1.0f, false, true);
-        if (ctx.state.valid) break;
+        ulog_replay_advance(ctx, 0.05f, 1.0f, false, true);
+        if (ctx->state.valid) break;
     }
-    assert(ctx.state.valid);
+    assert(ctx->state.valid);
 
     // Velocity should be within plausible range for an aircraft
-    float vx = ctx.state.vx / 100.0f;
-    float vy = ctx.state.vy / 100.0f;
-    float vz = ctx.state.vz / 100.0f;
+    float vx = ctx->state.vx / 100.0f;
+    float vy = ctx->state.vy / 100.0f;
+    float vz = ctx->state.vz / 100.0f;
     float speed = sqrtf(vx * vx + vy * vy + vz * vz);
     assert(speed < 200.0f); // less than 200 m/s
 
-    ulog_replay_close(&ctx);
+    ulog_replay_close(ctx);
+    free(ctx);
     printf("  PASS velocity (speed=%.1f m/s)\n", speed);
 }
 


### PR DESCRIPTION
`ulog_parser_t` is ~1.2 MB due to `formats[256]` with 64 fields each. Every test function stack-allocated it as a local variable, which exceeds the 1 MB default stack on Windows MSVC — causing segfaults in Release builds. The passing tests (`obj_models`, `ui_logic`, `theme`, `data_source`) were unaffected because they don't put these large structs on the stack.

Changes:
- Heap-allocate `ulog_parser_t` and `ulog_replay_ctx_t` in all affected test functions (`test_ulog_parser.c`, `test_ulog_replay.c`, `test_algorithms.c`)
- Fix NDEBUG handling in `tests/CMakeLists.txt`: replace GCC-only `-UNDEBUG` flag with `string(REPLACE)` to strip NDEBUG from `CMAKE_C_FLAGS_RELEASE`, which works on both MSVC and GCC/Clang
- Re-enable Windows tests in CI (removes `if: runner.os != 'Windows'` skip)

Closes #59