### PR TITLE
fix: arm64 cross-compile cmake can't find X11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,10 +229,11 @@ jobs:
             -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
             -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
             -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
-            -DCMAKE_FIND_ROOT_PATH=/usr/aarch64-linux-gnu \
+            -DCMAKE_FIND_ROOT_PATH="/usr/aarch64-linux-gnu;/usr" \
             -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
             -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
-            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+            -DCMAKE_LIBRARY_ARCHITECTURE=aarch64-linux-gnu \
             -DHAWKEYE_VERSION=${{ needs.source-tarball.outputs.version }}
 
       - name: Build


### PR DESCRIPTION
CMake couldn't find X11 because the find root path was too narrow and include mode was set to ONLY. Ubuntu multiarch puts arm64 headers under /usr/include and libs under /usr/lib/aarch64-linux-gnu, so we need /usr in the search path with BOTH for includes.