### PR TITLE
fix: Alt+number blocks drone selection, left-click pans ortho views

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -862,6 +862,7 @@ int main(int argc, char *argv[]) {
 
                 bool shift_held = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
                 bool ctrl_held = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
+                bool alt_held = IsKeyDown(KEY_LEFT_ALT) || IsKeyDown(KEY_RIGHT_ALT);
 
                 // Check chord timeout
                 if (chord_first >= 0 && GetTime() - chord_time > CHORD_TIMEOUT_S) {
@@ -872,7 +873,7 @@ int main(int argc, char *argv[]) {
                     chord_first = -1;
                 }
 
-                if (digit >= 0 && !ctrl_held) {
+                if (digit >= 0 && !ctrl_held && !alt_held) {
                     if (chord_first >= 0) {
                         // Second digit of chord: combine into two-digit number
                         int two_digit = chord_first * 10 + digit;

--- a/src/scene.c
+++ b/src/scene.c
@@ -521,8 +521,8 @@ void scene_handle_input(scene_t *s) {
         s->seq_1988 = 0;
     }
 
-    // Mouse drag to orbit/look (left button)
-    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+    // Mouse drag to orbit/look (left button, perspective only)
+    if (s->ortho_mode == ORTHO_NONE && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
         Vector2 delta = GetMouseDelta();
         if (s->cam_mode == CAM_MODE_CHASE) {
             s->chase_yaw   -= delta.x * 0.005f;
@@ -538,8 +538,9 @@ void scene_handle_input(scene_t *s) {
         }
     }
 
-    // Right-click drag to pan in ortho mode
-    if (s->ortho_mode != ORTHO_NONE && IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) {
+    // Click drag to pan in ortho mode (left or right button)
+    if (s->ortho_mode != ORTHO_NONE &&
+        (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || IsMouseButtonDown(MOUSE_BUTTON_RIGHT))) {
         Vector2 delta = GetMouseDelta();
         // Convert pixel delta to world units based on ortho span and screen size
         int screen_h = GetScreenHeight();


### PR DESCRIPTION
## Summary
- Alt+number keys no longer trigger drone selection when switching ortho views (Alt+1-7)
- Left-click drag now pans in fullscreen ortho mode, matching right-click — needed for macOS where right-click is awkward
- Orbit handler explicitly skips ortho mode to prevent double-firing with pan handler

## Test plan
- [x] All 7 existing tests pass
- [x] Alt+1-7 switches ortho views without changing selected drone
- [x] Left-click drag pans in fullscreen ortho mode
- [x] Number keys still select drones normally without Alt held
- [x] Camera orbit still works in perspective mode
- [x] Tested with 7-drone UVIFY swarm replay