### PR TITLE
fix: set deb architecture for arm64 cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,8 @@ jobs:
             -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
             -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
             -DCMAKE_LIBRARY_ARCHITECTURE=aarch64-linux-gnu \
-            -DHAWKEYE_VERSION=${{ needs.source-tarball.outputs.version }}
+            -DHAWKEYE_VERSION=${{ needs.source-tarball.outputs.version }} \
+            -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64
 
       - name: Build
         run: cmake --build build --config Release


### PR DESCRIPTION
The arm64 deb was being built successfully but CPack named it _amd64.deb (host arch), colliding with the real amd64 package on upload. Pass CPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 to cmake.