### PR TITLE
feat: tactical HUD mode with radar, gimbal rings, and ortho insets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if(NOT BUILD_TESTING_ONLY)
         src/ortho_panel.c
         src/asset_path.c
         src/theme.c
+        src/tactical_hud.c
     )
 
     target_include_directories(hawkeye PRIVATE

--- a/src/hud.c
+++ b/src/hud.c
@@ -236,8 +236,9 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
               const data_source_t *sources, int vehicle_count,
               int selected, int screen_w, int screen_h, const theme_t *theme,
               int trail_mode,
-              const hud_marker_data_t *markers,
-              const hud_marker_data_t *sys_markers,
+              const hud_marker_data_t *markers_all,
+              const hud_marker_data_t *sys_markers_all,
+              int marker_vehicle_count,
               bool ghost_mode, bool has_tier3, bool has_awaiting_gps) {
 
     // Semantic color variables from theme
@@ -323,7 +324,8 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     if (is_replay_source) {
         hud_draw_transport(h, &sources[selected].playback,
                            sources[selected].connected, &vehicles[selected],
-                           markers, sys_markers,
+                           markers_all, sys_markers_all,
+                           marker_vehicle_count, selected,
                            screen_w, (float)bar_y, (float)transport_h,
                            s, trail_mode, theme);
     }

--- a/src/hud.h
+++ b/src/hud.h
@@ -9,6 +9,13 @@
 #define HUD_MAX_PINNED 15
 #define HUD_MARKER_LABEL_MAX 48
 
+typedef enum {
+    HUD_CONSOLE,
+    HUD_TACTICAL,
+    HUD_OFF,
+    HUD_MODE_COUNT
+} hud_mode_t;
+
 typedef struct {
     const float *times;
     const char (*labels)[HUD_MARKER_LABEL_MAX];
@@ -20,9 +27,11 @@ typedef struct {
     int count;
     int current;
     bool selected;  // for sys markers: whether sys marker is selected
+    Color color;    // drone palette color (for multi-drone timeline tinting)
 } hud_marker_data_t;
 
 typedef struct {
+    hud_mode_t mode;
     float sim_time_s;
     int pinned[HUD_MAX_PINNED];   // indices of pinned vehicles (-1 = empty)
     int pinned_count;
@@ -45,8 +54,9 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
               const data_source_t *sources, int vehicle_count,
               int selected, int screen_w, int screen_h, const theme_t *theme,
               int trail_mode,
-              const hud_marker_data_t *markers,
-              const hud_marker_data_t *sys_markers,
+              const hud_marker_data_t *markers_all,
+              const hud_marker_data_t *sys_markers_all,
+              int marker_vehicle_count,
               bool ghost_mode, bool has_tier3, bool has_awaiting_gps);
 void hud_cleanup(hud_t *h);
 void hud_toast(hud_t *h, const char *text, float duration_s);

--- a/src/hud_transport.c
+++ b/src/hud_transport.c
@@ -11,8 +11,9 @@
 void hud_draw_transport(const hud_t *h,
                         const playback_state_t *pb, bool connected,
                         const vehicle_t *selected_vehicle,
-                        const hud_marker_data_t *markers,
-                        const hud_marker_data_t *sys_markers,
+                        const hud_marker_data_t *markers_all,
+                        const hud_marker_data_t *sys_markers_all,
+                        int marker_vehicle_count, int selected_idx,
                         int screen_w, float bar_y, float transport_h,
                         float scale, int trail_mode, const theme_t *theme) {
     float s = scale;
@@ -96,6 +97,7 @@ void hud_draw_transport(const hud_t *h,
             0.5f, 4, accent);
     }
     // Playhead ring — colored to match the drone's current trail color
+    bool multi = (marker_vehicle_count > 1);
     float dot_x = prog_x + prog_w * pb->progress;
     float dot_y = prog_y + prog_h / 2.0f;
     {
@@ -104,7 +106,8 @@ void hud_draw_transport(const hud_t *h,
                                             pv->vertical_speed,
                                             sqrtf(pv->ground_speed * pv->ground_speed +
                                                   pv->vertical_speed * pv->vertical_speed),
-                                            pv->trail_speed_max, theme, trail_mode);
+                                            pv->trail_speed_max, theme, trail_mode,
+                                            pv->color, multi);
         float r_outer = 6.5f * s;
         float r_inner = 5.5f * s;
         DrawRing((Vector2){dot_x, dot_y}, r_inner, r_outer, 0, 360, 24, ph_col);
@@ -141,119 +144,135 @@ void hud_draw_transport(const hud_t *h,
         }
     }
 
-    // Frame markers on timeline (colored diamonds with labels)
-    if (markers && markers->times && markers->count > 0 && pb->duration_s > 0.0f) {
+    // Frame markers on timeline (colored diamonds with labels) — all drones
+    {
         float fs_mlabel = 9 * s;
         float last_mlabel_x = -100.0f;
-        for (int i = 0; i < markers->count; i++) {
-            float t = markers->times[i] / pb->duration_s;
-            if (t < 0.0f || t > 1.0f) continue;
-            float mx = prog_x + prog_w * t;
-            float my = prog_y + prog_h / 2.0f;
+        for (int vi = 0; vi < marker_vehicle_count; vi++) {
+            const hud_marker_data_t *markers = &markers_all[vi];
+            if (!markers->times || markers->count == 0 || pb->duration_s <= 0.0f) continue;
+            bool is_selected_drone = (vi == selected_idx);
+            for (int i = 0; i < markers->count; i++) {
+                float t = markers->times[i] / pb->duration_s;
+                if (t < 0.0f || t > 1.0f) continue;
+                float mx = prog_x + prog_w * t;
+                float my = prog_y + prog_h / 2.0f;
 
-            bool is_cur = (i == markers->current);
-            Color mc = vehicle_marker_color(markers->roll[i], markers->pitch[i],
-                                            markers->vert[i], markers->speed[i],
-                                            markers->speed_max, theme, trail_mode);
-            if (is_cur) {
-                if (theme->thick_trails) {
-                    mc.r = (unsigned char)(mc.r * 0.55f);
-                    mc.g = (unsigned char)(mc.g * 0.55f);
-                    mc.b = (unsigned char)(mc.b * 0.55f);
-                } else {
-                    mc.r = (unsigned char)(mc.r + (230 - mc.r) * 0.7f);
-                    mc.g = (unsigned char)(mc.g + (230 - mc.g) * 0.7f);
-                    mc.b = (unsigned char)(mc.b + (230 - mc.b) * 0.7f);
-                }
-            }
-            mc.a = is_cur ? 255 : 220;
-
-            float d = is_cur ? 5.0f * s : 3.5f * s;
-            Vector2 diamond[4] = {
-                {mx, my - d}, {mx + d, my}, {mx, my + d}, {mx - d, my},
-            };
-            DrawTriangle(diamond[0], diamond[3], diamond[1], mc);
-            DrawTriangle(diamond[1], diamond[3], diamond[2], mc);
-
-            {
-                char mlbl[56];
-                if (markers->labels && markers->labels[i][0] != '\0')
-                    snprintf(mlbl, sizeof(mlbl), "%d:%s", i + 1, markers->labels[i]);
-                else
-                    snprintf(mlbl, sizeof(mlbl), "%d", i + 1);
-                Vector2 mlw = MeasureTextEx(h->font_label, mlbl, fs_mlabel, 0.5f);
-                float min_gap = is_cur ? 0 : (mlw.x + 6 * s);
-                if (is_cur || mx - last_mlabel_x > min_gap) {
-                    float lx = mx - mlw.x / 2.0f;
-                    if (lx < prog_x) lx = prog_x;
-                    if (lx + mlw.x > prog_x + prog_w) lx = prog_x + prog_w - mlw.x;
-                    float ly = prog_y + prog_h + 3 * s;
-                    if (is_cur) {
-                        float px = 4 * s, py = 2 * s;
-                        DrawRectangleRounded(
-                            (Rectangle){lx - px, ly - py, mlw.x + px * 2, mlw.y + py * 2},
-                            0.4f, 4, bg);
+                bool is_cur = is_selected_drone && (i == markers->current);
+                Color mc = vehicle_marker_color(markers->roll[i], markers->pitch[i],
+                                                markers->vert[i], markers->speed[i],
+                                                markers->speed_max, theme, trail_mode,
+                                                markers->color, multi);
+                if (is_cur) {
+                    if (theme->thick_trails) {
+                        mc.r = (unsigned char)(mc.r * 0.55f);
+                        mc.g = (unsigned char)(mc.g * 0.55f);
+                        mc.b = (unsigned char)(mc.b * 0.55f);
+                    } else {
+                        mc.r = (unsigned char)(mc.r + (230 - mc.r) * 0.7f);
+                        mc.g = (unsigned char)(mc.g + (230 - mc.g) * 0.7f);
+                        mc.b = (unsigned char)(mc.b + (230 - mc.b) * 0.7f);
                     }
-                    DrawTextEx(h->font_label, mlbl,
-                               (Vector2){lx, ly}, fs_mlabel, 0.5f, mc);
-                    last_mlabel_x = mx;
+                }
+                mc.a = is_cur ? 255 : (is_selected_drone ? 220 : 100);
+
+                float d = is_cur ? 5.0f * s : 3.5f * s;
+                if (!is_selected_drone) d *= 0.7f;
+                Vector2 diamond[4] = {
+                    {mx, my - d}, {mx + d, my}, {mx, my + d}, {mx - d, my},
+                };
+                DrawTriangle(diamond[0], diamond[3], diamond[1], mc);
+                DrawTriangle(diamond[1], diamond[3], diamond[2], mc);
+
+                // Labels only for selected drone to avoid clutter
+                if (is_selected_drone) {
+                    char mlbl[56];
+                    if (markers->labels && markers->labels[i][0] != '\0')
+                        snprintf(mlbl, sizeof(mlbl), "%d:%s", i + 1, markers->labels[i]);
+                    else
+                        snprintf(mlbl, sizeof(mlbl), "%d", i + 1);
+                    Vector2 mlw = MeasureTextEx(h->font_label, mlbl, fs_mlabel, 0.5f);
+                    float min_gap = is_cur ? 0 : (mlw.x + 6 * s);
+                    if (is_cur || mx - last_mlabel_x > min_gap) {
+                        float lx = mx - mlw.x / 2.0f;
+                        if (lx < prog_x) lx = prog_x;
+                        if (lx + mlw.x > prog_x + prog_w) lx = prog_x + prog_w - mlw.x;
+                        float ly = prog_y + prog_h + 3 * s;
+                        if (is_cur) {
+                            float px = 4 * s, py = 2 * s;
+                            DrawRectangleRounded(
+                                (Rectangle){lx - px, ly - py, mlw.x + px * 2, mlw.y + py * 2},
+                                0.4f, 4, bg);
+                        }
+                        DrawTextEx(h->font_label, mlbl,
+                                   (Vector2){lx, ly}, fs_mlabel, 0.5f, mc);
+                        last_mlabel_x = mx;
+                    }
                 }
             }
         }
     }
 
-    // System markers on timeline (squares)
-    if (sys_markers && sys_markers->times && sys_markers->count > 0 && pb->duration_s > 0.0f) {
+    // System markers on timeline (squares) — all drones
+    {
         float fs_mlabel = 9 * s;
         float last_slabel_x = -100.0f;
-        for (int i = 0; i < sys_markers->count; i++) {
-            float t = sys_markers->times[i] / pb->duration_s;
-            if (t < 0.0f || t > 1.0f) continue;
-            float mx = prog_x + prog_w * t;
-            float my = prog_y + prog_h / 2.0f;
+        for (int vi = 0; vi < marker_vehicle_count; vi++) {
+            const hud_marker_data_t *sysm = &sys_markers_all[vi];
+            if (!sysm->times || sysm->count == 0 || pb->duration_s <= 0.0f) continue;
+            bool is_selected_drone = (vi == selected_idx);
+            for (int i = 0; i < sysm->count; i++) {
+                float t = sysm->times[i] / pb->duration_s;
+                if (t < 0.0f || t > 1.0f) continue;
+                float mx = prog_x + prog_w * t;
+                float my = prog_y + prog_h / 2.0f;
 
-            bool is_cur = sys_markers->selected && (i == sys_markers->current);
-            Color mc = vehicle_marker_color(sys_markers->roll[i], sys_markers->pitch[i],
-                                            sys_markers->vert[i], sys_markers->speed[i],
-                                            sys_markers->speed_max, theme, trail_mode);
-            if (is_cur) {
-                if (theme->thick_trails) {
-                    mc.r = (unsigned char)(mc.r * 0.55f);
-                    mc.g = (unsigned char)(mc.g * 0.55f);
-                    mc.b = (unsigned char)(mc.b * 0.55f);
-                } else {
-                    mc.r = (unsigned char)(mc.r + (230 - mc.r) * 0.7f);
-                    mc.g = (unsigned char)(mc.g + (230 - mc.g) * 0.7f);
-                    mc.b = (unsigned char)(mc.b + (230 - mc.b) * 0.7f);
-                }
-            }
-            mc.a = is_cur ? 255 : 200;
-
-            float d = is_cur ? 5.0f * s : 3.5f * s;
-            DrawRectangle((int)(mx - d), (int)(my - d), (int)(d * 2), (int)(d * 2), mc);
-
-            {
-                char mlbl[56];
-                if (sys_markers->labels && sys_markers->labels[i][0] != '\0')
-                    snprintf(mlbl, sizeof(mlbl), "S:%s", sys_markers->labels[i]);
-                else
-                    snprintf(mlbl, sizeof(mlbl), "S%d", i + 1);
-                Vector2 mlw = MeasureTextEx(h->font_label, mlbl, fs_mlabel, 0.5f);
-                float min_gap = is_cur ? 0 : (mlw.x + 6 * s);
-                if (is_cur || mx - last_slabel_x > min_gap) {
-                    float lx = mx - mlw.x / 2.0f;
-                    if (lx < prog_x) lx = prog_x;
-                    if (lx + mlw.x > prog_x + prog_w) lx = prog_x + prog_w - mlw.x;
-                    float ly = prog_y - mlw.y - 3 * s;
-                    if (is_cur) {
-                        float px = 4 * s, py = 2 * s;
-                        DrawRectangleRounded(
-                            (Rectangle){lx - px, ly - py, mlw.x + px * 2, mlw.y + py * 2},
-                            0.4f, 4, bg);
+                bool is_cur = is_selected_drone && sysm->selected && (i == sysm->current);
+                Color mc = vehicle_marker_color(sysm->roll[i], sysm->pitch[i],
+                                                sysm->vert[i], sysm->speed[i],
+                                                sysm->speed_max, theme, trail_mode,
+                                                sysm->color, multi);
+                if (is_cur) {
+                    if (theme->thick_trails) {
+                        mc.r = (unsigned char)(mc.r * 0.55f);
+                        mc.g = (unsigned char)(mc.g * 0.55f);
+                        mc.b = (unsigned char)(mc.b * 0.55f);
+                    } else {
+                        mc.r = (unsigned char)(mc.r + (230 - mc.r) * 0.7f);
+                        mc.g = (unsigned char)(mc.g + (230 - mc.g) * 0.7f);
+                        mc.b = (unsigned char)(mc.b + (230 - mc.b) * 0.7f);
                     }
-                    DrawTextEx(h->font_label, mlbl,
-                               (Vector2){lx, ly}, fs_mlabel, 0.5f, mc);
-                    last_slabel_x = mx;
+                }
+                mc.a = is_cur ? 255 : (is_selected_drone ? 200 : 80);
+
+                float d = is_cur ? 5.0f * s : 3.5f * s;
+                if (!is_selected_drone) d *= 0.7f;
+                DrawRectangle((int)(mx - d), (int)(my - d), (int)(d * 2), (int)(d * 2), mc);
+
+                // Labels only for selected drone
+                if (is_selected_drone) {
+                    char mlbl[56];
+                    if (sysm->labels && sysm->labels[i][0] != '\0')
+                        snprintf(mlbl, sizeof(mlbl), "S:%s", sysm->labels[i]);
+                    else
+                        snprintf(mlbl, sizeof(mlbl), "S%d", i + 1);
+                    Vector2 mlw = MeasureTextEx(h->font_label, mlbl, fs_mlabel, 0.5f);
+                    float min_gap = is_cur ? 0 : (mlw.x + 6 * s);
+                    if (is_cur || mx - last_slabel_x > min_gap) {
+                        float lx = mx - mlw.x / 2.0f;
+                        if (lx < prog_x) lx = prog_x;
+                        if (lx + mlw.x > prog_x + prog_w) lx = prog_x + prog_w - mlw.x;
+                        float ly = prog_y - mlw.y - 3 * s;
+                        if (is_cur) {
+                            float px = 4 * s, py = 2 * s;
+                            DrawRectangleRounded(
+                                (Rectangle){lx - px, ly - py, mlw.x + px * 2, mlw.y + py * 2},
+                                0.4f, 4, bg);
+                        }
+                        DrawTextEx(h->font_label, mlbl,
+                                   (Vector2){lx, ly}, fs_mlabel, 0.5f, mc);
+                        last_slabel_x = mx;
+                    }
                 }
             }
         }

--- a/src/hud_transport.h
+++ b/src/hud_transport.h
@@ -10,8 +10,9 @@
 void hud_draw_transport(const hud_t *h,
                         const playback_state_t *pb, bool connected,
                         const vehicle_t *selected_vehicle,
-                        const hud_marker_data_t *markers,
-                        const hud_marker_data_t *sys_markers,
+                        const hud_marker_data_t *markers_all,
+                        const hud_marker_data_t *sys_markers_all,
+                        int marker_vehicle_count, int selected_idx,
                         int screen_w, float bar_y, float transport_h,
                         float scale, int trail_mode, const theme_t *theme);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1040,29 +1040,27 @@ int main(int argc, char *argv[]) {
             if (IsKeyPressed(KEY_RIGHT)) {
                 float step;
                 if (shift && ctrl) step = 1.0f;
-                else if (shift) { step = 0.02f; sources[0].playback.paused = true; }
+                else if (shift) { step = 0.02f; sources[selected].playback.paused = true; }
                 else step = 5.0f;
-                float seek_target = sources[0].playback.position_s + step;
+                float seek_target = sources[selected].playback.position_s + step;
                 for (int i = 0; i < nrf; i++) {
                     data_source_seek(&sources[i], seek_target);
                     vehicle_reset_trail(&vehicles[i]);
                 }
                 memset(corr, 0, sizeof(corr));
-                replay_sync_vehicle(&sources[0], &vehicles[0]);
             }
             if (IsKeyPressed(KEY_LEFT)) {
                 float step;
                 if (shift && ctrl) step = 1.0f;
-                else if (shift) { step = 0.02f; sources[0].playback.paused = true; }
+                else if (shift) { step = 0.02f; sources[selected].playback.paused = true; }
                 else step = 5.0f;
-                float target = sources[0].playback.position_s - step;
+                float target = sources[selected].playback.position_s - step;
                 if (target < 0.0f) target = 0.0f;
                 for (int i = 0; i < nrf; i++) {
                     data_source_seek(&sources[i], target);
                     vehicle_reset_trail(&vehicles[i]);
                 }
                 memset(corr, 0, sizeof(corr));
-                replay_sync_vehicle(&sources[0], &vehicles[0]);
             }
 
             // Frame markers: B = drop marker, B->L = drop + label, Shift+B = delete current
@@ -1105,6 +1103,15 @@ int main(int argc, char *argv[]) {
                     marker_cycle(&markers[selected], &sys_markers[selected], dir, shift,
                                  &sources[selected], &vehicles[selected],
                                  &precomp[selected], &scene, &last_pos[selected]);
+                }
+                // Sync all drones to the same playback time after marker seek
+                if (!shift && vehicle_count > 1) {
+                    float sync_time = sources[selected].playback.position_s;
+                    for (int i = 0; i < vehicle_count; i++) {
+                        if (i == selected) continue;
+                        data_source_seek(&sources[i], sync_time);
+                        vehicle_reset_trail(&vehicles[i]);
+                    }
                 }
             }
         }

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@
 #include "replay_trail.h"
 #include "replay_markers.h"
 #include "ui_marker_input.h"
+#include "tactical_hud.h"
 
 #define MAX_VEHICLES 16
 #define EARTH_RADIUS 6371000.0
@@ -424,6 +425,8 @@ int main(int argc, char *argv[]) {
     Vector3 last_pos[MAX_VEHICLES];
     memset(last_pos, 0, sizeof(last_pos));
     bool show_hud = true;
+    float saved_chase_distance = 0.0f;
+    float tactical_chase_target = 1.6f;
 
     // Key chord state for two-digit drone selection (10-16)
     int chord_first = -1;       // first digit pressed (-1 = no chord in progress)
@@ -441,21 +444,18 @@ int main(int argc, char *argv[]) {
     int insufficient_check_frames = 0;
     bool insufficient_toasted = false;
 
-    // Frame markers for replay
-    user_markers_t markers = {0};
-    markers.current = -1;
-    markers.last_drop_idx = -1;
-
-    // System markers (from ULog mode changes) — cubes, not user-editable
-    sys_markers_t sys_markers = {0};
-    sys_markers.current = -1;
-    if (is_replay) {
-        replay_init_sys_markers(&sys_markers, &sources[0]);
+    // Per-drone markers, system markers, and pre-computed trails
+    user_markers_t markers[MAX_VEHICLES] = {0};
+    sys_markers_t sys_markers[MAX_VEHICLES] = {0};
+    precomp_trail_t precomp[MAX_VEHICLES] = {0};
+    for (int i = 0; i < vehicle_count; i++) {
+        markers[i].current = -1;
+        markers[i].last_drop_idx = -1;
+        sys_markers[i].current = -1;
+        precomp_trail_init(&precomp[i]);
+        if (is_replay)
+            replay_init_sys_markers(&sys_markers[i], &sources[i]);
     }
-
-    // Pre-computed flight trail (built once after origin is established)
-    precomp_trail_t precomp = {0};
-    precomp_trail_init(&precomp);
 
     // Marker label input state
     bool show_marker_labels = true;
@@ -505,8 +505,12 @@ int main(int argc, char *argv[]) {
         }
 
         // Lazy-resolve system marker positions once origin is established
-        if (is_replay && !sys_markers.resolved && sys_markers.count > 0 && vehicles[0].origin_set) {
-            replay_resolve_and_build_trail(&sys_markers, &precomp, &sources[0], &vehicles[0]);
+        for (int i = 0; i < vehicle_count; i++) {
+            if (is_replay && !sys_markers[i].resolved && sys_markers[i].count > 0
+                && vehicles[i].origin_set) {
+                replay_resolve_and_build_trail(&sys_markers[i], &precomp[i],
+                                               &sources[i], &vehicles[i]);
+            }
         }
 
         // Detect drones with insufficient position data (~2s after start)
@@ -759,9 +763,20 @@ int main(int argc, char *argv[]) {
             hud.show_help = !hud.show_help;
         }
 
-        // Toggle HUD visibility
+        // Cycle HUD mode: Console → Tactical → Off
         if (IsKeyPressed(KEY_H)) {
-            show_hud = !show_hud;
+            hud_mode_t prev_mode = hud.mode;
+            hud.mode = (hud.mode + 1) % HUD_MODE_COUNT;
+            const char *mode_names[] = { "Console HUD", "Tactical HUD", "HUD Off" };
+            hud_toast(&hud, mode_names[hud.mode], 2.0f);
+            show_hud = (hud.mode != HUD_OFF);
+
+            if (hud.mode == HUD_TACTICAL) {
+                saved_chase_distance = scene.chase_distance;
+                scene.chase_distance = tactical_chase_target;
+            } else if (prev_mode == HUD_TACTICAL) {
+                scene.chase_distance = saved_chase_distance;
+            }
         }
 
         // Shift+T: cycle correlation overlay (off → ribbon → line → off)
@@ -904,7 +919,8 @@ int main(int argc, char *argv[]) {
 
         // Marker label text input — consumes all keyboard while active
         if (marker_input.active) {
-            marker_input_update(&marker_input, &markers, &sources[0], &vehicles[0]);
+            int di = marker_input.drone_idx;
+            marker_input_update(&marker_input, &markers[di], &sources[di], &vehicles[di]);
         }
 
         // Re-toast insufficient data warning when switching to a bad drone
@@ -946,7 +962,7 @@ int main(int argc, char *argv[]) {
             if (IsKeyPressed(KEY_Y)) {
                 hud.show_yaw = !hud.show_yaw;
             }
-            if (IsKeyPressed(KEY_L) && !IsKeyDown(KEY_LEFT_CONTROL) && !IsKeyDown(KEY_RIGHT_CONTROL) && !shift && (markers.last_drop_idx < 0 || GetTime() - markers.last_drop_time >= 0.5)) {
+            if (IsKeyPressed(KEY_L) && !IsKeyDown(KEY_LEFT_CONTROL) && !IsKeyDown(KEY_RIGHT_CONTROL) && !shift && (markers[selected].last_drop_idx < 0 || GetTime() - markers[selected].last_drop_time >= 0.5)) {
                 show_marker_labels = !show_marker_labels;
             }
             if (IsKeyPressed(KEY_I)) {
@@ -985,8 +1001,10 @@ int main(int argc, char *argv[]) {
                     vehicle_reset_trail(&vehicles[i]);
                 }
                 memset(corr, 0, sizeof(corr));
-                markers.count = 0;
-                markers.current = -1;
+                for (int i = 0; i < vehicle_count; i++) {
+                    markers[i].count = 0;
+                    markers[i].current = -1;
+                }
             }
             // A key: toggle takeoff time alignment
             if (IsKeyPressed(KEY_A) && num_replay_files > 1) {
@@ -1011,6 +1029,9 @@ int main(int argc, char *argv[]) {
                     sources[i].playback.correlation = NAN;
                     sources[i].playback.rmse = NAN;
                 }
+                // Re-resolve system marker positions with new time offsets
+                for (int i = 0; i < nrf; i++)
+                    sys_markers[i].resolved = false;
                 hud_toast(&hud, takeoff_aligned ? "Auto Align On" : "Auto Align Off", 2.0f);
             }
 
@@ -1045,31 +1066,46 @@ int main(int argc, char *argv[]) {
             }
 
             // Frame markers: B = drop marker, B->L = drop + label, Shift+B = delete current
-            if (IsKeyPressed(KEY_B) && vehicles[0].active && !marker_input.active) {
+            if (IsKeyPressed(KEY_B) && vehicles[selected].active && !marker_input.active) {
                 if (shift) {
-                    marker_delete(&markers);
-                } else if (markers.count < REPLAY_MAX_MARKERS) {
-                    marker_drop(&markers, sources[0].playback.position_s,
-                                vehicles[0].position, &vehicles[0], &sys_markers);
+                    marker_delete(&markers[selected]);
+                } else if (markers[selected].count < REPLAY_MAX_MARKERS) {
+                    marker_drop(&markers[selected], sources[selected].playback.position_s,
+                                vehicles[selected].position, &vehicles[selected],
+                                &sys_markers[selected]);
                 }
             }
 
             // B->L chord: if L pressed within 0.5s of dropping a marker, open label input
-            if (IsKeyPressed(KEY_L) && !marker_input.active && markers.last_drop_idx >= 0) {
-                double elapsed = GetTime() - markers.last_drop_time;
+            if (IsKeyPressed(KEY_L) && !marker_input.active
+                && markers[selected].last_drop_idx >= 0) {
+                double elapsed = GetTime() - markers[selected].last_drop_time;
                 if (elapsed < 0.5) {
-                    marker_input_begin(&marker_input, markers.last_drop_idx, &sources[0]);
-                    markers.last_drop_idx = -1;
+                    marker_input_begin(&marker_input, markers[selected].last_drop_idx,
+                                       &sources[selected]);
+                    marker_input.drone_idx = selected;
+                    markers[selected].last_drop_idx = -1;
+                    // Pause all drones during label input
+                    for (int i = 0; i < vehicle_count; i++)
+                        sources[i].playback.paused = true;
                 }
             }
 
-            // Unified [/] cycling through both user markers and system markers (sorted by time)
-            if ((IsKeyPressed(KEY_LEFT_BRACKET) || IsKeyPressed(KEY_RIGHT_BRACKET))
-                && (markers.count > 0 || sys_markers.count > 0)) {
+            // [/] cycling: per-drone or global (Ctrl)
+            if (IsKeyPressed(KEY_LEFT_BRACKET) || IsKeyPressed(KEY_RIGHT_BRACKET)) {
                 int dir = IsKeyPressed(KEY_LEFT_BRACKET) ? -1 : 1;
-                marker_cycle(&markers, &sys_markers, dir, shift,
-                             &sources[0], &vehicles[0], &precomp,
-                             &scene, &last_pos[0]);
+                bool ctrl = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
+                if (ctrl) {
+                    marker_cycle_result_t r = marker_cycle_global(
+                        markers, sys_markers, vehicle_count, selected, dir,
+                        sources, vehicles, precomp, &scene, last_pos);
+                    if (r.jumped && r.drone_idx != selected)
+                        selected = r.drone_idx;
+                } else if (markers[selected].count > 0 || sys_markers[selected].count > 0) {
+                    marker_cycle(&markers[selected], &sys_markers[selected], dir, shift,
+                                 &sources[selected], &vehicles[selected],
+                                 &precomp[selected], &scene, &last_pos[selected]);
+                }
             }
         }
 
@@ -1077,10 +1113,16 @@ int main(int argc, char *argv[]) {
         debug_panel_update(&dbg_panel, GetFrameTime());
 
         // Update camera to follow selected vehicle
-        scene_update_camera(&scene, vehicles[selected].position, vehicles[selected].rotation);
+        {
+            Vector3 cam_target = vehicles[selected].position;
+            if (hud.mode == HUD_TACTICAL)
+                cam_target.y += scene.chase_distance * 0.10f;
+            scene_update_camera(&scene, cam_target, vehicles[selected].rotation);
+        }
 
         // Render ortho views to textures (before main BeginDrawing)
-        if (ortho.visible) {
+        // Always render when tactical HUD is active (radar uses top-down data)
+        if (ortho.visible || hud.mode == HUD_TACTICAL) {
             ortho_panel_update(&ortho, vehicles[selected].position);
             ortho_panel_render(&ortho, vehicles, vehicle_count,
                                selected, scene.theme,
@@ -1106,23 +1148,32 @@ int main(int argc, char *argv[]) {
                                      classic_colors);
                     }
                 }
-                // Draw frame marker spheres during replay
-                if (is_replay && markers.count > 0) {
-                    vehicle_draw_markers(markers.positions, markers.labels, markers.count,
-                                         sys_markers.selected ? -1 : markers.current,
-                                         scene.camera.position, scene.camera,
-                                         markers.roll, markers.pitch, markers.vert, markers.speed,
-                                         vehicles[0].trail_speed_max, scene.theme, trail_mode,
-                                         MARKER_USER);
-                }
-                // Draw system marker cubes during replay
-                if (is_replay && sys_markers.count > 0) {
-                    vehicle_draw_markers(sys_markers.positions, sys_markers.labels, sys_markers.count,
-                                         sys_markers.selected ? sys_markers.current : -1,
-                                         scene.camera.position, scene.camera,
-                                         sys_markers.roll, sys_markers.pitch, sys_markers.vert, sys_markers.speed,
-                                         vehicles[0].trail_speed_max, scene.theme, trail_mode,
-                                         MARKER_SYSTEM);
+                // Draw frame marker spheres and system marker cubes for all drones
+                for (int i = 0; i < vehicle_count; i++) {
+                    if (is_replay && markers[i].count > 0) {
+                        int cur = (i == selected && !sys_markers[i].selected)
+                                  ? markers[i].current : -1;
+                        vehicle_draw_markers(markers[i].positions, markers[i].labels,
+                                             markers[i].count, cur,
+                                             scene.camera.position, scene.camera,
+                                             markers[i].roll, markers[i].pitch,
+                                             markers[i].vert, markers[i].speed,
+                                             vehicles[i].trail_speed_max, scene.theme,
+                                             trail_mode, MARKER_USER,
+                                             vehicles[i].color, vehicle_count > 1);
+                    }
+                    if (is_replay && sys_markers[i].count > 0) {
+                        int cur = (i == selected && sys_markers[i].selected)
+                                  ? sys_markers[i].current : -1;
+                        vehicle_draw_markers(sys_markers[i].positions, sys_markers[i].labels,
+                                             sys_markers[i].count, cur,
+                                             scene.camera.position, scene.camera,
+                                             sys_markers[i].roll, sys_markers[i].pitch,
+                                             sys_markers[i].vert, sys_markers[i].speed,
+                                             vehicles[i].trail_speed_max, scene.theme,
+                                             trail_mode, MARKER_SYSTEM,
+                                             vehicles[i].color, vehicle_count > 1);
+                    }
                 }
 
                 // Home position markers (formation mode only)
@@ -1189,24 +1240,35 @@ int main(int argc, char *argv[]) {
             }
 
             // Marker labels (2D billboarded text, after EndMode3D)
-            if (is_replay && markers.count > 0 && show_marker_labels) {
-                vehicle_draw_marker_labels(markers.positions, markers.labels, markers.count,
-                                           sys_markers.selected ? -1 : markers.current,
-                                           scene.camera.position, scene.camera,
-                                           hud.font_label, hud.font_value,
-                                           markers.roll, markers.pitch, markers.vert, markers.speed,
-                                           vehicles[0].trail_speed_max, scene.theme, trail_mode,
-                                           MARKER_USER);
-            }
-            // System marker labels
-            if (is_replay && sys_markers.count > 0 && show_marker_labels) {
-                vehicle_draw_marker_labels(sys_markers.positions, sys_markers.labels, sys_markers.count,
-                                           sys_markers.selected ? sys_markers.current : -1,
-                                           scene.camera.position, scene.camera,
-                                           hud.font_label, hud.font_value,
-                                           sys_markers.roll, sys_markers.pitch, sys_markers.vert, sys_markers.speed,
-                                           vehicles[0].trail_speed_max, scene.theme, trail_mode,
-                                           MARKER_SYSTEM);
+            if (is_replay && show_marker_labels) {
+                for (int i = 0; i < vehicle_count; i++) {
+                    if (markers[i].count > 0) {
+                        int cur = (i == selected && !sys_markers[i].selected)
+                                  ? markers[i].current : -1;
+                        vehicle_draw_marker_labels(markers[i].positions, markers[i].labels,
+                                                   markers[i].count, cur,
+                                                   scene.camera.position, scene.camera,
+                                                   hud.font_label, hud.font_value,
+                                                   markers[i].roll, markers[i].pitch,
+                                                   markers[i].vert, markers[i].speed,
+                                                   vehicles[i].trail_speed_max, scene.theme,
+                                                   trail_mode, MARKER_USER,
+                                                   vehicles[i].color, vehicle_count > 1);
+                    }
+                    if (sys_markers[i].count > 0) {
+                        int cur = (i == selected && sys_markers[i].selected)
+                                  ? sys_markers[i].current : -1;
+                        vehicle_draw_marker_labels(sys_markers[i].positions, sys_markers[i].labels,
+                                                   sys_markers[i].count, cur,
+                                                   scene.camera.position, scene.camera,
+                                                   hud.font_label, hud.font_value,
+                                                   sys_markers[i].roll, sys_markers[i].pitch,
+                                                   sys_markers[i].vert, sys_markers[i].speed,
+                                                   vehicles[i].trail_speed_max, scene.theme,
+                                                   trail_mode, MARKER_SYSTEM,
+                                                   vehicles[i].color, vehicle_count > 1);
+                    }
+                }
             }
 
             // Fullscreen ortho 2D overlays (trails + correlation line)
@@ -1220,28 +1282,50 @@ int main(int argc, char *argv[]) {
             if (show_hud) {
                 bool has_awaiting_gps = vehicles[selected].active &&
                     !vehicles[selected].origin_set && sources[selected].home.valid;
-                hud_marker_data_t user_markers = {
-                    .times = markers.times, .labels = markers.labels,
-                    .roll = markers.roll, .pitch = markers.pitch,
-                    .vert = markers.vert, .speed = markers.speed,
-                    .speed_max = markers.speed_max,
-                    .count = markers.count, .current = markers.current,
-                    .selected = true,
-                };
-                hud_marker_data_t sys_marker_data = {
-                    .times = sys_markers.times, .labels = sys_markers.labels,
-                    .roll = sys_markers.roll, .pitch = sys_markers.pitch,
-                    .vert = sys_markers.vert, .speed = sys_markers.speed,
-                    .speed_max = markers.speed_max,
-                    .count = sys_markers.count, .current = sys_markers.current,
-                    .selected = sys_markers.selected,
-                };
-                hud_draw(&hud, vehicles, sources, vehicle_count,
-                         selected, GetScreenWidth(), GetScreenHeight(),
-                         scene.theme, trail_mode,
-                         markers.count > 0 ? &user_markers : NULL,
-                         sys_markers.count > 0 ? &sys_marker_data : NULL,
-                         ghost_mode, has_tier3, has_awaiting_gps);
+                hud_marker_data_t all_user_md[MAX_VEHICLES] = {0};
+                hud_marker_data_t all_sys_md[MAX_VEHICLES] = {0};
+                for (int i = 0; i < vehicle_count; i++) {
+                    all_user_md[i] = (hud_marker_data_t){
+                        .times = markers[i].times,
+                        .labels = markers[i].labels,
+                        .roll = markers[i].roll,
+                        .pitch = markers[i].pitch,
+                        .vert = markers[i].vert,
+                        .speed = markers[i].speed,
+                        .speed_max = markers[i].speed_max,
+                        .count = markers[i].count,
+                        .current = markers[i].current,
+                        .selected = true,
+                        .color = vehicles[i].color,
+                    };
+                    all_sys_md[i] = (hud_marker_data_t){
+                        .times = sys_markers[i].times,
+                        .labels = sys_markers[i].labels,
+                        .roll = sys_markers[i].roll,
+                        .pitch = sys_markers[i].pitch,
+                        .vert = sys_markers[i].vert,
+                        .speed = sys_markers[i].speed,
+                        .speed_max = markers[i].speed_max,
+                        .count = sys_markers[i].count,
+                        .current = sys_markers[i].current,
+                        .selected = sys_markers[i].selected,
+                        .color = vehicles[i].color,
+                    };
+                }
+                if (hud.mode == HUD_CONSOLE) {
+                    hud_draw(&hud, vehicles, sources, vehicle_count,
+                             selected, GetScreenWidth(), GetScreenHeight(),
+                             scene.theme, trail_mode,
+                             all_user_md, all_sys_md, vehicle_count,
+                             ghost_mode, has_tier3, has_awaiting_gps);
+                } else if (hud.mode == HUD_TACTICAL) {
+                    tactical_hud_draw(&hud, vehicles, sources, vehicle_count,
+                                      selected, GetScreenWidth(), GetScreenHeight(),
+                                      scene.theme, ghost_mode,
+                                      has_tier3, has_awaiting_gps,
+                                      &ortho, trail_mode, corr_mode,
+                                      all_user_md, all_sys_md, vehicle_count);
+                }
             }
 
             // Debug panel
@@ -1260,12 +1344,14 @@ int main(int argc, char *argv[]) {
                                  vehicle_tier[selected]);
             }
 
-            // Ortho panel overlay
-            int bar_h = show_hud ? hud_bar_height(&hud, GetScreenHeight()) : 0;
-            ortho_panel_draw(&ortho, GetScreenHeight(), bar_h, scene.theme, hud.font_label,
-                             vehicles, vehicle_count, selected, trail_mode,
-                             corr_mode, hud.pinned, hud.pinned_count,
-                             show_axes);
+            // Ortho panel overlay (sidebar in Console mode; tactical draws its own insets)
+            if (hud.mode != HUD_TACTICAL) {
+                int bar_h = show_hud ? hud_bar_height(&hud, GetScreenHeight()) : 0;
+                ortho_panel_draw(&ortho, GetScreenHeight(), bar_h, scene.theme, hud.font_label,
+                                 vehicles, vehicle_count, selected, trail_mode,
+                                 corr_mode, hud.pinned, hud.pinned_count,
+                                 show_axes);
+            }
 
             // Fullscreen ortho view label
             ortho_panel_draw_fullscreen_label(GetScreenWidth(), GetScreenHeight(),
@@ -1289,7 +1375,8 @@ int main(int argc, char *argv[]) {
         if (sources[i].ops) data_source_close(&sources[i]);
     }
     scene_cleanup(&scene);
-    precomp_trail_cleanup(&precomp);
+    for (int i = 0; i < vehicle_count; i++)
+        precomp_trail_cleanup(&precomp[i]);
     CloseWindow();
 
     return 0;

--- a/src/ortho_panel.c
+++ b/src/ortho_panel.c
@@ -563,6 +563,124 @@ void ortho_panel_draw(const ortho_panel_t *op, int screen_h, int hud_bar_h,
     }
 }
 
+// ── Single ortho view at arbitrary position (for tactical HUD insets) ────────
+
+void ortho_panel_draw_single(const ortho_panel_t *op, int view_index,
+                             float x, float y, float size, float grid_alpha,
+                             const theme_t *theme, Font font,
+                             const vehicle_t *vehicles, int vehicle_count,
+                             int selected, int trail_mode,
+                             int corr_mode, const int *pinned, int pinned_count) {
+    if (view_index < 0 || view_index >= ORTHO_VIEW_COUNT) return;
+    int ps = (int)size;
+    int i = view_index;
+
+    float s = powf(size / 180.0f, 0.7f);
+    if (s < 1.0f) s = 1.0f;
+    float font_size = 12 * s;
+
+    Color accent = theme->hud_accent;
+    Color border_col = (Color){ accent.r, accent.g, accent.b, 120 };
+    Color label_col  = (Color){ accent.r, accent.g, accent.b, 200 };
+    Color scale_col  = (Color){ accent.r, accent.g, accent.b, 160 };
+    Color cross_col  = (Color){ accent.r, accent.g, accent.b, 60 };
+    Color gnd_col = theme->ground;
+    Color grid_minor, grid_major;
+    if (grid_alpha < 1.0f) {
+        // Tactical style: accent-colored grid matching radar compass
+        grid_minor = (Color){accent.r, accent.g, accent.b, (unsigned char)(40 * grid_alpha)};
+        grid_major = (Color){accent.r, accent.g, accent.b, (unsigned char)(60 * grid_alpha)};
+    } else {
+        grid_minor = theme->ortho_grid_minor;
+        grid_major = theme->ortho_grid_major;
+    }
+
+    static const char *view_labels[] = { "TOP", "FRONT", "RIGHT" };
+
+    Color bg_col = (grid_alpha < 1.0f) ? theme->hud_bg : (Color){ 5, 5, 12, 200 };
+    DrawRectangle((int)x, (int)y, ps, ps, bg_col);
+
+    // In tactical mode (grid_alpha < 1), skip the 3D render texture — draw 2D only
+    // like the radar does. In normal mode, blit the 3D render.
+    if (grid_alpha >= 1.0f) {
+        Rectangle src = { 0, (float)ORTHO_TEX_SIZE, (float)ORTHO_TEX_SIZE, (float)(-ORTHO_TEX_SIZE) };
+        Rectangle dst = { x, y, (float)ps, (float)ps };
+        DrawTexturePro(op->targets[i].texture, src, dst, (Vector2){0, 0}, 0.0f, WHITE);
+    }
+
+    BeginScissorMode((int)x, (int)y, ps, ps);
+
+    Vector3 center = op->cameras[i].target;
+
+    draw_grid_2d(center, op->ortho_span, x, y, (float)ps, i, grid_minor, grid_major);
+
+    if (i > 0) {
+        Vector3 gnd_pt = { center.x, 0.0f, center.z };
+        Vector2 gp = world_to_panel(gnd_pt, center, op->ortho_span, x, y, (float)ps, i);
+        int gy = (int)gp.y;
+        if (gy < (int)y) gy = (int)y;
+        if (gy + 1 < (int)(y + ps)) {
+            DrawRectangle((int)x, gy + 1, ps, (int)(y + ps) - gy - 1, gnd_col);
+        }
+        Color gnd_line = grid_major;
+        gnd_line.a = 220;
+        Vector2 gl0 = world_to_panel((Vector3){ center.x - op->ortho_span * 2.0f, 0, center.z },
+                                      center, op->ortho_span, x, y, (float)ps, i);
+        Vector2 gl1 = world_to_panel((Vector3){ center.x + op->ortho_span * 2.0f, 0, center.z },
+                                      center, op->ortho_span, x, y, (float)ps, i);
+        DrawLineEx(gl0, gl1, 1.5f, gnd_line);
+    }
+
+    project_ctx_t trail_ctx = {
+        .center = center, .span = op->ortho_span,
+        .px = x, .py = y, .ps = (float)ps, .view = i,
+        .fullscreen = false,
+    };
+    for (int vi = 0; vi < vehicle_count; vi++) {
+        if (vehicles[vi].active || vehicle_count == 1) {
+            draw_trail_2d_impl(&vehicles[vi], theme, trail_mode,
+                               project_panel, &trail_ctx);
+        }
+    }
+
+    if (corr_mode == 1 && pinned_count > 0) {
+        for (int p = 0; p < pinned_count; p++) {
+            int pidx = pinned[p];
+            if (pidx >= 0 && pidx < vehicle_count && vehicles[pidx].active
+                && pidx != selected) {
+                float off_a = vehicles[selected].model_scale * 0.15f;
+                float off_b = vehicles[pidx].model_scale * 0.15f;
+                Vector3 pa = { vehicles[selected].position.x,
+                               vehicles[selected].position.y + off_a,
+                               vehicles[selected].position.z };
+                Vector3 pb = { vehicles[pidx].position.x,
+                               vehicles[pidx].position.y + off_b,
+                               vehicles[pidx].position.z };
+                Vector2 sa = world_to_panel(pa, center, op->ortho_span, x, y, (float)ps, i);
+                Vector2 sb = world_to_panel(pb, center, op->ortho_span, x, y, (float)ps, i);
+                Color mid = {
+                    (unsigned char)((vehicles[selected].color.r + vehicles[pidx].color.r) / 2),
+                    (unsigned char)((vehicles[selected].color.g + vehicles[pidx].color.g) / 2),
+                    (unsigned char)((vehicles[selected].color.b + vehicles[pidx].color.b) / 2),
+                    200
+                };
+                DrawLineEx(sa, sb, 2.0f, mid);
+            }
+        }
+    }
+
+    EndScissorMode();
+
+    DrawRectangleLines((int)x, (int)y, ps, ps, border_col);
+    draw_crosshair(x + ps / 2.0f, y + ps / 2.0f, 6.0f, cross_col);
+
+    Vector2 ts = MeasureTextEx(font, view_labels[i], font_size, 0);
+    DrawTextEx(font, view_labels[i],
+        (Vector2){ x + ps / 2.0f - ts.x / 2.0f, y + 3 }, font_size, 0, label_col);
+
+    draw_scale_bar(x, y, (float)ps, op->ortho_span, scale_col, font, font_size * 0.85f);
+}
+
 // ── Fullscreen 2D ortho overlay ──────────────────────────────────────────────
 
 // Compute the 2D world-space distance visible in a given ortho view.
@@ -835,31 +953,124 @@ static void draw_axis_gizmo_at(float ox, float oy, float sc, int ortho_mode, Fon
 
 // ── 3D axis gizmo at world position ──────────────────────────────────────────
 
+// Draw a 3D ring (circle of line segments) at a position, in a given plane,
+// rotated by the drone's quaternion.
+// plane_a and plane_b are the two local axes that define the ring plane.
+// tri_angle is where to place the direction pyramid (radians around the ring).
+static void draw_3d_ring(Vector3 pos, float radius, Quaternion rot,
+                          Vector3 plane_a, Vector3 plane_b,
+                          float tri_angle, Color color) {
+    int segs = 48;
+    for (int i = 0; i < segs; i++) {
+        float a1 = (float)i / segs * 2.0f * PI;
+        float a2 = (float)(i + 1) / segs * 2.0f * PI;
+        Vector3 local1 = {
+            plane_a.x * cosf(a1) * radius + plane_b.x * sinf(a1) * radius,
+            plane_a.y * cosf(a1) * radius + plane_b.y * sinf(a1) * radius,
+            plane_a.z * cosf(a1) * radius + plane_b.z * sinf(a1) * radius
+        };
+        Vector3 local2 = {
+            plane_a.x * cosf(a2) * radius + plane_b.x * sinf(a2) * radius,
+            plane_a.y * cosf(a2) * radius + plane_b.y * sinf(a2) * radius,
+            plane_a.z * cosf(a2) * radius + plane_b.z * sinf(a2) * radius
+        };
+        Vector3 w1 = Vector3RotateByQuaternion(local1, rot);
+        Vector3 w2 = Vector3RotateByQuaternion(local2, rot);
+        DrawLine3D(
+            (Vector3){pos.x + w1.x, pos.y + w1.y, pos.z + w1.z},
+            (Vector3){pos.x + w2.x, pos.y + w2.y, pos.z + w2.z},
+            color);
+    }
+
+    // Outward-pointing 4-sided pyramid at the apex of the ring
+    float tri_size = radius * 0.06f;
+    float ta = tri_angle;
+
+    Vector3 radial = {
+        plane_a.x * cosf(ta) + plane_b.x * sinf(ta),
+        plane_a.y * cosf(ta) + plane_b.y * sinf(ta),
+        plane_a.z * cosf(ta) + plane_b.z * sinf(ta)
+    };
+    Vector3 tangent = {
+        -plane_a.x * sinf(ta) + plane_b.x * cosf(ta),
+        -plane_a.y * sinf(ta) + plane_b.y * cosf(ta),
+        -plane_a.z * sinf(ta) + plane_b.z * cosf(ta)
+    };
+    Vector3 normal = {
+        plane_a.y * plane_b.z - plane_a.z * plane_b.y,
+        plane_a.z * plane_b.x - plane_a.x * plane_b.z,
+        plane_a.x * plane_b.y - plane_a.y * plane_b.x
+    };
+
+    Vector3 p_tip = {
+        radial.x * (radius + tri_size),
+        radial.y * (radius + tri_size),
+        radial.z * (radius + tri_size)
+    };
+    float bs = tri_size * 0.45f;
+    Vector3 p_b1 = { radial.x * radius + tangent.x * bs + normal.x * bs,
+                     radial.y * radius + tangent.y * bs + normal.y * bs,
+                     radial.z * radius + tangent.z * bs + normal.z * bs };
+    Vector3 p_b2 = { radial.x * radius - tangent.x * bs + normal.x * bs,
+                     radial.y * radius - tangent.y * bs + normal.y * bs,
+                     radial.z * radius - tangent.z * bs + normal.z * bs };
+    Vector3 p_b3 = { radial.x * radius - tangent.x * bs - normal.x * bs,
+                     radial.y * radius - tangent.y * bs - normal.y * bs,
+                     radial.z * radius - tangent.z * bs - normal.z * bs };
+    Vector3 p_b4 = { radial.x * radius + tangent.x * bs - normal.x * bs,
+                     radial.y * radius + tangent.y * bs - normal.y * bs,
+                     radial.z * radius + tangent.z * bs - normal.z * bs };
+
+    Vector3 wt  = Vector3RotateByQuaternion(p_tip, rot);
+    Vector3 wb1 = Vector3RotateByQuaternion(p_b1, rot);
+    Vector3 wb2 = Vector3RotateByQuaternion(p_b2, rot);
+    Vector3 wb3 = Vector3RotateByQuaternion(p_b3, rot);
+    Vector3 wb4 = Vector3RotateByQuaternion(p_b4, rot);
+
+    #define VOFF(v) (Vector3){pos.x + v.x, pos.y + v.y, pos.z + v.z}
+    DrawTriangle3D(VOFF(wt), VOFF(wb1), VOFF(wb2), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb2), VOFF(wb3), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb3), VOFF(wb4), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb4), VOFF(wb1), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb2), VOFF(wb1), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb3), VOFF(wb2), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb4), VOFF(wb3), color);
+    DrawTriangle3D(VOFF(wt), VOFF(wb1), VOFF(wb4), color);
+    #undef VOFF
+}
+
 void draw_axis_gizmo_3d(Vector3 pos, float scale, Quaternion rot) {
-    float len = scale;
+    float r = scale;
 
-    // Rotate unit axis vectors by the drone's quaternion
-    Vector3 ax = Vector3RotateByQuaternion((Vector3){len, 0, 0}, rot);
-    Vector3 ay = Vector3RotateByQuaternion((Vector3){0, len, 0}, rot);
-    Vector3 az = Vector3RotateByQuaternion((Vector3){0, 0, len}, rot);
+    // Decompose quaternion into gimbal hierarchy:
+    // Yaw (Y-axis) -> Pitch (X-axis) -> Roll (Z-axis)
+    Vector3 fwd = Vector3RotateByQuaternion((Vector3){0, 0, -1}, rot);
+    float yaw = atan2f(-fwd.x, -fwd.z);
+    Quaternion q_yaw = QuaternionFromAxisAngle((Vector3){0, 1, 0}, yaw);
 
-    Vector3 tip_x = { pos.x + ax.x, pos.y + ax.y, pos.z + ax.z };
-    Vector3 tip_y = { pos.x + ay.x, pos.y + ay.y, pos.z + ay.z };
-    Vector3 tip_z = { pos.x + az.x, pos.y + az.y, pos.z + az.z };
+    Quaternion q_yaw_inv = QuaternionInvert(q_yaw);
+    Quaternion q_remainder = QuaternionMultiply(q_yaw_inv, rot);
+    Vector3 fwd_rem = Vector3RotateByQuaternion((Vector3){0, 0, -1}, q_remainder);
+    float pitch = atan2f(fwd_rem.y, -fwd_rem.z);
+    Quaternion q_pitch = QuaternionFromAxisAngle((Vector3){1, 0, 0}, pitch);
 
-    // X = red, Y = green, Z = blue
-    Color col_x = { 220,  60,  60, 240 };
-    Color col_y = {  60, 200,  60, 240 };
-    Color col_z = {  60, 100, 220, 240 };
+    Quaternion q_yaw_pitch = QuaternionMultiply(q_yaw, q_pitch);
+    Quaternion q_full = rot;
 
-    DrawLine3D(pos, tip_x, col_x);
-    DrawLine3D(pos, tip_y, col_y);
-    DrawLine3D(pos, tip_z, col_z);
+    // Yaw ring (cyan, outermost) — horizontal XZ plane, rotated by yaw only
+    Color col_yaw = { 0, 180, 204, 200 };
+    draw_3d_ring(pos, r * 1.15f, q_yaw, (Vector3){1, 0, 0}, (Vector3){0, 0, -1},
+                 PI * 0.5f, col_yaw);
 
-    float r = len * 0.06f;
-    DrawSphere(tip_x, r, col_x);
-    DrawSphere(tip_y, r, col_y);
-    DrawSphere(tip_z, r, col_z);
+    // Pitch ring (green, middle) — vertical YZ plane, rotated by yaw+pitch
+    Color col_pitch = { 52, 211, 153, 200 };
+    draw_3d_ring(pos, r, q_yaw_pitch, (Vector3){0, 0, -1}, (Vector3){0, 1, 0},
+                 PI * 0.5f, col_pitch);
+
+    // Roll ring (red, innermost) — vertical XY plane, rotated by full quaternion
+    Color col_roll = { 255, 100, 100, 200 };
+    draw_3d_ring(pos, r * 0.85f, q_full, (Vector3){1, 0, 0}, (Vector3){0, 1, 0},
+                 0.0f, col_roll);
 }
 
 // ── Cleanup ──────────────────────────────────────────────────────────────────

--- a/src/ortho_panel.h
+++ b/src/ortho_panel.h
@@ -35,6 +35,15 @@ void ortho_draw_fullscreen_2d(const scene_t *s, const vehicle_t *vehicles,
 void ortho_panel_draw_fullscreen_label(int screen_w, int screen_h, int ortho_mode,
                                        float ortho_span, const theme_t *theme,
                                        Font font, bool show_axes);
+// Draw a single ortho view at an arbitrary screen position/size.
+// view_index: 0=top, 1=front, 2=side (right). grid_alpha: 0.0-1.0 grid opacity.
+void ortho_panel_draw_single(const ortho_panel_t *op, int view_index,
+                             float x, float y, float size, float grid_alpha,
+                             const theme_t *theme, Font font,
+                             const vehicle_t *vehicles, int vehicle_count,
+                             int selected, int trail_mode,
+                             int corr_mode, const int *pinned, int pinned_count);
+
 void ortho_panel_cleanup(ortho_panel_t *op);
 
 // Draw XYZ axis gizmo at a world position, rotated by quaternion (call inside BeginMode3D).

--- a/src/replay_markers.c
+++ b/src/replay_markers.c
@@ -2,6 +2,7 @@
 #include "replay_trail.h"
 #include "raylib.h"
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
 
 int marker_drop(user_markers_t *um, float time, Vector3 pos,
@@ -143,6 +144,11 @@ void marker_cycle(user_markers_t *um, sys_markers_t *sm,
             scene->camera.position = seek_pos;
             scene->camera.target = vehicle->position;
         } else {
+            // Return to chase camera if free mode was active
+            if (scene->cam_mode == CAM_MODE_FREE) {
+                scene->cam_mode = CAM_MODE_CHASE;
+                scene->free_track = false;
+            }
             // Seek and sync state
             data_source_seek(source, seek_time);
             vehicle->current_time = source->playback.position_s;
@@ -182,4 +188,151 @@ void marker_cycle(user_markers_t *um, sys_markers_t *sm,
             *last_pos = vehicle->position;
         }
     }
+}
+
+marker_cycle_result_t marker_cycle_global(
+    user_markers_t *all_markers, sys_markers_t *all_sys,
+    int vehicle_count, int current_drone, int direction,
+    data_source_t *sources, vehicle_t *vehicles,
+    const precomp_trail_t *precomps,
+    scene_t *scene, Vector3 *last_pos)
+{
+    marker_cycle_result_t result = {current_drone, false};
+
+    // Build merged list of all drones' markers
+    typedef struct { float time; int idx; int drone; bool is_sys; } gm_t;
+    int max_entries = vehicle_count * (REPLAY_MAX_MARKERS + REPLAY_MAX_SYS_MARKERS);
+    gm_t *merged = (gm_t *)malloc(max_entries * sizeof(gm_t));
+    if (!merged) return result;
+
+    int total = 0;
+    for (int d = 0; d < vehicle_count; d++) {
+        for (int m = 0; m < all_markers[d].count; m++)
+            merged[total++] = (gm_t){all_markers[d].times[m], m, d, false};
+        for (int m = 0; m < all_sys[d].count; m++)
+            merged[total++] = (gm_t){all_sys[d].times[m], m, d, true};
+    }
+
+    if (total == 0) { free(merged); return result; }
+
+    // Insertion sort by time
+    for (int a = 1; a < total; a++) {
+        gm_t key = merged[a];
+        int b = a - 1;
+        while (b >= 0 && merged[b].time > key.time) {
+            merged[b + 1] = merged[b];
+            b--;
+        }
+        merged[b + 1] = key;
+    }
+
+    // Find current position: check if any drone has a selected marker
+    int cur = -1;
+    for (int d = 0; d < vehicle_count; d++) {
+        if (all_sys[d].selected && all_sys[d].current >= 0) {
+            for (int m = 0; m < total; m++) {
+                if (merged[m].is_sys && merged[m].drone == d
+                    && merged[m].idx == all_sys[d].current) {
+                    cur = m; break;
+                }
+            }
+            if (cur >= 0) break;
+        } else if (!all_sys[d].selected && all_markers[d].current >= 0) {
+            for (int m = 0; m < total; m++) {
+                if (!merged[m].is_sys && merged[m].drone == d
+                    && merged[m].idx == all_markers[d].current) {
+                    cur = m; break;
+                }
+            }
+            if (cur >= 0) break;
+        }
+    }
+
+    // Step to target
+    int target = -1;
+    if (direction < 0) {
+        if (cur > 0) target = cur - 1;
+        else if (cur == 0) target = total - 1;
+        else {
+            float t = sources[current_drone].playback.position_s;
+            for (int m = total - 1; m >= 0; m--) {
+                if (merged[m].time <= t) { target = m; break; }
+            }
+            if (target < 0) target = total - 1;
+        }
+    } else {
+        if (cur >= 0 && cur < total - 1) target = cur + 1;
+        else if (cur < 0) {
+            float t = sources[current_drone].playback.position_s;
+            for (int m = 0; m < total; m++) {
+                if (merged[m].time >= t) { target = m; break; }
+            }
+            if (target < 0) target = 0;
+        } else {
+            target = 0;
+        }
+    }
+
+    if (target >= 0 && target < total) {
+        gm_t tgt = merged[target];
+        int d = tgt.drone;
+        float seek_time = tgt.time;
+
+        // Clear all drones' marker selection
+        for (int i = 0; i < vehicle_count; i++) {
+            all_sys[i].selected = false;
+            all_sys[i].current = -1;
+            all_markers[i].current = -1;
+        }
+
+        // Set target drone's marker as current
+        all_sys[d].selected = tgt.is_sys;
+        if (tgt.is_sys) {
+            all_sys[d].current = tgt.idx;
+        } else {
+            all_markers[d].current = tgt.idx;
+        }
+
+        // Seek only the target drone's source and restore its trail
+        data_source_seek(&sources[d], seek_time);
+        vehicles[d].current_time = sources[d].playback.position_s;
+
+        if (precomps[d].ready && precomps[d].count > 0) {
+            int lo = 0, hi = precomps[d].count - 1, cut = 0;
+            while (lo <= hi) {
+                int mid = (lo + hi) / 2;
+                if (precomps[d].time[mid] <= seek_time) {
+                    cut = mid + 1; lo = mid + 1;
+                } else {
+                    hi = mid - 1;
+                }
+            }
+            int n = cut;
+            if (n > vehicles[d].trail_capacity) n = vehicles[d].trail_capacity;
+            int src_start = cut - n;
+            vehicles[d].trail_count = n;
+            vehicles[d].trail_head = n % vehicles[d].trail_capacity;
+            vehicles[d].trail_speed_max = 0.0f;
+            for (int ti = 0; ti < n; ti++) {
+                int si = src_start + ti;
+                vehicles[d].trail[ti] = precomps[d].trail[si];
+                vehicles[d].trail_roll[ti] = precomps[d].roll[si];
+                vehicles[d].trail_pitch[ti] = precomps[d].pitch[si];
+                vehicles[d].trail_vert[ti] = precomps[d].vert[si];
+                vehicles[d].trail_speed[ti] = precomps[d].speed[si];
+                vehicles[d].trail_time[ti] = precomps[d].time[si];
+                if (precomps[d].speed[si] > vehicles[d].trail_speed_max)
+                    vehicles[d].trail_speed_max = precomps[d].speed[si];
+            }
+        }
+
+        vehicle_update(&vehicles[d], &sources[d].state, &sources[d].home);
+        last_pos[d] = vehicles[d].position;
+
+        result.drone_idx = d;
+        result.jumped = true;
+    }
+
+    free(merged);
+    return result;
 }

--- a/src/replay_markers.h
+++ b/src/replay_markers.h
@@ -37,4 +37,16 @@ void marker_cycle(user_markers_t *um, sys_markers_t *sm,
                   const precomp_trail_t *precomp,
                   scene_t *scene, Vector3 *last_pos);
 
+typedef struct {
+    int drone_idx;
+    bool jumped;
+} marker_cycle_result_t;
+
+marker_cycle_result_t marker_cycle_global(
+    user_markers_t *all_markers, sys_markers_t *all_sys,
+    int vehicle_count, int current_drone, int direction,
+    data_source_t *sources, vehicle_t *vehicles,
+    const precomp_trail_t *precomps,
+    scene_t *scene, Vector3 *last_pos);
+
 #endif

--- a/src/replay_trail.c
+++ b/src/replay_trail.c
@@ -34,16 +34,20 @@ void replay_init_sys_markers(sys_markers_t *sm, const data_source_t *source) {
 void replay_resolve_and_build_trail(sys_markers_t *sm, precomp_trail_t *pt,
                                     data_source_t *source, vehicle_t *vehicle) {
     float saved_pos = source->playback.position_s;
+    float offset = source->playback.time_offset_s;
     int valid = 0;
     for (int i = 0; i < sm->count; i++) {
-        data_source_seek(source, sm->times[i]);
+        // Adjust marker time to playback space (subtract offset)
+        float playback_time = sm->times[i] - offset;
+        if (playback_time < 0.0f) continue;
+        data_source_seek(source, playback_time);
         replay_sync_vehicle(source, vehicle);
         if (source->state.lat == 0 && source->state.lon == 0) continue;
         Vector3 mp = vehicle->position;
         if (mp.x == 0.0f && mp.y == 0.0f && mp.z == 0.0f) continue;
         float mdist = sqrtf(mp.x * mp.x + mp.y * mp.y + mp.z * mp.z);
         if (mdist > 5000.0f) continue;
-        sm->times[valid] = sm->times[i];
+        sm->times[valid] = playback_time;
         memcpy(sm->labels[valid], sm->labels[i], HUD_MARKER_LABEL_MAX);
         sm->positions[valid] = vehicle->position;
         sm->roll[valid] = vehicle->roll_deg;

--- a/src/tactical_hud.c
+++ b/src/tactical_hud.c
@@ -1,0 +1,823 @@
+#include "tactical_hud.h"
+#include "hud_transport.h"
+#include "theme.h"
+#include "ulog_replay.h"
+#include "raylib.h"
+#include "raymath.h"
+#include "rlgl.h"
+
+#ifdef _WIN32
+#undef DrawText
+#endif
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+// All wireframe coordinates are from a 1920x1080 viewBox.
+// We map proportionally to actual screen dimensions.
+#define WF_W 1920.0f
+#define WF_H 1080.0f
+
+static float wx(float v, int sw) { return v * sw / WF_W; }
+static float wy(float v, int sh) { return v * sh / WF_H; }
+static float ws(float v, int sw, int sh) {
+    float scale = (sw / WF_W < sh / WF_H) ? sw / WF_W : sh / WF_H;
+    return v * scale;
+}
+
+// ── Tag shape ──────────────────────────────────────────────────────────────
+static void draw_tag(float x, float y, float body_w, float h, float point_w,
+                     float cr, bool point_right, float thick, Color color) {
+    float mid_y = y + h / 2.0f;
+    int segs = 6;
+
+    if (point_right) {
+        for (int i = 0; i <= segs; i++) {
+            float a1 = PI + (PI / 2.0f) * (float)i / segs;
+            float a2 = PI + (PI / 2.0f) * (float)(i + 1) / segs;
+            if (i == segs) a2 = PI + PI / 2.0f;
+            DrawLineEx(
+                (Vector2){x + cr + cosf(a1) * cr, y + cr + sinf(a1) * cr},
+                (Vector2){x + cr + cosf(a2) * cr, y + cr + sinf(a2) * cr},
+                thick, color);
+        }
+        DrawLineEx((Vector2){x + cr, y}, (Vector2){x + body_w, y}, thick, color);
+        DrawLineEx((Vector2){x + body_w, y}, (Vector2){x + body_w + point_w, mid_y}, thick, color);
+        DrawLineEx((Vector2){x + body_w + point_w, mid_y}, (Vector2){x + body_w, y + h}, thick, color);
+        DrawLineEx((Vector2){x + body_w, y + h}, (Vector2){x + cr, y + h}, thick, color);
+        for (int i = 0; i <= segs; i++) {
+            float a1 = PI / 2.0f + (PI / 2.0f) * (float)i / segs;
+            float a2 = PI / 2.0f + (PI / 2.0f) * (float)(i + 1) / segs;
+            if (i == segs) a2 = PI;
+            DrawLineEx(
+                (Vector2){x + cr + cosf(a1) * cr, y + h - cr + sinf(a1) * cr},
+                (Vector2){x + cr + cosf(a2) * cr, y + h - cr + sinf(a2) * cr},
+                thick, color);
+        }
+        DrawLineEx((Vector2){x, y + h - cr}, (Vector2){x, y + cr}, thick, color);
+    } else {
+        float rx = x + point_w + body_w;
+        DrawLineEx((Vector2){x, mid_y}, (Vector2){x + point_w, y}, thick, color);
+        DrawLineEx((Vector2){x + point_w, y}, (Vector2){rx - cr, y}, thick, color);
+        for (int i = 0; i <= segs; i++) {
+            float a1 = -PI / 2.0f + (PI / 2.0f) * (float)i / segs;
+            float a2 = -PI / 2.0f + (PI / 2.0f) * (float)(i + 1) / segs;
+            if (i == segs) a2 = 0;
+            DrawLineEx(
+                (Vector2){rx - cr + cosf(a1) * cr, y + cr + sinf(a1) * cr},
+                (Vector2){rx - cr + cosf(a2) * cr, y + cr + sinf(a2) * cr},
+                thick, color);
+        }
+        DrawLineEx((Vector2){rx, y + cr}, (Vector2){rx, y + h - cr}, thick, color);
+        for (int i = 0; i <= segs; i++) {
+            float a1 = (PI / 2.0f) * (float)i / segs;
+            float a2 = (PI / 2.0f) * (float)(i + 1) / segs;
+            if (i == segs) a2 = PI / 2.0f;
+            DrawLineEx(
+                (Vector2){rx - cr + cosf(a1) * cr, y + h - cr + sinf(a1) * cr},
+                (Vector2){rx - cr + cosf(a2) * cr, y + h - cr + sinf(a2) * cr},
+                thick, color);
+        }
+        DrawLineEx((Vector2){rx - cr, y + h}, (Vector2){x + point_w, y + h}, thick, color);
+        DrawLineEx((Vector2){x + point_w, y + h}, (Vector2){x, mid_y}, thick, color);
+    }
+}
+
+// ── Timer + Status (top-left) ─────────────────────────────────────────────
+static void tac_draw_timer_status(const hud_t *h, const data_source_t *src,
+                                   int sw, int sh, const theme_t *theme) {
+    float mx = wx(27, sw);
+    float my = wy(27, sh);
+    float fs_timer = wy(21, sh);
+    float fs_label = wy(12, sh);
+    float fs_status = wy(13, sh);
+
+    char b[16];
+    int total_secs = (int)h->sim_time_s;
+    int mins = total_secs / 60;
+    int secs = total_secs % 60;
+    if (mins >= 60)
+        snprintf(b, sizeof(b), "%d:%02d:%02d", mins / 60, mins % 60, secs);
+    else
+        snprintf(b, sizeof(b), "%02d:%02d", mins, secs);
+    DrawTextEx(h->font_value, b, (Vector2){mx, my}, fs_timer, 0.5f, theme->hud_value);
+    DrawTextEx(h->font_label, "SIM",
+               (Vector2){mx, my + fs_timer + wy(2, sh)}, fs_label, 0.5f, theme->hud_dim);
+
+    bool connected = src->connected;
+    float dot_y = my + fs_timer + fs_label + wy(12, sh);
+    Color dot_c = connected ? theme->hud_connected : (Color){200, 60, 60, 255};
+    DrawCircle((int)(mx + wy(4, sh)), (int)(dot_y + wy(4, sh)), wy(4, sh), dot_c);
+
+    char status_buf[48];
+    if (src->playback.duration_s > 0.0f) {
+        if (!connected) snprintf(status_buf, sizeof(status_buf), "Replay ended");
+        else if (src->playback.paused) snprintf(status_buf, sizeof(status_buf), "Replay paused");
+        else snprintf(status_buf, sizeof(status_buf), "Replaying log...");
+    } else if (connected) {
+        snprintf(status_buf, sizeof(status_buf), "MAVLink connected");
+    } else {
+        snprintf(status_buf, sizeof(status_buf), "Waiting...");
+    }
+    DrawTextEx(h->font_label, status_buf,
+               (Vector2){mx + wy(14, sh), dot_y}, fs_status, 0.5f,
+               connected ? theme->hud_connected : theme->hud_dim);
+}
+
+// ── Ticker (top-center) ───────────────────────────────────────────────────
+static void tac_draw_ticker(const hud_t *h, const playback_state_t *pb,
+                             const hud_marker_data_t *user_md,
+                             const hud_marker_data_t *sys_md,
+                             int sw, int sh, const theme_t *theme) {
+    float fs = wy(16, sh);
+    float line_y = wy(27, sh);
+
+    // Check if a marker is selected
+    const char *marker_label = NULL;
+    char marker_buf[64];
+    if (sys_md && sys_md->selected && sys_md->current >= 0 && sys_md->current < sys_md->count) {
+        if (sys_md->labels[sys_md->current][0] != '\0')
+            snprintf(marker_buf, sizeof(marker_buf), "S: %s", sys_md->labels[sys_md->current]);
+        else
+            snprintf(marker_buf, sizeof(marker_buf), "S%d", sys_md->current + 1);
+        marker_label = marker_buf;
+    } else if (user_md && user_md->current >= 0 && user_md->current < user_md->count) {
+        if (user_md->labels[user_md->current][0] != '\0')
+            snprintf(marker_buf, sizeof(marker_buf), "%d: %s", user_md->current + 1, user_md->labels[user_md->current]);
+        else
+            snprintf(marker_buf, sizeof(marker_buf), "MARKER %d", user_md->current + 1);
+        marker_label = marker_buf;
+    }
+
+    // Get flight mode name
+    const char *mode_name = NULL;
+    if (pb && pb->mode_changes && pb->mode_change_count > 0) {
+        for (int i = pb->mode_change_count - 1; i >= 0; i--) {
+            if (pb->mode_changes[i].time_s <= pb->position_s) {
+                mode_name = ulog_nav_state_name(pb->mode_changes[i].nav_state);
+                break;
+            }
+        }
+    }
+
+    // Cycle between mode and marker every 3 seconds
+    if (marker_label && mode_name) {
+        bool show_marker = ((int)(GetTime() / 3.0) % 2) == 1;
+        if (show_marker) {
+            Vector2 mw = MeasureTextEx(h->font_label, marker_label, fs, 0.5f);
+            DrawTextEx(h->font_label, marker_label,
+                       (Vector2){sw / 2.0f - mw.x / 2, line_y},
+                       fs, 0.5f, theme->hud_accent);
+        } else {
+            char buf[64];
+            snprintf(buf, sizeof(buf), "MODE: %s", mode_name);
+            Vector2 tw = MeasureTextEx(h->font_label, buf, fs, 0.5f);
+            DrawTextEx(h->font_label, buf,
+                       (Vector2){sw / 2.0f - tw.x / 2, line_y},
+                       fs, 0.5f, theme->hud_warn);
+        }
+    } else if (marker_label) {
+        Vector2 mw = MeasureTextEx(h->font_label, marker_label, fs, 0.5f);
+        DrawTextEx(h->font_label, marker_label,
+                   (Vector2){sw / 2.0f - mw.x / 2, line_y},
+                   fs, 0.5f, theme->hud_accent);
+    } else if (mode_name) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "MODE: %s", mode_name);
+        Vector2 tw = MeasureTextEx(h->font_label, buf, fs, 0.5f);
+        DrawTextEx(h->font_label, buf,
+                   (Vector2){sw / 2.0f - tw.x / 2, line_y},
+                   fs, 0.5f, theme->hud_warn);
+    }
+}
+
+// ── Heading (top-right) ───────────────────────────────────────────────────
+static void tac_draw_heading(const hud_t *h, const vehicle_t *v,
+                              int sw, int sh, const theme_t *theme) {
+    float mx = wx(27, sw);
+    float fs_label = wy(13, sh);
+    float fs_value = wy(27, sh);
+
+    const char *lbl = "HDG";
+    Vector2 lw = MeasureTextEx(h->font_label, lbl, fs_label, 0.5f);
+    DrawTextEx(h->font_label, lbl,
+               (Vector2){sw - mx - lw.x, wy(27, sh)},
+               fs_label, 0.5f, theme->hud_accent_dim);
+
+    char b[8];
+    snprintf(b, sizeof(b), "%03d", ((int)v->heading_deg % 360 + 360) % 360);
+    Vector2 vw = MeasureTextEx(h->font_value, b, fs_value, 0.5f);
+    DrawTextEx(h->font_value, b,
+               (Vector2){sw - mx - vw.x, wy(27, sh) + fs_label + wy(2, sh)},
+               fs_value, 0.5f, theme->hud_value);
+}
+
+// ── Speed Stack (GS tag, left of center) ──────────────────────────────────
+static void tac_draw_speed_stack(const hud_t *h, const vehicle_t *vehicles,
+                                  int vehicle_count, int selected,
+                                  int sw, int sh, const theme_t *theme) {
+    float anchor = sw * 0.25f;
+    float cy = sh * 0.5f;
+
+    float body_w = wx(102, sw);
+    float tag_h = wy(36, sh);
+    float point_w = wx(22, sw);
+    float tag_total = body_w + point_w;
+
+    float fs_label = wy(13, sh);
+    float fs_value = wy(28, sh);
+    float fs_unit = wy(11, sh);
+    float fs_pinned = wy(19, sh);
+    float line_h = wy(22, sh);
+
+    Color border = theme->hud_border;
+    Color value_c = theme->hud_value;
+    Color label_c = theme->hud_accent_dim;
+    Color dim_c = theme->hud_dim;
+
+    const vehicle_t *v = &vehicles[selected];
+
+    float tag_x = anchor - tag_total;
+    float tag_y = cy - tag_h / 2.0f;
+    float cr = ws(6.66f, sw, sh);
+    draw_tag(tag_x, tag_y, body_w, tag_h, point_w, cr, true, 1.3f, border);
+
+    char val[16];
+    snprintf(val, sizeof(val), "%.1f", v->ground_speed);
+    Vector2 vw = MeasureTextEx(h->font_value, val, fs_value, 0.5f);
+    DrawTextEx(h->font_value, val,
+               (Vector2){tag_x + body_w / 2 - vw.x / 2, tag_y + tag_h / 2 - vw.y / 2},
+               fs_value, 0.5f, value_c);
+
+    Vector2 lw = MeasureTextEx(h->font_label, "GS", fs_label, 0.5f);
+    DrawTextEx(h->font_label, "GS",
+               (Vector2){tag_x + body_w - lw.x, tag_y - fs_label - wy(4, sh)},
+               fs_label, 0.5f, label_c);
+
+    Vector2 uw = MeasureTextEx(h->font_label, "m/s", fs_unit, 0.5f);
+    DrawTextEx(h->font_label, "m/s",
+               (Vector2){tag_x + body_w - uw.x, tag_y + tag_h + wy(4, sh)},
+               fs_unit, 0.5f, dim_c);
+
+    float pinned_y = tag_y - fs_label - wy(4, sh) - line_h;
+    for (int p = 0; p < h->pinned_count; p++) {
+        int pidx = h->pinned[p];
+        if (pidx < 0 || pidx >= vehicle_count) continue;
+        char pb[16];
+        snprintf(pb, sizeof(pb), "%.1f", vehicles[pidx].ground_speed);
+        Vector2 pw = MeasureTextEx(h->font_value, pb, fs_pinned, 0.5f);
+        DrawTextEx(h->font_value, pb,
+                   (Vector2){tag_x + body_w - pw.x, pinned_y - p * line_h},
+                   fs_pinned, 0.5f, vehicles[pidx].color);
+    }
+}
+
+// ── Altitude Stack (ALT tag, right of center) ─────────────────────────────
+static void tac_draw_alt_stack(const hud_t *h, const vehicle_t *vehicles,
+                                int vehicle_count, int selected,
+                                int sw, int sh, const theme_t *theme) {
+    float anchor = sw * 0.75f;
+    float cy = sh * 0.5f;
+
+    float body_w = wx(102, sw);
+    float tag_h = wy(36, sh);
+    float point_w = wx(22, sw);
+
+    float fs_label = wy(13, sh);
+    float fs_value = wy(28, sh);
+    float fs_vs = wy(13, sh);
+    float fs_pinned = wy(19, sh);
+    float fs_pinned_vs = wy(12, sh);
+    float line_h = wy(22, sh);
+
+    Color border = theme->hud_border;
+    Color value_c = theme->hud_value;
+    Color label_c = theme->hud_accent_dim;
+    Color dim_c = theme->hud_dim;
+    Color climb_c = theme->hud_climb;
+    Color warn_c = theme->hud_warn;
+
+    const vehicle_t *v = &vehicles[selected];
+
+    float tag_x = anchor;
+    float tag_y = cy - tag_h / 2.0f;
+    float cr = ws(6.66f, sw, sh);
+    draw_tag(tag_x, tag_y, body_w, tag_h, point_w, cr, false, 1.3f, border);
+
+    char val[16];
+    snprintf(val, sizeof(val), "%.1f", v->altitude_rel);
+    Vector2 vw = MeasureTextEx(h->font_value, val, fs_value, 0.5f);
+    float body_x = tag_x + point_w;
+    DrawTextEx(h->font_value, val,
+               (Vector2){body_x + body_w / 2 - vw.x / 2, tag_y + tag_h / 2 - vw.y / 2},
+               fs_value, 0.5f, value_c);
+
+    DrawTextEx(h->font_label, "ALT",
+               (Vector2){body_x, tag_y - fs_label - wy(4, sh)},
+               fs_label, 0.5f, label_c);
+
+    Color vs_c = (v->vertical_speed > 0.1f) ? climb_c :
+                 (v->vertical_speed < -0.1f) ? warn_c : value_c;
+    const char *arrow = (v->vertical_speed > 0.1f) ? "^" :
+                        (v->vertical_speed < -0.1f) ? "v" : "";
+    char vs_buf[16];
+    snprintf(vs_buf, sizeof(vs_buf), "%s %.1f m/s", arrow, fabsf(v->vertical_speed));
+    DrawTextEx(h->font_value, vs_buf,
+               (Vector2){body_x, tag_y + tag_h + wy(4, sh)},
+               fs_vs, 0.5f, vs_c);
+
+    float pinned_y = tag_y - fs_label - wy(4, sh) - line_h;
+    for (int p = 0; p < h->pinned_count; p++) {
+        int pidx = h->pinned[p];
+        if (pidx < 0 || pidx >= vehicle_count) continue;
+        char pb[16];
+        snprintf(pb, sizeof(pb), "%.1f", vehicles[pidx].altitude_rel);
+        DrawTextEx(h->font_value, pb,
+                   (Vector2){body_x, pinned_y - p * line_h},
+                   fs_pinned, 0.5f, vehicles[pidx].color);
+
+        Vector2 pw = MeasureTextEx(h->font_value, pb, fs_pinned, 0.5f);
+        const char *va = (vehicles[pidx].vertical_speed > 0.1f) ? "^" :
+                         (vehicles[pidx].vertical_speed < -0.1f) ? "v" : "-";
+        DrawTextEx(h->font_value, va,
+                   (Vector2){body_x + pw.x + wx(4, sw), pinned_y - p * line_h},
+                   fs_pinned_vs, 0.5f, vehicles[pidx].color);
+    }
+}
+
+// ── Radar Panel (bottom-left) ─────────────────────────────────────────────
+static void tac_draw_radar(const hud_t *h, const vehicle_t *vehicles,
+                            int vehicle_count, int selected,
+                            int sw, int sh, const theme_t *theme,
+                            const ortho_panel_t *ortho,
+                            int trail_mode, int corr_mode) {
+    float ps = wx(293, sw);
+    float px = wx(95, sw);
+    float py = (float)sh - wy(130, sh) - ps;
+
+    float ccx = px + ps / 2.0f;
+    float compass_offset = ps / 4.0f;
+    float ccy = py + ps / 2.0f + compass_offset;
+    float cr = ps * 0.46f;
+
+    Color accent = theme->hud_accent;
+    Color dim_c = theme->hud_dim;
+    Color warn = theme->hud_warn;
+
+    DrawRectangle((int)px, (int)py, (int)ps, (int)ps, theme->hud_bg);
+
+    if (ortho) {
+        BeginScissorMode((int)px, (int)py, (int)ps, (int)ps);
+        Vector3 center = vehicles[selected].position;
+        float span = ortho->ortho_span;
+        float grid_scale = ps / span;
+
+        float spacing = 10.0f;
+        if (span > 200.0f) spacing = 50.0f;
+        else if (span > 80.0f) spacing = 20.0f;
+        else if (span < 20.0f) spacing = 2.0f;
+
+        Color grid_minor = theme->ortho_grid_minor;
+        grid_minor.a = (unsigned char)(grid_minor.a * 0.5f);
+        Color grid_major = theme->ortho_grid_major;
+        grid_major.a = (unsigned char)(grid_major.a * 0.5f);
+        float ext = span * 0.8f;
+        float sx_start = floorf((center.x - ext) / spacing) * spacing;
+        float sz_start = floorf((center.z - ext) / spacing) * spacing;
+
+        for (float x = sx_start; x <= center.x + ext; x += spacing) {
+            bool major = fabsf(fmodf(x, spacing * 5)) < 0.1f;
+            Color gc = major ? grid_major : grid_minor;
+            float lw = major ? 1.5f : 1.0f;
+            float sx1 = ccx + (x - center.x) * grid_scale;
+            float sy1 = ccy + (-ext) * grid_scale;
+            float sy2 = ccy + (ext) * grid_scale;
+            DrawLineEx((Vector2){sx1, sy1}, (Vector2){sx1, sy2}, lw, gc);
+        }
+        for (float z = sz_start; z <= center.z + ext; z += spacing) {
+            bool major = fabsf(fmodf(z, spacing * 5)) < 0.1f;
+            Color gc = major ? grid_major : grid_minor;
+            float lw = major ? 1.5f : 1.0f;
+            float sy1 = ccy + (z - center.z) * grid_scale;
+            float sx1 = ccx + (-ext) * grid_scale;
+            float sx2 = ccx + (ext) * grid_scale;
+            DrawLineEx((Vector2){sx1, sy1}, (Vector2){sx2, sy1}, lw, gc);
+        }
+
+        // Trails
+        for (int vi = 0; vi < vehicle_count; vi++) {
+            const vehicle_t *v = &vehicles[vi];
+            if (trail_mode <= 0 || v->trail_count < 2) continue;
+            if (!v->active && vehicle_count > 1) continue;
+            int start = (v->trail_count < v->trail_capacity) ? 0 : v->trail_head;
+
+            Color col_fwd  = theme->trail_forward;
+            Color col_back = theme->trail_backward;
+            Color col_up   = theme->trail_climb;
+            Color col_down = theme->trail_descend;
+            Color col_rp   = theme->trail_roll_pos;
+            Color col_rn   = theme->trail_roll_neg;
+
+            for (int ti = 1; ti < v->trail_count; ti++) {
+                int i0 = (start + ti - 1) % v->trail_capacity;
+                int i1 = (start + ti) % v->trail_capacity;
+                float t = (float)ti / (float)v->trail_count;
+
+                float cr_f, cg_f, cb_f;
+                unsigned char ca;
+
+                if (trail_mode == 1) {
+                    cr_f = (float)col_fwd.r; cg_f = (float)col_fwd.g; cb_f = (float)col_fwd.b;
+                    float pitch = v->trail_pitch[i1];
+                    float vert  = v->trail_vert[i1];
+                    float roll  = v->trail_roll[i1];
+
+                    float bt = pitch / 15.0f;
+                    if (bt < 0) bt = 0; if (bt > 1) bt = 1;
+                    cr_f += (col_back.r - cr_f) * bt;
+                    cg_f += (col_back.g - cg_f) * bt;
+                    cb_f += (col_back.b - cb_f) * bt;
+
+                    float vt = vert / 5.0f;
+                    if (vt > 1) vt = 1; if (vt < -1) vt = -1;
+                    if (vt > 0) { cr_f += (col_up.r - cr_f)*vt; cg_f += (col_up.g - cg_f)*vt; cb_f += (col_up.b - cb_f)*vt; }
+                    else if (vt < 0) { float d=-vt; cr_f += (col_down.r - cr_f)*d; cg_f += (col_down.g - cg_f)*d; cb_f += (col_down.b - cb_f)*d; }
+
+                    float rt = roll / 15.0f;
+                    if (rt > 1) rt = 1; if (rt < -1) rt = -1;
+                    if (rt > 0) { cr_f += (col_rp.r - cr_f)*rt*0.7f; cg_f += (col_rp.g - cg_f)*rt*0.7f; cb_f += (col_rp.b - cb_f)*rt*0.7f; }
+                    else if (rt < 0) { float d=-rt; cr_f += (col_rn.r - cr_f)*d*0.7f; cg_f += (col_rn.g - cg_f)*d*0.7f; cb_f += (col_rn.b - cb_f)*d*0.7f; }
+
+                    ca = (unsigned char)(t * col_fwd.a);
+                } else if (trail_mode == 2) {
+                    float max_spd = v->trail_speed_max > 1.0f ? v->trail_speed_max : 1.0f;
+                    float spd = v->trail_speed[i1];
+                    float heat = spd / max_spd;
+                    if (heat > 1.0f) heat = 1.0f;
+                    if (heat < 0.0f) heat = 0.0f;
+                    Color hc = theme_heat_color(theme, heat, (unsigned char)(t * 200));
+                    cr_f = hc.r; cg_f = hc.g; cb_f = hc.b;
+                    ca = hc.a;
+                } else {
+                    cr_f = v->color.r; cg_f = v->color.g; cb_f = v->color.b;
+                    ca = (unsigned char)(t * 200);
+                }
+
+                float sx0 = ccx + (v->trail[i0].x - center.x) * grid_scale;
+                float sz0 = ccy + (v->trail[i0].z - center.z) * grid_scale;
+                float sx1 = ccx + (v->trail[i1].x - center.x) * grid_scale;
+                float sz1 = ccy + (v->trail[i1].z - center.z) * grid_scale;
+                float line_w = (trail_mode == 2) ? 2.0f : 1.0f;
+                DrawLineEx((Vector2){sx0, sz0}, (Vector2){sx1, sz1}, line_w,
+                           (Color){(unsigned char)cr_f, (unsigned char)cg_f, (unsigned char)cb_f, ca});
+            }
+        }
+
+        // Compass rings
+        DrawCircleLines((int)ccx, (int)ccy, cr, (Color){accent.r, accent.g, accent.b, 100});
+        DrawCircleLines((int)ccx, (int)ccy, cr * 0.66f, (Color){accent.r, accent.g, accent.b, 60});
+        DrawCircleLines((int)ccx, (int)ccy, cr * 0.33f, (Color){accent.r, accent.g, accent.b, 40});
+
+        // Heading-up bearing lines
+        float heading_rad = vehicles[selected].heading_deg * DEG2RAD;
+        for (int deg = 0; deg < 360; deg += 30) {
+            float angle = (deg * DEG2RAD) - heading_rad - PI / 2.0f;
+            float inner = cr * 0.88f;
+            float outer = cr;
+            Color tc = (deg % 90 == 0) ? (Color){accent.r, accent.g, accent.b, 120}
+                                       : (Color){accent.r, accent.g, accent.b, 60};
+            DrawLineEx(
+                (Vector2){ccx + cosf(angle) * inner, ccy + sinf(angle) * inner},
+                (Vector2){ccx + cosf(angle) * outer, ccy + sinf(angle) * outer},
+                1.0f, tc);
+        }
+
+        // Cardinal labels
+        const char *labels[] = {"N", "E", "S", "W"};
+        int label_degs[] = {0, 90, 180, 270};
+        float fs_card = wy(13, sh);
+        for (int i = 0; i < 4; i++) {
+            float angle = (label_degs[i] * DEG2RAD) - heading_rad - PI / 2.0f;
+            float lr = cr + wy(10, sh);
+            float lx = ccx + cosf(angle) * lr;
+            float ly = ccy + sinf(angle) * lr;
+            Vector2 tw = MeasureTextEx(h->font_value, labels[i], fs_card, 0.5f);
+            Color lc = (i == 0) ? warn : dim_c;
+            DrawTextEx(h->font_value, labels[i],
+                       (Vector2){lx - tw.x / 2, ly - tw.y / 2}, fs_card, 0.5f, lc);
+        }
+
+        // Drone position dots
+        {
+            Vector3 self_pos = center;
+            float dot_scale = grid_scale;
+            for (int vi = 0; vi < vehicle_count; vi++) {
+                if (!vehicles[vi].active && vehicle_count > 1) continue;
+                float dx = vehicles[vi].position.x - self_pos.x;
+                float dz = vehicles[vi].position.z - self_pos.z;
+                float bx = ccx + dx * dot_scale;
+                float by = ccy + dz * dot_scale;
+                float dot_r = (vi == selected) ? ws(5, sw, sh) : ws(4, sw, sh);
+                DrawCircle((int)bx, (int)by, dot_r, vehicles[vi].color);
+            }
+
+            // Correlation overlays
+            if (corr_mode > 0 && h->pinned_count > 0) {
+                for (int p = 0; p < h->pinned_count; p++) {
+                    int pidx = h->pinned[p];
+                    if (pidx < 0 || pidx >= vehicle_count || !vehicles[pidx].active || pidx == selected) continue;
+                    const vehicle_t *va = &vehicles[selected];
+                    const vehicle_t *vb = &vehicles[pidx];
+
+                    if (corr_mode == 2) {
+                        int n = va->trail_count < vb->trail_count ? va->trail_count : vb->trail_count;
+                        if (n >= 2) {
+                            int sa = (va->trail_count < va->trail_capacity) ? 0 : va->trail_head;
+                            int sb = (vb->trail_count < vb->trail_capacity) ? 0 : vb->trail_head;
+                            for (int i = 1; i < n; i++) {
+                                int ia0 = (sa + (int)((float)(i-1)/n * va->trail_count)) % va->trail_capacity;
+                                int ia1 = (sa + (int)((float)i/n * va->trail_count)) % va->trail_capacity;
+                                int ib0 = (sb + (int)((float)(i-1)/n * vb->trail_count)) % vb->trail_capacity;
+                                int ib1 = (sb + (int)((float)i/n * vb->trail_count)) % vb->trail_capacity;
+                                float t = (float)i / (float)n;
+                                unsigned char al = (unsigned char)(t * 120);
+                                Color mc = {(unsigned char)((va->color.r + vb->color.r)/2),
+                                            (unsigned char)((va->color.g + vb->color.g)/2),
+                                            (unsigned char)((va->color.b + vb->color.b)/2), al};
+                                Vector2 a0 = {ccx + (va->trail[ia0].x - self_pos.x) * dot_scale,
+                                              ccy + (va->trail[ia0].z - self_pos.z) * dot_scale};
+                                Vector2 a1 = {ccx + (va->trail[ia1].x - self_pos.x) * dot_scale,
+                                              ccy + (va->trail[ia1].z - self_pos.z) * dot_scale};
+                                Vector2 b0 = {ccx + (vb->trail[ib0].x - self_pos.x) * dot_scale,
+                                              ccy + (vb->trail[ib0].z - self_pos.z) * dot_scale};
+                                Vector2 b1 = {ccx + (vb->trail[ib1].x - self_pos.x) * dot_scale,
+                                              ccy + (vb->trail[ib1].z - self_pos.z) * dot_scale};
+                                DrawTriangle(a0, b0, a1, mc);
+                                DrawTriangle(a0, a1, b0, mc);
+                                DrawTriangle(b0, b1, a1, mc);
+                                DrawTriangle(b0, a1, b1, mc);
+                            }
+                        }
+                    }
+
+                    float dx_p = vb->position.x - self_pos.x;
+                    float dz_p = vb->position.z - self_pos.z;
+                    float bx_c = ccx + dx_p * dot_scale;
+                    float by_c = ccy + dz_p * dot_scale;
+                    Color mid = {(unsigned char)((va->color.r + vb->color.r)/2),
+                                 (unsigned char)((va->color.g + vb->color.g)/2),
+                                 (unsigned char)((va->color.b + vb->color.b)/2), 200};
+                    DrawLineEx((Vector2){ccx, ccy}, (Vector2){bx_c, by_c}, 2.0f, mid);
+                }
+            }
+        }
+
+        EndScissorMode();
+    }
+
+    DrawRectangleLinesEx((Rectangle){px, py, ps, ps}, 1.0f, accent);
+
+    float fs_label = wy(12, sh);
+    DrawTextEx(h->font_value, "RADAR",
+               (Vector2){px + wx(8, sw), py + wy(5, sh)}, fs_label, 0.5f, accent);
+}
+
+// ── Gimbal Rings ──────────────────────────────────────────────────────────
+static Color blend_color(Color base, Color drone, float t) {
+    return (Color){
+        (unsigned char)(base.r + (drone.r - base.r) * t),
+        (unsigned char)(base.g + (drone.g - base.g) * t),
+        (unsigned char)(base.b + (drone.b - base.b) * t),
+        base.a
+    };
+}
+
+static Vector2 project_ring_point(float x3, float y3, float z3) {
+    float cam_pitch = -30.0f * DEG2RAD;
+    float cos_p = cosf(cam_pitch);
+    float sin_p = sinf(cam_pitch);
+    float py = y3 * cos_p - z3 * sin_p;
+    return (Vector2){ x3, -py };
+}
+
+static void draw_projected_ring(float cx, float cy, float radius,
+                                 Quaternion q, Vector3 axis_a, Vector3 axis_b,
+                                 float scale, float thick, Color color) {
+    int segs = 48;
+    for (int i = 0; i < segs; i++) {
+        float a1 = (float)i / segs * 2.0f * PI;
+        float a2 = (float)(i + 1) / segs * 2.0f * PI;
+        Vector3 local1 = {
+            axis_a.x * cosf(a1) + axis_b.x * sinf(a1),
+            axis_a.y * cosf(a1) + axis_b.y * sinf(a1),
+            axis_a.z * cosf(a1) + axis_b.z * sinf(a1)
+        };
+        Vector3 local2 = {
+            axis_a.x * cosf(a2) + axis_b.x * sinf(a2),
+            axis_a.y * cosf(a2) + axis_b.y * sinf(a2),
+            axis_a.z * cosf(a2) + axis_b.z * sinf(a2)
+        };
+        Vector3 w1 = Vector3RotateByQuaternion(local1, q);
+        Vector3 w2 = Vector3RotateByQuaternion(local2, q);
+        Vector2 p1 = project_ring_point(w1.x * radius, w1.y * radius, w1.z * radius);
+        Vector2 p2 = project_ring_point(w2.x * radius, w2.y * radius, w2.z * radius);
+        DrawLineEx(
+            (Vector2){cx + p1.x * scale, cy + p1.y * scale},
+            (Vector2){cx + p2.x * scale, cy + p2.y * scale},
+            thick, color);
+    }
+}
+
+static void tac_draw_gimbal_rings(const hud_t *h, const vehicle_t *vehicles,
+                                   int vehicle_count, int sw, int sh,
+                                   const theme_t *theme) {
+    if (h->pinned_count == 0) return;
+
+    float ring_y = wy(968, sh);
+
+    float transport_w = sw * 0.5f;
+    float cell_w = transport_w / 15.0f;
+    float r = cell_w * 0.38f;
+    float spacing = cell_w;
+    float total_w = (h->pinned_count - 1) * spacing;
+    float start_x = sw / 2.0f - total_w / 2.0f;
+
+    float fs_id = r * 0.6f;
+    float tint = 0.5f;
+
+    Color base_roll  = (Color){255, 100, 100, 180};
+    Color base_pitch = (Color){ 52, 211, 153, 180};
+    Color base_yaw   = (Color){  0, 180, 204, 160};
+
+    for (int p = 0; p < h->pinned_count; p++) {
+        int pidx = h->pinned[p];
+        if (pidx < 0 || pidx >= vehicle_count) continue;
+
+        Color dc = vehicles[pidx].color;
+        float cx = start_x + p * spacing;
+        float cy = ring_y;
+
+        Quaternion rot = vehicles[pidx].rotation;
+
+        Vector3 fwd = Vector3RotateByQuaternion((Vector3){0, 0, -1}, rot);
+        float yaw = atan2f(-fwd.x, -fwd.z);
+        Quaternion q_yaw = QuaternionFromAxisAngle((Vector3){0, 1, 0}, yaw);
+
+        Quaternion q_yaw_inv = QuaternionInvert(q_yaw);
+        Quaternion q_remainder = QuaternionMultiply(q_yaw_inv, rot);
+        Vector3 fwd_rem = Vector3RotateByQuaternion((Vector3){0, 0, -1}, q_remainder);
+        float pitch = atan2f(fwd_rem.y, -fwd_rem.z);
+        Quaternion q_pitch = QuaternionFromAxisAngle((Vector3){1, 0, 0}, pitch);
+
+        Quaternion q_yaw_pitch = QuaternionMultiply(q_yaw, q_pitch);
+
+        Color yc = blend_color(base_yaw, dc, tint);
+        draw_projected_ring(cx, cy, 1.15f, q_yaw,
+                            (Vector3){1, 0, 0}, (Vector3){0, 0, -1},
+                            r, 1.0f, yc);
+
+        {
+            Vector3 north_local = {cosf(0) * 1.15f, 0, -sinf(0) * 1.15f};
+            Vector3 nw = Vector3RotateByQuaternion(north_local, q_yaw);
+            Vector2 np = project_ring_point(nw.x * r, nw.y * r, nw.z * r);
+            DrawCircle((int)(cx + np.x), (int)(cy + np.y),
+                       ws(2.5f, sw, sh), (Color){255, 68, 68, 220});
+        }
+
+        Color pc = blend_color(base_pitch, dc, tint);
+        draw_projected_ring(cx, cy, 1.0f, q_yaw_pitch,
+                            (Vector3){0, 0, -1}, (Vector3){0, 1, 0},
+                            r, 1.2f, pc);
+
+        Color rc = blend_color(base_roll, dc, tint);
+        draw_projected_ring(cx, cy, 0.85f, rot,
+                            (Vector3){1, 0, 0}, (Vector3){0, 1, 0},
+                            r, 1.2f, rc);
+
+        DrawCircle((int)cx, (int)cy, ws(2, sw, sh), (Color){dc.r, dc.g, dc.b, 130});
+
+        char id_buf[8];
+        snprintf(id_buf, sizeof(id_buf), "D%d", pidx + 1);
+        Vector2 tw = MeasureTextEx(h->font_value, id_buf, fs_id, 0.5f);
+        DrawTextEx(h->font_value, id_buf,
+                   (Vector2){cx - tw.x / 2, cy + r * 1.2f + wy(4, sh)},
+                   fs_id, 0.5f, dc);
+    }
+}
+
+// ── Toast ─────────────────────────────────────────────────────────────────
+static void tac_draw_toast(const hud_t *h, int sw, int sh, const theme_t *theme) {
+    if (h->toast_timer <= 0.0f) return;
+    float fs = wy(14, sh);
+    Vector2 tw = MeasureTextEx(h->font_label, h->toast_text, fs, 0.5f);
+    float fade = (h->toast_timer < 0.5f) ? h->toast_timer / 0.5f : 1.0f;
+    Color base = (h->toast_color.a > 0) ? h->toast_color : theme->hud_climb;
+    Color tc = (Color){base.r, base.g, base.b, (unsigned char)(fade * 255)};
+    DrawTextEx(h->font_label, h->toast_text,
+               (Vector2){sw / 2.0f - tw.x / 2, wy(50, sh)}, fs, 0.5f, tc);
+}
+
+// ── Warnings ──────────────────────────────────────────────────────────────
+static void tac_draw_warnings(const hud_t *h, bool has_tier3, bool has_awaiting_gps,
+                               int sw, int sh, const theme_t *theme) {
+    float fs = wy(13, sh);
+    float base_y = wy(70, sh);
+    if (has_tier3) {
+        const char *t = "ESTIMATED POSITION";
+        Vector2 tw = MeasureTextEx(h->font_label, t, fs, 0.5f);
+        DrawTextEx(h->font_label, t,
+                   (Vector2){sw / 2.0f - tw.x / 2, base_y}, fs, 0.5f, theme->hud_warn);
+        base_y += tw.y + wy(4, sh);
+    }
+    if (has_awaiting_gps) {
+        const char *t = "AWAITING GPS";
+        Vector2 tw = MeasureTextEx(h->font_label, t, fs, 0.5f);
+        DrawTextEx(h->font_label, t,
+                   (Vector2){sw / 2.0f - tw.x / 2, base_y}, fs, 0.5f, theme->hud_warn);
+    }
+}
+
+// ── Reticle ───────────────────────────────────────────────────────────────
+static void tac_draw_reticle(int sw, int sh, const theme_t *theme) {
+    float cx = sw / 2.0f;
+    float cy = sh / 2.0f;
+    Color r = (Color){theme->hud_value.r, theme->hud_value.g, theme->hud_value.b, 90};
+    float l = ws(12, sw, sh);
+    float g = ws(5, sw, sh);
+    DrawLineEx((Vector2){cx - l, cy}, (Vector2){cx - g, cy}, 1.3f, r);
+    DrawLineEx((Vector2){cx + g, cy}, (Vector2){cx + l, cy}, 1.3f, r);
+    DrawCircle((int)cx, (int)cy, ws(2.5f, sw, sh), r);
+}
+
+// ── Main Draw ─────────────────────────────────────────────────────────────
+void tactical_hud_draw(const hud_t *h, const vehicle_t *vehicles,
+                       const data_source_t *sources, int vehicle_count,
+                       int selected, int screen_w, int screen_h,
+                       const theme_t *theme, bool ghost_mode,
+                       bool has_tier3, bool has_awaiting_gps,
+                       const ortho_panel_t *ortho,
+                       int trail_mode, int corr_mode,
+                       const hud_marker_data_t *markers_all,
+                       const hud_marker_data_t *sys_markers_all,
+                       int marker_vehicle_count) {
+
+    const data_source_t *src = &sources[selected];
+    (void)ghost_mode;
+
+    tac_draw_reticle(screen_w, screen_h, theme);
+    tac_draw_timer_status(h, src, screen_w, screen_h, theme);
+    tac_draw_heading(h, &vehicles[selected], screen_w, screen_h, theme);
+    {
+        const hud_marker_data_t *sel_user = markers_all ? &markers_all[selected] : NULL;
+        const hud_marker_data_t *sel_sys = sys_markers_all ? &sys_markers_all[selected] : NULL;
+        tac_draw_ticker(h, &src->playback, sel_user, sel_sys, screen_w, screen_h, theme);
+    }
+    tac_draw_toast(h, screen_w, screen_h, theme);
+    tac_draw_warnings(h, has_tier3, has_awaiting_gps, screen_w, screen_h, theme);
+    tac_draw_speed_stack(h, vehicles, vehicle_count, selected,
+                         screen_w, screen_h, theme);
+    tac_draw_alt_stack(h, vehicles, vehicle_count, selected,
+                       screen_w, screen_h, theme);
+    tac_draw_radar(h, vehicles, vehicle_count, selected,
+                   screen_w, screen_h, theme, ortho, trail_mode, corr_mode);
+    tac_draw_gimbal_rings(h, vehicles, vehicle_count, screen_w, screen_h, theme);
+
+    // Ortho insets (O toggle): side view top-left, front view top-right
+    // Replaces the normal sidebar ortho panels in tactical mode
+    if (ortho && ortho->visible) {
+        float inset_size = screen_w * 0.153f;
+        float margin = screen_w * 0.05f;
+        float top_y = margin + screen_h * 0.04f;
+        // Front view — top-left corner
+        ortho_panel_draw_single(ortho, 1, margin, top_y, inset_size, 0.5f,
+                                theme, h->font_label,
+                                vehicles, vehicle_count, selected, trail_mode,
+                                corr_mode, h->pinned, h->pinned_count);
+        // Side (right) view — top-right corner
+        ortho_panel_draw_single(ortho, 2, screen_w - margin - inset_size, top_y, inset_size, 0.5f,
+                                theme, h->font_label,
+                                vehicles, vehicle_count, selected, trail_mode,
+                                corr_mode, h->pinned, h->pinned_count);
+    }
+
+    // Reuse shared transport bar — 50% width centered (25% to 75%)
+    if (src->playback.duration_s > 0.0f) {
+        float s = powf(screen_h / 720.0f, 0.7f);
+        if (s < 1.0f) s = 1.0f;
+        float transport_h = 28 * s;
+        float bar_y = (float)screen_h - transport_h;
+        float tbar_w = screen_w * 0.5f;
+        float tbar_x = screen_w * 0.25f;
+        BeginScissorMode((int)tbar_x, (int)bar_y, (int)tbar_w, (int)transport_h + 20);
+        rlPushMatrix();
+        rlTranslatef(tbar_x, 0, 0);
+        hud_draw_transport(h, &src->playback, src->connected,
+                           &vehicles[selected],
+                           markers_all, sys_markers_all,
+                           marker_vehicle_count, selected,
+                           (int)tbar_w, bar_y, transport_h,
+                           s, trail_mode, theme);
+        rlPopMatrix();
+        EndScissorMode();
+    }
+}

--- a/src/tactical_hud.h
+++ b/src/tactical_hud.h
@@ -1,0 +1,18 @@
+#ifndef TACTICAL_HUD_H
+#define TACTICAL_HUD_H
+
+#include "hud.h"
+#include "ortho_panel.h"
+
+void tactical_hud_draw(const hud_t *h, const vehicle_t *vehicles,
+                       const data_source_t *sources, int vehicle_count,
+                       int selected, int screen_w, int screen_h,
+                       const theme_t *theme, bool ghost_mode,
+                       bool has_tier3, bool has_awaiting_gps,
+                       const ortho_panel_t *ortho,
+                       int trail_mode, int corr_mode,
+                       const hud_marker_data_t *markers_all,
+                       const hud_marker_data_t *sys_markers_all,
+                       int marker_vehicle_count);
+
+#endif

--- a/src/ui_marker_input.h
+++ b/src/ui_marker_input.h
@@ -15,6 +15,7 @@ typedef struct {
     char buf[HUD_MARKER_LABEL_MAX];
     int len;
     int target;
+    int drone_idx;
 } marker_input_t;
 
 void marker_input_update(marker_input_t *mi, user_markers_t *um,

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -785,7 +785,11 @@ void vehicle_truncate_trail(vehicle_t *v, float time_s) {
 }
 
 Color vehicle_marker_color(float roll, float pitch, float vert, float speed,
-                           float speed_max, const theme_t *theme, int trail_mode) {
+                           float speed_max, const theme_t *theme, int trail_mode,
+                           Color drone_color, bool multi_drone) {
+    if (trail_mode == 3 || multi_drone) {
+        return drone_color;
+    }
     if (trail_mode == 2) {
         float ms = speed_max > 1.0f ? speed_max : 1.0f;
         float heat = speed / ms;
@@ -849,7 +853,7 @@ void vehicle_draw_markers(Vector3 *positions, char labels[][48], int count,
                           int current_marker, Vector3 cam_pos, Camera3D camera,
                           float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                           float speed_max, const theme_t *theme, int trail_mode,
-                          marker_type_t type) {
+                          marker_type_t type, Color drone_color, bool multi_drone) {
     (void)labels;
     bool is_system = (type == MARKER_SYSTEM);
 
@@ -864,7 +868,7 @@ void vehicle_draw_markers(Vector3 *positions, char labels[][48], int count,
         bool is_current = (i == current_marker);
 
         Color col = vehicle_marker_color(m_roll[i], m_pitch[i], m_vert[i], m_speed[i],
-                                         speed_max, theme, trail_mode);
+                                         speed_max, theme, trail_mode, drone_color, multi_drone);
 
         if (is_current) {
             if (theme->thick_trails) {
@@ -920,7 +924,7 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
                                 Font font_label, Font font_value,
                                 float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                                 float speed_max, const theme_t *theme, int trail_mode,
-                                marker_type_t type) {
+                                marker_type_t type, Color drone_color, bool multi_drone) {
     bool is_system = (type == MARKER_SYSTEM);
     Vector3 cam_fwd = Vector3Normalize(Vector3Subtract(camera.target, camera.position));
 
@@ -970,7 +974,7 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
         float rh = tw.y + pad_y * 2;
 
         Color text_col = vehicle_marker_color(m_roll[i], m_pitch[i], m_vert[i], m_speed[i],
-                                              speed_max, theme, trail_mode);
+                                              speed_max, theme, trail_mode, drone_color, multi_drone);
         if (is_current) {
             if (theme->thick_trails) {
                 text_col.r = (unsigned char)(text_col.r * 0.55f);

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -131,12 +131,12 @@ void vehicle_reset_trail(vehicle_t *v);
 void vehicle_truncate_trail(vehicle_t *v, float time_s);
 
 // Draw marker shapes (spheres for MARKER_USER, cubes for MARKER_SYSTEM).
-// Call inside BeginMode3D.
+// Call inside BeginMode3D. drone_color used when trail_mode == 3 (ID trails).
 void vehicle_draw_markers(Vector3 *positions, char labels[][48], int count,
                           int current_marker, Vector3 cam_pos, Camera3D camera,
                           float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                           float speed_max, const theme_t *theme, int trail_mode,
-                          marker_type_t type);
+                          marker_type_t type, Color drone_color, bool multi_drone);
 
 // Draw billboarded marker labels (call AFTER EndMode3D, in 2D pass).
 void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count,
@@ -144,11 +144,13 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
                                 Font font_label, Font font_value,
                                 float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                                 float speed_max, const theme_t *theme, int trail_mode,
-                                marker_type_t type);
+                                marker_type_t type, Color drone_color, bool multi_drone);
 
 // Compute marker color from snapshotted telemetry.
+// drone_color used when trail_mode == 3 (ID trails) or multi-drone mode.
 Color vehicle_marker_color(float roll, float pitch, float vert, float speed,
-                           float speed_max, const theme_t *theme, int trail_mode);
+                           float speed_max, const theme_t *theme, int trail_mode,
+                           Color drone_color, bool multi_drone);
 
 // Draw correlation curtain between two vehicles (cross-vehicle overlay).
 void vehicle_draw_correlation_curtain(


### PR DESCRIPTION
## Summary
Adds a minimal, uncluttered alternative to the traditional Console HUD. The Tactical HUD floats all elements over the 3D viewport with no background panels, keeping screen obstruction to ~5% while providing speed, altitude, heading, radar, and attitude readouts.

- H key cycles: Console → Tactical → Off
- Speed (GS) and altitude (ALT) flanking tags with pinned drone values stacked above
- Heading-up radar panel (bottom-left) with compass, grid, trails, drone dots, and correlation overlays
- 3D gimbal rings replace axis gizmo (Z key) — yaw/pitch/roll with directional pyramids
- Mini 2D gimbal rings for pinned drones above transport bar
- Timer + connection status (top-left), heading (top-right), center reticle
- Ticker cycles between flight mode and current marker name (3s each) when a marker is selected
- O key toggles front + right ortho insets in top corners — replaces normal sidebar in tactical mode
- Ortho insets use hud_bg background and accent-colored grid (matches radar)
- Transport bar narrowed to 50% width (25%-75%) in tactical mode
- Reuses shared `hud_draw_transport` — multi-drone markers work in both views
- Camera zooms to close chase on tactical entry, restores on exit

## Blocked by
- #72 (multi-drone marker support)

## Test plan
- [x] All 7 existing tests pass
- [x] H key cycles Console → Tactical → Off with toast and camera zoom
- [x] Timer, heading, GS/ALT tags, radar, gimbal rings, transport bar all render
- [x] Z key shows 3D gimbal rings on selected drone (replaces old axis gizmo)
- [x] O key toggles front (top-left) and right (top-right) ortho insets
- [x] Ortho insets use hud_bg background and accent-colored grid
- [x] Normal sidebar ortho suppressed in tactical mode
- [x] Ticker cycles between flight mode and marker name when marker selected
- [x] B drops markers, [/] cycles, transport bar shows markers in tactical mode
- [x] Markers persist when switching Console ↔ Tactical
- [x] Trail modes (T) and theme cycling (V) work in both views
- [x] Pinned drone data (Shift+number) shows in GS/ALT stacks and gimbal rings
- [x] Single-drone regression: one ULog, tactical mode, no crash
- [x] Multi-drone: 7-drone UVIFY swarm, all tactical elements render correctly