### PR TITLE
fix: arm64 deb cross-compile apt source setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,9 +204,16 @@ jobs:
       - name: Install cross-compilation toolchain
         run: |
           sudo dpkg --add-architecture arm64
-          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          # Pin existing sources to amd64 only, skip non-deb lines and files that already have arch qualifiers
+          for f in /etc/apt/sources.list.d/*.list; do
+            sudo sed -i '/^\s*#/!{/\[arch=/!s/^deb /deb [arch=amd64] /}' "$f" 2>/dev/null || true
+          done
+          # Also handle /etc/apt/sources.list if it exists
+          [ -f /etc/apt/sources.list ] && sudo sed -i '/^\s*#/!{/\[arch=/!s/^deb /deb [arch=amd64] /}' /etc/apt/sources.list || true
+          # Add arm64 ports
+          CODENAME=$(lsb_release -cs)
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           sudo apt-get install -y libgl1-mesa-dev:arm64 libx11-dev:arm64 libxrandr-dev:arm64 \


### PR DESCRIPTION
The sed that pins existing sources to amd64 was mangling source list files that don't start with a plain `deb ` (like microsoft-prod.list on GitHub runners). Now skips commented lines and lines that already have an arch qualifier.