### PR TITLE
feat: HUD polish — annunciators, adaptive numpad, STATUSTEXT ticker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if(NOT BUILD_TESTING_ONLY)
         src/asset_path.c
         src/theme.c
         src/tactical_hud.c
+        src/hud_annunciators.c
     )
 
     target_include_directories(hawkeye PRIVATE

--- a/src/data_source.h
+++ b/src/data_source.h
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "mavlink_receiver.h"  // hil_state_t, home_position_t
 
+// Forward declaration for STATUSTEXT ring buffer (defined in ulog_replay.h)
+struct statustext_ring;
+
 // Flight mode change event for timeline markers
 typedef struct {
     float time_s;          // seconds from log start
@@ -30,6 +33,7 @@ typedef struct {
     float correlation;          // Pearson r vs reference drone (NAN = N/A)
     float rmse;                 // RMS position error vs reference (m) (NAN = N/A)
     float time_offset_s;        // alignment offset for display
+    const struct statustext_ring *statustext;  // STATUSTEXT ring (NULL for MAVLink)
 } playback_state_t;
 
 typedef struct data_source data_source_t;

--- a/src/data_source_ulog.c
+++ b/src/data_source_ulog.c
@@ -28,6 +28,7 @@ static void ulog_poll(data_source_t *ds, float dt) {
     ds->playback.time_offset_s = (float)ctx->time_offset_s;
     ds->playback.mode_changes = (const playback_mode_change_t *)ctx->mode_changes;
     ds->playback.mode_change_count = ctx->mode_change_count;
+    ds->playback.statustext = &ctx->statustext;
 
     // Update playback progress
     uint64_t range = ctx->parser.end_timestamp - ctx->parser.start_timestamp;

--- a/src/hud.c
+++ b/src/hud.c
@@ -43,6 +43,8 @@ void hud_init(hud_t *h) {
         printf("Warning: could not load fonts/JetBrainsMono-Medium.ttf, using default font\n");
     if (h->font_label.glyphCount == 0)
         printf("Warning: could not load fonts/Inter-Medium.ttf, using default font\n");
+
+    annunc_init(&h->annunciators);
 }
 
 void hud_update(hud_t *h, uint64_t time_usec, bool connected, float dt) {
@@ -54,6 +56,13 @@ void hud_update(hud_t *h, uint64_t time_usec, bool connected, float dt) {
     // Tick toast timer
     if (h->toast_timer > 0.0f)
         h->toast_timer -= dt;
+    // Tick annunciator timers
+    annunc_update(&h->annunciators, dt);
+    // Tick STATUSTEXT ticker flash timers (entries persist, only flash fades)
+    for (int i = 0; i < h->ticker_count; i++) {
+        if (h->ticker[i].timer > 0.0f)
+            h->ticker[i].timer -= dt;
+    }
 }
 
 void hud_toast(hud_t *h, const char *text, float duration_s) {
@@ -70,15 +79,71 @@ void hud_toast_color(hud_t *h, const char *text, float duration_s, Color color) 
     h->toast_color = color;
 }
 
+static Color severity_color(uint8_t sev, const theme_t *theme) {
+    // Source severity colors from the drone palette warm tones
+    if (sev <= 2) return theme->drone_palette[2];   // critical — palette red/pink
+    if (sev == 3) return theme->drone_palette[4];   // error — palette orange/warm
+    if (sev == 4) return theme->hud_warn;            // warning — theme warn color
+    return theme->hud_dim;                           // info+
+}
+
+void hud_feed_statustext(hud_t *h, const struct statustext_ring *ring, int drone_idx) {
+    if (!ring || drone_idx < 0 || drone_idx >= 16) return;
+    int last = h->ticker_consumed[drone_idx];
+    if (ring->head == last) return;  // no new entries
+
+    // Walk from last consumed to current head
+    int count = ring->count;
+    int head = ring->head;
+    int start = last;
+    // How many new entries?
+    int new_count = head - start;
+    if (new_count < 0) new_count += STATUSTEXT_RING_SIZE;
+    if (new_count > count) new_count = count;
+
+    for (int n = 0; n < new_count; n++) {
+        int idx = (start + n) % STATUSTEXT_RING_SIZE;
+        const statustext_entry_t *e = &ring->entries[idx];
+        // Severity may be raw (0-7) or ASCII ('0'-'7')
+        uint8_t sev = e->severity;
+        if (sev >= '0') sev -= '0';
+        if (sev > 4) continue;  // only WARNING or worse
+
+        // Shift existing ticker entries down
+        if (h->ticker_count < HUD_TICKER_MAX) h->ticker_count++;
+        for (int j = h->ticker_count - 1; j > 0; j--)
+            h->ticker[j] = h->ticker[j - 1];
+
+        // Insert at top
+        snprintf(h->ticker[0].text, sizeof(h->ticker[0].text), "%s", e->text);
+        h->ticker[0].severity = sev;
+        h->ticker[0].timer = 8.0f;
+        h->ticker[0].total = 8.0f;
+        h->ticker[0].drone_idx = drone_idx;
+
+        // Trigger annunciators
+        annunc_trigger_ticker_flash(&h->annunciators, 0);
+        annunc_trigger_ring_shake(&h->annunciators, drone_idx);
+    }
+    h->ticker_consumed[drone_idx] = head;
+}
 
 static void draw_numpad(const hud_t *h, const vehicle_t *vehicles,
                         const data_source_t *sources, int vehicle_count,
                         int selected, float numpad_x, float numpad_y,
-                        Font font_label, float btn_size, float gap, float scale) {
+                        Font font_label, float btn_size, float gap, float scale,
+                        int *out_cols, int *out_rows) {
+    // Dynamic grid: up to 3 cols, rows sized to fit vehicle_count
+    int cols = (vehicle_count <= 9) ? 3 : (vehicle_count <= 12) ? 3 : 4;
+    int rows = (vehicle_count <= 9) ? 3 : (vehicle_count <= 12) ? 4 : 4;
+    int total_slots = cols * rows;
+    if (out_cols) *out_cols = cols;
+    if (out_rows) *out_rows = rows;
+
     float fs = 12 * scale;
-    for (int i = 0; i < 9; i++) {
-        int row = i / 3;
-        int col = i % 3;
+    for (int i = 0; i < total_slots; i++) {
+        int row = i / cols;
+        int col = i % cols;
         float bx = numpad_x + col * (btn_size + gap);
         float by = numpad_y + row * (btn_size + gap);
         int veh_idx = i;
@@ -116,11 +181,13 @@ static void draw_numpad(const hud_t *h, const vehicle_t *vehicles,
                         vehicles[veh_idx].color.b, 80});
         }
 
-        char nb[2] = { '1' + i, '\0' };
-        Vector2 nw = MeasureTextEx(font_label, nb, fs, 0.5f);
+        char nb[4];
+        snprintf(nb, sizeof(nb), "%d", i + 1);
+        float lfs = (i >= 9) ? fs * 0.8f : fs;
+        Vector2 nw = MeasureTextEx(font_label, nb, lfs, 0.5f);
         DrawTextEx(font_label, nb,
-                   (Vector2){bx + btn_size/2 - nw.x/2, by + btn_size/2 - fs/2},
-                   fs, 0.5f, btn_text);
+                   (Vector2){bx + btn_size/2 - nw.x/2, by + btn_size/2 - lfs/2},
+                   lfs, 0.5f, btn_text);
     }
 }
 
@@ -141,8 +208,13 @@ static void draw_secondary_row(const hud_t *h, const vehicle_t *pv, int pidx,
                (Vector2){(float)screen_w, (float)row_y},
                1.0f, (Color){255, 255, 255, 20});
 
-    // Color bar
-    DrawRectangle(0, row_y, (int)(3 * scale), secondary_h, pv->color);
+    // Color bar (fades on marker crossing for this drone)
+    {
+        float tab_a = annunc_tab_fade_alpha(&h->annunciators, pidx);
+        Color tc = pv->color;
+        tc.a = (unsigned char)(tc.a * tab_a);
+        DrawRectangle(0, row_y, (int)(3 * scale), secondary_h, tc);
+    }
 
     // Vehicle number
     char vnum[4];
@@ -247,7 +319,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     Color bg = theme->hud_bg;
     Color border = theme->hud_border;
     Color warn = theme->hud_warn;
-    Color label_color = accent_dim;
+    Color label_color = (Color){accent_dim.r, accent_dim.g, accent_dim.b, (unsigned char)(accent_dim.a * 0.7f)};
     Color value_color = theme->hud_value;
     Color dim_color = theme->hud_dim;
     Color climb_color = theme->hud_climb;
@@ -258,12 +330,12 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     if (s < 1.0f) s = 1.0f;
 
     // Scaled font sizes
-    float fs_label = 16 * s;
-    float fs_value = 23 * s;
-    float fs_unit  = 15 * s;
-    float fs_dim   = 15 * s;
-    float fs_sec_label = 14 * s;
-    float fs_sec_value = 18 * s;
+    float fs_label = fmaxf(16 * s, 10.0f);
+    float fs_value = fmaxf(23 * s, 14.0f);
+    float fs_unit  = fmaxf(15 * s, 9.0f);
+    float fs_dim   = fmaxf(15 * s, 9.0f);
+    float fs_sec_label = fmaxf(14 * s, 9.0f);
+    float fs_sec_value = fmaxf(18 * s, 12.0f);
 
     // Dynamic bar height
     int primary_h = (int)(120 * s);
@@ -279,12 +351,70 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     DrawRectangle(0, bar_y, screen_w, total_bar_h, bg);
     DrawLineEx((Vector2){0, (float)bar_y}, (Vector2){(float)screen_w, (float)bar_y}, 1.0f, border);
 
-    // Toast notification (fades in/out, always above other notices)
+    // Ticker zone: STATUSTEXT warnings take priority, toast shows when no warnings
     float toast_h_used = 0.0f;
-    if (h->toast_timer > 0.0f) {
-        float toast_fs = 14 * s;
-        Vector2 tw = MeasureTextEx(h->font_label, h->toast_text, toast_fs, 0.5f);
-        // Fade: full opacity for most of duration, fade out in last 0.5s
+    float ticker_fs = fmaxf(14 * s, 10.0f);
+    float ticker_y = (float)bar_y - 8 * s;
+
+    if (h->ticker_count > 0 && h->show_notifications) {
+        // STATUSTEXT warnings — take over the ticker zone
+        for (int i = 0; i < h->ticker_count; i++) {
+            float fade = 1.0f;
+            if (h->ticker[i].timer < 1.0f)
+                fade = h->ticker[i].timer;
+            Color sc = severity_color(h->ticker[i].severity, theme);
+
+            char tag[8];
+            snprintf(tag, sizeof(tag), "D%d", h->ticker[i].drone_idx + 1);
+            Vector2 tag_w = MeasureTextEx(h->font_label, tag, ticker_fs * 0.8f, 0.5f);
+            Vector2 msg_w = MeasureTextEx(h->font_label, h->ticker[i].text, ticker_fs, 0.5f);
+            float total_w = tag_w.x + 8 * s + msg_w.x;
+            float tx = (float)(screen_w / 2) - total_w / 2.0f;
+            float ty = ticker_y - msg_w.y;
+
+            // Gradient background with faded edges
+            float bg_pad = 40 * s;
+            float flash_a = annunc_ticker_flash_alpha(&h->annunciators, i);
+            float bg_alpha = fade * (25 + flash_a * 120);
+            Color bg_c = (Color){sc.r, sc.g, sc.b, (unsigned char)bg_alpha};
+            // Center solid, edges fade to transparent
+            float bg_x = tx - bg_pad;
+            float bg_w = total_w + bg_pad * 2;
+            float bg_h = msg_w.y + 4 * s;
+            float edge = bg_pad;
+            // Left fade
+            for (int px = 0; px < (int)edge; px++) {
+                float a = (float)px / edge;
+                Color fc = {bg_c.r, bg_c.g, bg_c.b, (unsigned char)(bg_c.a * a)};
+                DrawRectangle((int)(bg_x + px), (int)ty, 1, (int)bg_h, fc);
+            }
+            // Center solid
+            DrawRectangle((int)(bg_x + edge), (int)ty, (int)(bg_w - edge * 2), (int)bg_h, bg_c);
+            // Right fade
+            for (int px = 0; px < (int)edge; px++) {
+                float a = 1.0f - (float)px / edge;
+                Color fc = {bg_c.r, bg_c.g, bg_c.b, (unsigned char)(bg_c.a * a)};
+                DrawRectangle((int)(bg_x + bg_w - edge + px), (int)ty, 1, (int)bg_h, fc);
+            }
+
+            // Drone tag
+            Color tag_c = (Color){sc.r, sc.g, sc.b, (unsigned char)(fade * 140)};
+            DrawTextEx(h->font_label, tag, (Vector2){tx, ty + 1}, ticker_fs * 0.8f, 0.5f, tag_c);
+
+            // Message text — invert to black during flash
+            sc.a = (unsigned char)(fade * 255);
+            Color text_c = (flash_a > 0.3f)
+                ? (Color){0, 0, 0, (unsigned char)(fade * 255)}
+                : sc;
+            DrawTextEx(h->font_label, h->ticker[i].text,
+                       (Vector2){tx + tag_w.x + 8 * s, ty}, ticker_fs, 0.5f, text_c);
+
+            ticker_y = ty - 2 * s;
+        }
+        toast_h_used = (float)bar_y - 8 * s - ticker_y;
+    } else if (h->toast_timer > 0.0f) {
+        // Regular toast when no STATUSTEXT warnings active
+        Vector2 tw = MeasureTextEx(h->font_label, h->toast_text, ticker_fs, 0.5f);
         float fade = 1.0f;
         if (h->toast_timer < 0.5f)
             fade = h->toast_timer / 0.5f;
@@ -294,7 +424,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         float toast_y = (float)bar_y - tw.y - 8 * s;
         float toast_x = (float)(screen_w / 2) - tw.x / 2.0f;
         DrawTextEx(h->font_label, h->toast_text, (Vector2){toast_x, toast_y},
-                   toast_fs, 0.5f, toast_c);
+                   ticker_fs, 0.5f, toast_c);
         toast_h_used = tw.y + 8 * s;
     }
 
@@ -333,8 +463,13 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     // Offset the main HUD content below the transport row
     bar_y += transport_h;
 
-    // Primary color bar on left edge
-    DrawRectangle(0, bar_y, (int)(3 * s), primary_h, v->color);
+    // Primary color bar on left edge (fades on marker crossing)
+    {
+        float tab_a = annunc_tab_fade_alpha(&h->annunciators, selected);
+        Color tab_c = v->color;
+        tab_c.a = (unsigned char)(tab_c.a * tab_a);
+        DrawRectangle(0, bar_y, (int)(3 * s), primary_h, tab_c);
+    }
 
     // Instruments -- centered vertically in primary area
     float inst_radius = INSTRUMENT_RADIUS * s;
@@ -356,7 +491,8 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     float np_btn = NUMPAD_BTN_SIZE * s;
     float np_gap = NUMPAD_GAP * s;
     float status_x = (float)(screen_w - 16 * s - 110 * s);
-    float numpad_total_w = 3 * (np_btn + np_gap) - np_gap;
+    int np_cols = (vehicle_count <= 9) ? 3 : (vehicle_count <= 12) ? 3 : 4;
+    float numpad_total_w = np_cols * (np_btn + np_gap) - np_gap;
     float numpad_x = status_x - 20 * s - numpad_total_w;
     float timer_x = numpad_x - 24 * s - 60 * s;
 
@@ -401,15 +537,20 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
         .label_color = label_color, .value_color = value_color,
         .dim_color = dim_color, .warn = warn,
         .climb_color = climb_color, .connected_color = connected_color,
+        .selected = selected,
     };
 
     hud_draw_telemetry(h, v, &tlay);
 
     // Numpad (only when vehicle_count > 1)
     if (vehicle_count > 1) {
-        float np_y = bar_y + (primary_h / 2.0f) - (3 * (np_btn + np_gap)) / 2.0f;
+        int np_r = (vehicle_count <= 9) ? 3 : 4;
+        float np_grid_h = np_r * (np_btn + np_gap) - np_gap;
+        float np_y = bar_y + (primary_h / 2.0f) - np_grid_h / 2.0f;
+        int np_c_out, np_r_out;
         draw_numpad(h, vehicles, sources, vehicle_count, selected,
-                    numpad_x, np_y, h->font_label, np_btn, np_gap, s);
+                    numpad_x, np_y, h->font_label, np_btn, np_gap, s,
+                    &np_c_out, &np_r_out);
     }
 
     hud_draw_status(h, v, &sources[selected], &tlay, ghost_mode);

--- a/src/hud.c
+++ b/src/hud.c
@@ -106,7 +106,7 @@ void hud_feed_statustext(hud_t *h, const struct statustext_ring *ring, int drone
         const statustext_entry_t *e = &ring->entries[idx];
         // Severity may be raw (0-7) or ASCII ('0'-'7')
         uint8_t sev = e->severity;
-        if (sev >= '0') sev -= '0';
+        if (sev >= '0' && sev <= '7') sev -= '0';
         if (sev > 4) continue;  // only WARNING or worse
 
         // Shift existing ticker entries down

--- a/src/hud.h
+++ b/src/hud.h
@@ -5,6 +5,7 @@
 #include "data_source.h"
 #include "theme.h"
 #include <stdbool.h>
+#include "hud_annunciators.h"
 
 #define HUD_MAX_PINNED 15
 #define HUD_MARKER_LABEL_MAX 48
@@ -46,6 +47,24 @@ typedef struct {
     float toast_timer;  // seconds remaining (0 = hidden)
     float toast_total;  // total duration for fade calc
     Color toast_color;  // custom color (0,0,0,0 = use default)
+
+    // STATUSTEXT ticker (severity-colored warning messages)
+    #define HUD_TICKER_MAX 4
+    struct {
+        char text[128];
+        uint8_t severity;
+        float timer;
+        float total;
+        int drone_idx;
+    } ticker[4];
+    int ticker_count;
+    int ticker_consumed[16];  // per-drone: last consumed ring head
+
+    // STATUSTEXT notification toggle
+    bool show_notifications;
+
+    // Annunciator animation state
+    hud_annunciators_t annunciators;
 } hud_t;
 
 void hud_init(hud_t *h);
@@ -61,6 +80,9 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
 void hud_cleanup(hud_t *h);
 void hud_toast(hud_t *h, const char *text, float duration_s);
 void hud_toast_color(hud_t *h, const char *text, float duration_s, Color color);
+
+// Feed STATUSTEXT messages from a drone's ring buffer into the ticker.
+void hud_feed_statustext(hud_t *h, const struct statustext_ring *ring, int drone_idx);
 
 // Returns the total height of the HUD bar in pixels (for layout by other panels).
 int hud_bar_height(const hud_t *h, int screen_h);

--- a/src/hud_annunciators.c
+++ b/src/hud_annunciators.c
@@ -1,0 +1,164 @@
+#include "hud_annunciators.h"
+#include <math.h>
+#include <string.h>
+
+#ifndef PI
+#define PI 3.14159265358979323846f
+#endif
+
+void annunc_init(hud_annunciators_t *a) {
+    memset(a, 0, sizeof(*a));
+    a->tab_fade.duration = 1.0f;
+    a->ring_bounce.duration = 0.8f;
+    a->radar_wave.duration = 1.2f;
+    a->ticker_flash.duration = 0.3f;
+    a->ring_shake.duration = 0.4f;
+    a->ring_shake.cycles = 3;
+    a->ring_shake.amplitude = 2.0f;
+    // Initialize peak tracking to -INFINITY so first value triggers
+    for (int d = 0; d < ANNUNC_MAX_VEHICLES; d++)
+        for (int c = 0; c < ANNUNC_PEAK_CHANNELS; c++)
+            a->peak_scale.max_val[d][c] = -1e30f;
+}
+
+void annunc_update(hud_annunciators_t *a, float dt) {
+    // Tab fade (per-drone)
+    for (int i = 0; i < ANNUNC_MAX_VEHICLES; i++) {
+        if (a->tab_fade.timer[i] > 0.0f) {
+            a->tab_fade.timer[i] -= dt;
+            if (a->tab_fade.timer[i] < 0.0f) a->tab_fade.timer[i] = 0.0f;
+        }
+    }
+    // Ring bounce
+    for (int i = 0; i < ANNUNC_MAX_VEHICLES; i++) {
+        if (a->ring_bounce.timer[i] > 0.0f) {
+            a->ring_bounce.timer[i] -= dt;
+            if (a->ring_bounce.timer[i] < 0.0f) a->ring_bounce.timer[i] = 0.0f;
+        }
+    }
+    // Radar wave
+    for (int i = 0; i < ANNUNC_MAX_VEHICLES; i++) {
+        if (a->radar_wave.timer[i] > 0.0f) {
+            a->radar_wave.timer[i] -= dt;
+            if (a->radar_wave.timer[i] < 0.0f) a->radar_wave.timer[i] = 0.0f;
+        }
+    }
+    // Ticker flash
+    for (int i = 0; i < 4; i++) {
+        if (a->ticker_flash.timer[i] > 0.0f) {
+            a->ticker_flash.timer[i] -= dt;
+            if (a->ticker_flash.timer[i] < 0.0f) a->ticker_flash.timer[i] = 0.0f;
+        }
+    }
+    // Ring shake
+    for (int i = 0; i < ANNUNC_MAX_VEHICLES; i++) {
+        if (a->ring_shake.timer[i] > 0.0f) {
+            a->ring_shake.timer[i] -= dt;
+            if (a->ring_shake.timer[i] < 0.0f) a->ring_shake.timer[i] = 0.0f;
+        }
+    }
+}
+
+// ── Triggers ────────────────────────────────────────────────────────────────
+
+void annunc_trigger_tab_fade(hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx >= 0 && drone_idx < ANNUNC_MAX_VEHICLES)
+        a->tab_fade.timer[drone_idx] = a->tab_fade.duration;
+}
+
+void annunc_trigger_ring_bounce(hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx >= 0 && drone_idx < ANNUNC_MAX_VEHICLES)
+        a->ring_bounce.timer[drone_idx] = a->ring_bounce.duration;
+}
+
+void annunc_trigger_radar_wave(hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx >= 0 && drone_idx < ANNUNC_MAX_VEHICLES)
+        a->radar_wave.timer[drone_idx] = a->radar_wave.duration;
+}
+
+void annunc_trigger_ticker_flash(hud_annunciators_t *a, int slot) {
+    if (slot >= 0 && slot < 4)
+        a->ticker_flash.timer[slot] = a->ticker_flash.duration;
+}
+
+void annunc_trigger_ring_shake(hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx >= 0 && drone_idx < ANNUNC_MAX_VEHICLES)
+        a->ring_shake.timer[drone_idx] = a->ring_shake.duration;
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+// Tab fade: returns alpha multiplier (1.0 = normal, 0.0 = fully faded out)
+// Animation: fade out then back in (V-shaped)
+float annunc_tab_fade_alpha(const hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 1.0f;
+    if (a->tab_fade.timer[drone_idx] <= 0.0f) return 1.0f;
+    float progress = 1.0f - (a->tab_fade.timer[drone_idx] / a->tab_fade.duration);
+    // Double pulse: fade out, in, out, in
+    float cycle = progress * 2.0f;  // two full cycles in duration
+    if (cycle > 1.0f) cycle -= 1.0f;
+    // Each cycle: out then in (V-shape)
+    if (cycle < 0.4f)
+        return 1.0f - (cycle / 0.4f);
+    else
+        return (cycle - 0.4f) / 0.6f;
+}
+
+// Ring bounce: returns Y offset in pixels (before scaling)
+float annunc_ring_bounce_offset(const hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 0.0f;
+    float t = a->ring_bounce.timer[drone_idx];
+    if (t <= 0.0f) return 0.0f;
+    float progress = 1.0f - (t / a->ring_bounce.duration);
+    // Two up-down cycles, second one smaller
+    float cycle = progress * 2.0f;
+    if (cycle <= 1.0f)
+        return sinf(cycle * PI) * -8.0f;
+    else
+        return sinf((cycle - 1.0f) * PI) * -4.0f;
+}
+
+// Peak scale: update max tracking and at_peak flag
+void annunc_peak_update(hud_annunciators_t *a, int drone_idx, int channel, float value) {
+    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return;
+    if (channel < 0 || channel >= ANNUNC_PEAK_CHANNELS) return;
+    if (value > a->peak_scale.max_val[drone_idx][channel])
+        a->peak_scale.max_val[drone_idx][channel] = value;
+    a->peak_scale.at_peak[drone_idx][channel] =
+        (value >= a->peak_scale.max_val[drone_idx][channel] - 0.01f);
+}
+
+// Peak scale: returns font scale factor (1.0 normal, 1.05 at peak)
+float annunc_peak_scale_factor(const hud_annunciators_t *a, int drone_idx, int channel) {
+    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 1.0f;
+    if (channel < 0 || channel >= ANNUNC_PEAK_CHANNELS) return 1.0f;
+    return a->peak_scale.at_peak[drone_idx][channel] ? 1.10f : 1.0f;
+}
+
+// Radar wave: returns progress 0.0-1.0 (0 = idle)
+float annunc_radar_wave_progress(const hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 0.0f;
+    float t = a->radar_wave.timer[drone_idx];
+    if (t <= 0.0f) return 0.0f;
+    return 1.0f - (t / a->radar_wave.duration);
+}
+
+// Ticker flash: returns alpha 0.0-1.0 for background fill
+float annunc_ticker_flash_alpha(const hud_annunciators_t *a, int slot) {
+    if (slot < 0 || slot >= 4) return 0.0f;
+    float t = a->ticker_flash.timer[slot];
+    if (t <= 0.0f) return 0.0f;
+    return t / a->ticker_flash.duration;
+}
+
+// Ring shake: returns X offset in pixels (before scaling)
+float annunc_ring_shake_offset(const hud_annunciators_t *a, int drone_idx) {
+    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 0.0f;
+    float t = a->ring_shake.timer[drone_idx];
+    if (t <= 0.0f) return 0.0f;
+    float progress = 1.0f - (t / a->ring_shake.duration);
+    float amp = a->ring_shake.amplitude;
+    int cycles = a->ring_shake.cycles;
+    // Damped oscillation
+    return sinf(progress * cycles * 2.0f * PI) * amp * (1.0f - progress);
+}

--- a/src/hud_annunciators.c
+++ b/src/hud_annunciators.c
@@ -15,10 +15,6 @@ void annunc_init(hud_annunciators_t *a) {
     a->ring_shake.duration = 0.4f;
     a->ring_shake.cycles = 3;
     a->ring_shake.amplitude = 2.0f;
-    // Initialize peak tracking to -INFINITY so first value triggers
-    for (int d = 0; d < ANNUNC_MAX_VEHICLES; d++)
-        for (int c = 0; c < ANNUNC_PEAK_CHANNELS; c++)
-            a->peak_scale.max_val[d][c] = -1e30f;
 }
 
 void annunc_update(hud_annunciators_t *a, float dt) {
@@ -119,22 +115,6 @@ float annunc_ring_bounce_offset(const hud_annunciators_t *a, int drone_idx) {
 }
 
 // Peak scale: update max tracking and at_peak flag
-void annunc_peak_update(hud_annunciators_t *a, int drone_idx, int channel, float value) {
-    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return;
-    if (channel < 0 || channel >= ANNUNC_PEAK_CHANNELS) return;
-    if (value > a->peak_scale.max_val[drone_idx][channel])
-        a->peak_scale.max_val[drone_idx][channel] = value;
-    a->peak_scale.at_peak[drone_idx][channel] =
-        (value >= a->peak_scale.max_val[drone_idx][channel] - 0.01f);
-}
-
-// Peak scale: returns font scale factor (1.0 normal, 1.05 at peak)
-float annunc_peak_scale_factor(const hud_annunciators_t *a, int drone_idx, int channel) {
-    if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 1.0f;
-    if (channel < 0 || channel >= ANNUNC_PEAK_CHANNELS) return 1.0f;
-    return a->peak_scale.at_peak[drone_idx][channel] ? 1.10f : 1.0f;
-}
-
 // Radar wave: returns progress 0.0-1.0 (0 = idle)
 float annunc_radar_wave_progress(const hud_annunciators_t *a, int drone_idx) {
     if (drone_idx < 0 || drone_idx >= ANNUNC_MAX_VEHICLES) return 0.0f;

--- a/src/hud_annunciators.h
+++ b/src/hud_annunciators.h
@@ -4,14 +4,6 @@
 #include <stdbool.h>
 
 #define ANNUNC_MAX_VEHICLES 16
-#define ANNUNC_PEAK_CHANNELS 7
-#define PEAK_HDG   0
-#define PEAK_ROLL  1
-#define PEAK_PITCH 2
-#define PEAK_ALT   3
-#define PEAK_GS    4
-#define PEAK_AS    5
-#define PEAK_VS    6
 
 // (a) Console tab fade — per-drone color bar fades out and back in
 typedef struct {
@@ -25,13 +17,7 @@ typedef struct {
     float duration;
 } annunc_ring_bounce_t;
 
-// (c) Value peak scale — 1.05x when at all-time max
-typedef struct {
-    float max_val[ANNUNC_MAX_VEHICLES][ANNUNC_PEAK_CHANNELS];
-    bool at_peak[ANNUNC_MAX_VEHICLES][ANNUNC_PEAK_CHANNELS];
-} annunc_peak_scale_t;
-
-// (d) Radar droplet wave — two expanding rings from drone blip
+// (c) Radar droplet wave — two expanding rings from drone blip
 typedef struct {
     float timer[ANNUNC_MAX_VEHICLES];
     float duration;
@@ -55,7 +41,6 @@ typedef struct {
 typedef struct {
     annunc_tab_fade_t     tab_fade;
     annunc_ring_bounce_t  ring_bounce;
-    annunc_peak_scale_t   peak_scale;
     annunc_radar_wave_t   radar_wave;
     annunc_ticker_flash_t ticker_flash;
     annunc_ring_shake_t   ring_shake;
@@ -74,8 +59,6 @@ void annunc_trigger_ring_shake(hud_annunciators_t *a, int drone_idx);
 // Queries (return animation values)
 float annunc_tab_fade_alpha(const hud_annunciators_t *a, int drone_idx);
 float annunc_ring_bounce_offset(const hud_annunciators_t *a, int drone_idx);
-void  annunc_peak_update(hud_annunciators_t *a, int drone_idx, int channel, float value);
-float annunc_peak_scale_factor(const hud_annunciators_t *a, int drone_idx, int channel);
 float annunc_radar_wave_progress(const hud_annunciators_t *a, int drone_idx);
 float annunc_ticker_flash_alpha(const hud_annunciators_t *a, int slot);
 float annunc_ring_shake_offset(const hud_annunciators_t *a, int drone_idx);

--- a/src/hud_annunciators.h
+++ b/src/hud_annunciators.h
@@ -1,0 +1,83 @@
+#ifndef HUD_ANNUNCIATORS_H
+#define HUD_ANNUNCIATORS_H
+
+#include <stdbool.h>
+
+#define ANNUNC_MAX_VEHICLES 16
+#define ANNUNC_PEAK_CHANNELS 7
+#define PEAK_HDG   0
+#define PEAK_ROLL  1
+#define PEAK_PITCH 2
+#define PEAK_ALT   3
+#define PEAK_GS    4
+#define PEAK_AS    5
+#define PEAK_VS    6
+
+// (a) Console tab fade — per-drone color bar fades out and back in
+typedef struct {
+    float timer[ANNUNC_MAX_VEHICLES];
+    float duration;
+} annunc_tab_fade_t;
+
+// (b) Gimbal ring bounce — pinned drone cell bounces on marker
+typedef struct {
+    float timer[ANNUNC_MAX_VEHICLES];
+    float duration;
+} annunc_ring_bounce_t;
+
+// (c) Value peak scale — 1.05x when at all-time max
+typedef struct {
+    float max_val[ANNUNC_MAX_VEHICLES][ANNUNC_PEAK_CHANNELS];
+    bool at_peak[ANNUNC_MAX_VEHICLES][ANNUNC_PEAK_CHANNELS];
+} annunc_peak_scale_t;
+
+// (d) Radar droplet wave — two expanding rings from drone blip
+typedef struct {
+    float timer[ANNUNC_MAX_VEHICLES];
+    float duration;
+} annunc_radar_wave_t;
+
+// (e) Ticker warning flash — background fill on severity <= 4
+typedef struct {
+    float timer[4];  // HUD_TICKER_MAX
+    float duration;
+} annunc_ticker_flash_t;
+
+// (f) Ring shake — horizontal oscillation on warning
+typedef struct {
+    float timer[ANNUNC_MAX_VEHICLES];
+    float duration;
+    int cycles;
+    float amplitude;
+} annunc_ring_shake_t;
+
+// Aggregate
+typedef struct {
+    annunc_tab_fade_t     tab_fade;
+    annunc_ring_bounce_t  ring_bounce;
+    annunc_peak_scale_t   peak_scale;
+    annunc_radar_wave_t   radar_wave;
+    annunc_ticker_flash_t ticker_flash;
+    annunc_ring_shake_t   ring_shake;
+} hud_annunciators_t;
+
+void annunc_init(hud_annunciators_t *a);
+void annunc_update(hud_annunciators_t *a, float dt);
+
+// Triggers
+void annunc_trigger_tab_fade(hud_annunciators_t *a, int drone_idx);
+void annunc_trigger_ring_bounce(hud_annunciators_t *a, int drone_idx);
+void annunc_trigger_radar_wave(hud_annunciators_t *a, int drone_idx);
+void annunc_trigger_ticker_flash(hud_annunciators_t *a, int slot);
+void annunc_trigger_ring_shake(hud_annunciators_t *a, int drone_idx);
+
+// Queries (return animation values)
+float annunc_tab_fade_alpha(const hud_annunciators_t *a, int drone_idx);
+float annunc_ring_bounce_offset(const hud_annunciators_t *a, int drone_idx);
+void  annunc_peak_update(hud_annunciators_t *a, int drone_idx, int channel, float value);
+float annunc_peak_scale_factor(const hud_annunciators_t *a, int drone_idx, int channel);
+float annunc_radar_wave_progress(const hud_annunciators_t *a, int drone_idx);
+float annunc_ticker_flash_alpha(const hud_annunciators_t *a, int slot);
+float annunc_ring_shake_offset(const hud_annunciators_t *a, int drone_idx);
+
+#endif

--- a/src/hud_telemetry.c
+++ b/src/hud_telemetry.c
@@ -27,11 +27,14 @@ void hud_draw_telemetry(const hud_t *h, const vehicle_t *v,
     Color warn = lay->warn;
     Color climb_color = lay->climb_color;
 
+    int sel = lay->selected;
+
     // NAV group: HDG, ROLL, PITCH (evenly spaced)
     // HDG / YAW (Y key toggles)
     {
         char b[8];
         float x = nav_start + nav_step * 0;
+        float hdg_fs = fs_value; // no peak scale on heading (circular)
         if (h->show_yaw) {
             DrawTextEx(h->font_label, "YAW", (Vector2){x, (float)label_y}, fs_label, 0.5f, label_color);
             float yaw = v->heading_deg;
@@ -41,7 +44,7 @@ void hud_draw_telemetry(const hud_t *h, const vehicle_t *v,
             DrawTextEx(h->font_label, "HDG", (Vector2){x, (float)label_y}, fs_label, 0.5f, label_color);
             snprintf(b, sizeof(b), "%03d", ((int)v->heading_deg % 360 + 360) % 360);
         }
-        DrawTextEx(h->font_value, b, (Vector2){x, (float)value_y}, fs_value, 0.5f, value_color);
+        DrawTextEx(h->font_value, b, (Vector2){x, (float)value_y}, hdg_fs, 0.5f, value_color);
         Vector2 vw = MeasureTextEx(h->font_value, b, fs_value, 0.5f);
         Vector2 uw = MeasureTextEx(h->font_label, "deg", fs_unit, 0.5f);
         float boundary = item_x0 + 1 * item_step;
@@ -72,9 +75,10 @@ void hud_draw_telemetry(const hud_t *h, const vehicle_t *v,
     {
         char b[16];
         float x = energy_start + energy_step * 0;
+        float alt_fs = fs_value;
         DrawTextEx(h->font_label, "ALT", (Vector2){x, (float)label_y}, fs_label, 0.5f, label_color);
         snprintf(b, sizeof(b), "%.1f", v->altitude_rel);
-        DrawTextEx(h->font_value, b, (Vector2){x, (float)value_y}, fs_value, 0.5f, value_color);
+        DrawTextEx(h->font_value, b, (Vector2){x, (float)value_y}, alt_fs, 0.5f, value_color);
         Vector2 vw = MeasureTextEx(h->font_value, b, fs_value, 0.5f);
         Vector2 uw = MeasureTextEx(h->font_label, "m", fs_unit, 0.5f);
         float boundary = item_x0 + 4 * item_step;
@@ -86,9 +90,10 @@ void hud_draw_telemetry(const hud_t *h, const vehicle_t *v,
     {
         char b[16];
         float x = energy_start + energy_step * 1;
+        float gs_fs = fs_value;
         DrawTextEx(h->font_label, "GS", (Vector2){x, (float)label_y}, fs_label, 0.5f, label_color);
         snprintf(b, sizeof(b), "%.1f", v->ground_speed);
-        DrawTextEx(h->font_value, b, (Vector2){x, (float)value_y}, fs_value, 0.5f, value_color);
+        DrawTextEx(h->font_value, b, (Vector2){x, (float)value_y}, gs_fs, 0.5f, value_color);
         Vector2 vw = MeasureTextEx(h->font_value, b, fs_value, 0.5f);
         Vector2 uw = MeasureTextEx(h->font_label, "m/s", fs_unit, 0.5f);
         float boundary = item_x0 + 5 * item_step;

--- a/src/hud_telemetry.h
+++ b/src/hud_telemetry.h
@@ -34,6 +34,7 @@ typedef struct {
     Color warn;
     Color climb_color;
     Color connected_color;
+    int selected;  // selected drone index (for peak scale annunciator)
 } hud_telemetry_layout_t;
 
 void hud_draw_telemetry(const hud_t *h, const vehicle_t *v,

--- a/src/hud_transport.c
+++ b/src/hud_transport.c
@@ -97,7 +97,6 @@ void hud_draw_transport(const hud_t *h,
             0.5f, 4, accent);
     }
     // Playhead ring — colored to match the drone's current trail color
-    bool multi = (marker_vehicle_count > 1);
     float dot_x = prog_x + prog_w * pb->progress;
     float dot_y = prog_y + prog_h / 2.0f;
     {
@@ -107,7 +106,7 @@ void hud_draw_transport(const hud_t *h,
                                             sqrtf(pv->ground_speed * pv->ground_speed +
                                                   pv->vertical_speed * pv->vertical_speed),
                                             pv->trail_speed_max, theme, trail_mode,
-                                            pv->color, multi);
+                                            pv->color);
         float r_outer = 6.5f * s;
         float r_inner = 5.5f * s;
         DrawRing((Vector2){dot_x, dot_y}, r_inner, r_outer, 0, 360, 24, ph_col);
@@ -162,7 +161,7 @@ void hud_draw_transport(const hud_t *h,
                 Color mc = vehicle_marker_color(markers->roll[i], markers->pitch[i],
                                                 markers->vert[i], markers->speed[i],
                                                 markers->speed_max, theme, trail_mode,
-                                                markers->color, multi);
+                                                markers->color);
                 if (is_cur) {
                     if (theme->thick_trails) {
                         mc.r = (unsigned char)(mc.r * 0.55f);
@@ -231,7 +230,7 @@ void hud_draw_transport(const hud_t *h,
                 Color mc = vehicle_marker_color(sysm->roll[i], sysm->pitch[i],
                                                 sysm->vert[i], sysm->speed[i],
                                                 sysm->speed_max, theme, trail_mode,
-                                                sysm->color, multi);
+                                                sysm->color);
                 if (is_cur) {
                     if (theme->thick_trails) {
                         mc.r = (unsigned char)(mc.r * 0.55f);

--- a/src/main.c
+++ b/src/main.c
@@ -432,7 +432,7 @@ int main(int argc, char *argv[]) {
     int chord_first = -1;       // first digit pressed (-1 = no chord in progress)
     double chord_time = 0.0;    // when first digit was pressed
     bool chord_shift = false;   // whether shift was held on first digit
-    int trail_mode = 1;              // 0=off, 1=directional trail, 2=speed ribbon
+    int trail_mode = (num_replay_files > 1) ? 3 : 1;  // multi-drone defaults to ID trails
     bool show_ground_track = false;  // ground projection off by default
     bool classic_colors = false;     // K key: toggle classic (red/blue) vs modern (yellow/purple)
     bool show_edge_indicators = true; // Ctrl+L: screen edge drone indicators
@@ -441,6 +441,8 @@ int main(int argc, char *argv[]) {
     bool show_axes = false;          // Z: axis orientation gizmo
     bool insufficient_data[MAX_VEHICLES];  // drones with no position data
     memset(insufficient_data, 0, sizeof(insufficient_data));
+    float prev_playback_pos[MAX_VEHICLES];
+    memset(prev_playback_pos, 0, sizeof(prev_playback_pos));
     int insufficient_check_frames = 0;
     bool insufficient_toasted = false;
 
@@ -471,6 +473,49 @@ int main(int argc, char *argv[]) {
         // Poll all data sources and update vehicles
         for (int i = 0; i < vehicle_count; i++) {
             data_source_poll(&sources[i], GetFrameTime());
+
+            // Feed STATUSTEXT messages into HUD ticker
+            if (sources[i].playback.statustext)
+                hud_feed_statustext(&hud, sources[i].playback.statustext, i);
+
+            // Check if playback crossed any marker times (annunciator triggers)
+            if (is_replay && !sources[i].playback.paused) {
+                float cur_pos = sources[i].playback.position_s;
+                float prev_pos = prev_playback_pos[i];
+                // User markers
+                for (int m = 0; m < markers[i].count; m++) {
+                    if (markers[i].times[m] > prev_pos && markers[i].times[m] <= cur_pos) {
+                        annunc_trigger_tab_fade(&hud.annunciators, i);
+                        annunc_trigger_radar_wave(&hud.annunciators, i);
+                        if (i != selected) {
+                            for (int p = 0; p < hud.pinned_count; p++)
+                                if (hud.pinned[p] == i)
+                                    annunc_trigger_ring_bounce(&hud.annunciators, i);
+                        }
+                        break;
+                    }
+                }
+                // System markers
+                for (int m = 0; m < sys_markers[i].count; m++) {
+                    if (sys_markers[i].times[m] > prev_pos && sys_markers[i].times[m] <= cur_pos) {
+                        annunc_trigger_tab_fade(&hud.annunciators, i);
+                        annunc_trigger_radar_wave(&hud.annunciators, i);
+                        if (i != selected) {
+                            for (int p = 0; p < hud.pinned_count; p++)
+                                if (hud.pinned[p] == i)
+                                    annunc_trigger_ring_bounce(&hud.annunciators, i);
+                        }
+                        break;
+                    }
+                }
+                prev_playback_pos[i] = cur_pos;
+            }
+
+            // Update peak value tracking for annunciators
+            if (vehicles[i].active) {
+                annunc_peak_update(&hud.annunciators, i, PEAK_GS, vehicles[i].ground_speed);
+                annunc_peak_update(&hud.annunciators, i, PEAK_ALT, vehicles[i].altitude_rel);
+            }
 
             // Reset trail and origin on reconnect
             if (sources[i].connected && !was_connected[i]) {
@@ -962,6 +1007,10 @@ int main(int argc, char *argv[]) {
             if (IsKeyPressed(KEY_Y)) {
                 hud.show_yaw = !hud.show_yaw;
             }
+            if (IsKeyPressed(KEY_N)) {
+                hud.show_notifications = !hud.show_notifications;
+                hud_toast(&hud, hud.show_notifications ? "Notifications On" : "Notifications Off", 2.0f);
+            }
             if (IsKeyPressed(KEY_L) && !IsKeyDown(KEY_LEFT_CONTROL) && !IsKeyDown(KEY_RIGHT_CONTROL) && !shift && (markers[selected].last_drop_idx < 0 || GetTime() - markers[selected].last_drop_time >= 0.5)) {
                 show_marker_labels = !show_marker_labels;
             }
@@ -969,7 +1018,7 @@ int main(int argc, char *argv[]) {
                 bool interp = !sources[selected].playback.interpolation;
                 for (int i = 0; i < nrf; i++)
                     sources[i].playback.interpolation = interp;
-                printf("Interpolation: %s\n", interp ? "ON" : "OFF");
+                hud_toast(&hud, interp ? "Interpolation On" : "Interpolation Off", 2.0f);
             }
             if (IsKeyPressed(KEY_EQUAL)) {
                 float spd = sources[selected].playback.speed;
@@ -1104,6 +1153,17 @@ int main(int argc, char *argv[]) {
                                  &sources[selected], &vehicles[selected],
                                  &precomp[selected], &scene, &last_pos[selected]);
                 }
+                // Trigger annunciators on marker cycle
+                if (!shift) {
+                    annunc_trigger_tab_fade(&hud.annunciators, selected);
+                    annunc_trigger_radar_wave(&hud.annunciators, selected);
+                    // Bounce any pinned drones
+                    for (int p = 0; p < hud.pinned_count; p++) {
+                        int pidx = hud.pinned[p];
+                        if (pidx >= 0 && pidx < vehicle_count)
+                            annunc_trigger_ring_bounce(&hud.annunciators, pidx);
+                    }
+                }
                 // Sync all drones to the same playback time after marker seek
                 if (!shift && vehicle_count > 1) {
                     float sync_time = sources[selected].playback.position_s;
@@ -1167,7 +1227,7 @@ int main(int argc, char *argv[]) {
                                              markers[i].vert, markers[i].speed,
                                              vehicles[i].trail_speed_max, scene.theme,
                                              trail_mode, MARKER_USER,
-                                             vehicles[i].color, vehicle_count > 1);
+                                             vehicles[i].color);
                     }
                     if (is_replay && sys_markers[i].count > 0) {
                         int cur = (i == selected && sys_markers[i].selected)
@@ -1179,7 +1239,7 @@ int main(int argc, char *argv[]) {
                                              sys_markers[i].vert, sys_markers[i].speed,
                                              vehicles[i].trail_speed_max, scene.theme,
                                              trail_mode, MARKER_SYSTEM,
-                                             vehicles[i].color, vehicle_count > 1);
+                                             vehicles[i].color);
                     }
                 }
 
@@ -1260,7 +1320,7 @@ int main(int argc, char *argv[]) {
                                                    markers[i].vert, markers[i].speed,
                                                    vehicles[i].trail_speed_max, scene.theme,
                                                    trail_mode, MARKER_USER,
-                                                   vehicles[i].color, vehicle_count > 1);
+                                                   vehicles[i].color);
                     }
                     if (sys_markers[i].count > 0) {
                         int cur = (i == selected && sys_markers[i].selected)
@@ -1273,7 +1333,7 @@ int main(int argc, char *argv[]) {
                                                    sys_markers[i].vert, sys_markers[i].speed,
                                                    vehicles[i].trail_speed_max, scene.theme,
                                                    trail_mode, MARKER_SYSTEM,
-                                                   vehicles[i].color, vehicle_count > 1);
+                                                   vehicles[i].color);
                     }
                 }
             }

--- a/src/main.c
+++ b/src/main.c
@@ -511,12 +511,6 @@ int main(int argc, char *argv[]) {
                 prev_playback_pos[i] = cur_pos;
             }
 
-            // Update peak value tracking for annunciators
-            if (vehicles[i].active) {
-                annunc_peak_update(&hud.annunciators, i, PEAK_GS, vehicles[i].ground_speed);
-                annunc_peak_update(&hud.annunciators, i, PEAK_ALT, vehicles[i].altitude_rel);
-            }
-
             // Reset trail and origin on reconnect
             if (sources[i].connected && !was_connected[i]) {
                 vehicle_reset_trail(&vehicles[i]);

--- a/src/ortho_panel.c
+++ b/src/ortho_panel.c
@@ -515,18 +515,10 @@ void ortho_panel_draw(const ortho_panel_t *op, int screen_h, int hud_bar_h,
                     Vector2 sa = world_to_panel(pa, center, op->ortho_span, x, y, (float)ps, i);
                     Vector2 sb = world_to_panel(pb, center, op->ortho_span, x, y, (float)ps, i);
 
-                    // Gradient line: interpolate vehicle colors
-                    Color ca = vehicles[selected].color;
-                    Color cb = vehicles[pidx].color;
-                    ca.a = 200; cb.a = 200;
-                    // Draw as single line with blended midpoint color
-                    Color mid = {
-                        (unsigned char)((ca.r + cb.r) / 2),
-                        (unsigned char)((ca.g + cb.g) / 2),
-                        (unsigned char)((ca.b + cb.b) / 2),
-                        200
-                    };
-                    DrawLineEx(sa, sb, 2.0f, mid);
+                    // Use pinned drone's color for correlation line
+                    Color lc = vehicles[pidx].color;
+                    lc.a = 200;
+                    DrawLineEx(sa, sb, 2.0f, lc);
                 }
             }
         }
@@ -743,15 +735,9 @@ void ortho_draw_fullscreen_2d(const scene_t *s, const vehicle_t *vehicles,
                 Vector2 sa = world_to_screen_ortho(pa, center, span, screen_w, screen_h, ortho_mode);
                 Vector2 sb = world_to_screen_ortho(pb, center, span, screen_w, screen_h, ortho_mode);
 
-                Color ca = vehicles[selected].color;
-                Color cb = vehicles[pidx].color;
-                Color mid = {
-                    (unsigned char)((ca.r + cb.r) / 2),
-                    (unsigned char)((ca.g + cb.g) / 2),
-                    (unsigned char)((ca.b + cb.b) / 2),
-                    200
-                };
-                DrawLineEx(sa, sb, 2.0f, mid);
+                Color lc = vehicles[pidx].color;
+                lc.a = 200;
+                DrawLineEx(sa, sb, 2.0f, lc);
             }
         }
     }

--- a/src/ortho_panel.c
+++ b/src/ortho_panel.c
@@ -650,13 +650,10 @@ void ortho_panel_draw_single(const ortho_panel_t *op, int view_index,
                                vehicles[pidx].position.z };
                 Vector2 sa = world_to_panel(pa, center, op->ortho_span, x, y, (float)ps, i);
                 Vector2 sb = world_to_panel(pb, center, op->ortho_span, x, y, (float)ps, i);
-                Color mid = {
-                    (unsigned char)((vehicles[selected].color.r + vehicles[pidx].color.r) / 2),
-                    (unsigned char)((vehicles[selected].color.g + vehicles[pidx].color.g) / 2),
-                    (unsigned char)((vehicles[selected].color.b + vehicles[pidx].color.b) / 2),
-                    200
-                };
-                DrawLineEx(sa, sb, 2.0f, mid);
+                // Use pinned drone's color for correlation line
+                Color lc = vehicles[pidx].color;
+                lc.a = 200;
+                DrawLineEx(sa, sb, 2.0f, lc);
             }
         }
     }

--- a/src/tactical_hud.c
+++ b/src/tactical_hud.c
@@ -125,6 +125,13 @@ static void tac_draw_timer_status(const hud_t *h, const data_source_t *src,
 }
 
 // ── Ticker (top-center) ───────────────────────────────────────────────────
+static Color tac_severity_color(uint8_t sev, const theme_t *theme) {
+    if (sev <= 2) return theme->drone_palette[2];
+    if (sev == 3) return theme->drone_palette[4];
+    if (sev == 4) return theme->hud_warn;
+    return theme->hud_dim;
+}
+
 static void tac_draw_ticker(const hud_t *h, const playback_state_t *pb,
                              const hud_marker_data_t *user_md,
                              const hud_marker_data_t *sys_md,
@@ -519,6 +526,18 @@ static void tac_draw_radar(const hud_t *h, const vehicle_t *vehicles,
                 float by = ccy + dz * dot_scale;
                 float dot_r = (vi == selected) ? ws(5, sw, sh) : ws(4, sw, sh);
                 DrawCircle((int)bx, (int)by, dot_r, vehicles[vi].color);
+
+                // Radar droplet wave annunciator
+                float wave_p = annunc_radar_wave_progress(&h->annunciators, vi);
+                if (wave_p > 0.0f) {
+                    float wave_alpha = 1.0f - wave_p;
+                    Color wc = vehicles[vi].color;
+                    wc.a = (unsigned char)(wave_alpha * 180);
+                    float r1 = dot_r + wave_p * ps * 0.12f;
+                    float r2 = dot_r + (wave_p - 0.3f) * ps * 0.12f;
+                    if (r2 > dot_r) DrawCircleLines((int)bx, (int)by, r2, wc);
+                    DrawCircleLines((int)bx, (int)by, r1, wc);
+                }
             }
 
             // Correlation overlays
@@ -541,9 +560,7 @@ static void tac_draw_radar(const hud_t *h, const vehicle_t *vehicles,
                                 int ib1 = (sb + (int)((float)i/n * vb->trail_count)) % vb->trail_capacity;
                                 float t = (float)i / (float)n;
                                 unsigned char al = (unsigned char)(t * 120);
-                                Color mc = {(unsigned char)((va->color.r + vb->color.r)/2),
-                                            (unsigned char)((va->color.g + vb->color.g)/2),
-                                            (unsigned char)((va->color.b + vb->color.b)/2), al};
+                                Color mc = {vb->color.r, vb->color.g, vb->color.b, al};
                                 Vector2 a0 = {ccx + (va->trail[ia0].x - self_pos.x) * dot_scale,
                                               ccy + (va->trail[ia0].z - self_pos.z) * dot_scale};
                                 Vector2 a1 = {ccx + (va->trail[ia1].x - self_pos.x) * dot_scale,
@@ -564,10 +581,8 @@ static void tac_draw_radar(const hud_t *h, const vehicle_t *vehicles,
                     float dz_p = vb->position.z - self_pos.z;
                     float bx_c = ccx + dx_p * dot_scale;
                     float by_c = ccy + dz_p * dot_scale;
-                    Color mid = {(unsigned char)((va->color.r + vb->color.r)/2),
-                                 (unsigned char)((va->color.g + vb->color.g)/2),
-                                 (unsigned char)((va->color.b + vb->color.b)/2), 200};
-                    DrawLineEx((Vector2){ccx, ccy}, (Vector2){bx_c, by_c}, 2.0f, mid);
+                    Color lc = {vb->color.r, vb->color.g, vb->color.b, 200};
+                    DrawLineEx((Vector2){ccx, ccy}, (Vector2){bx_c, by_c}, 2.0f, lc);
                 }
             }
         }
@@ -654,8 +669,10 @@ static void tac_draw_gimbal_rings(const hud_t *h, const vehicle_t *vehicles,
         if (pidx < 0 || pidx >= vehicle_count) continue;
 
         Color dc = vehicles[pidx].color;
-        float cx = start_x + p * spacing;
-        float cy = ring_y;
+        float cx = start_x + p * spacing
+                   + annunc_ring_shake_offset(&h->annunciators, pidx);
+        float cy = ring_y
+                   + annunc_ring_bounce_offset(&h->annunciators, pidx);
 
         Quaternion rot = vehicles[pidx].rotation;
 
@@ -819,5 +836,29 @@ void tactical_hud_draw(const hud_t *h, const vehicle_t *vehicles,
                            s, trail_mode, theme);
         rlPopMatrix();
         EndScissorMode();
+    }
+
+    // Persistent notification panel (bottom-right, N toggle)
+    if (h->show_notifications && h->ticker_count > 0) {
+        float nfs = wy(11, screen_h);
+        float margin = wx(20, screen_w);
+        float ny = (float)screen_h - wy(60, screen_h);
+        for (int i = 0; i < h->ticker_count; i++) {
+            Color sc = tac_severity_color(h->ticker[i].severity, theme);
+            char tag[8];
+            snprintf(tag, sizeof(tag), "D%d", h->ticker[i].drone_idx + 1);
+            Vector2 tag_w = MeasureTextEx(h->font_label, tag, nfs * 0.8f, 0.5f);
+            Vector2 msg_w = MeasureTextEx(h->font_label, h->ticker[i].text, nfs, 0.5f);
+            float total_w = tag_w.x + wy(6, screen_h) + msg_w.x;
+            float tx = (float)screen_w - margin - total_w;
+            float ty = ny - (msg_w.y + wy(3, screen_h));
+
+            Color tag_c = (Color){sc.r, sc.g, sc.b, 120};
+            DrawTextEx(h->font_label, tag, (Vector2){tx, ty + 1}, nfs * 0.8f, 0.5f, tag_c);
+            sc.a = 200;
+            DrawTextEx(h->font_label, h->ticker[i].text,
+                       (Vector2){tx + tag_w.x + wy(6, screen_h), ty}, nfs, 0.5f, sc);
+            ny = ty;
+        }
     }
 }

--- a/src/ulog_parser.c
+++ b/src/ulog_parser.c
@@ -343,6 +343,14 @@ bool ulog_parser_next(ulog_parser_t *p, ulog_data_msg_t *out) {
             out->data_len = msg_size - 2;
             return true;
         }
+        if ((char)msg_type == ULOG_MSG_LOGGING && p->logging_cb && msg_size >= 9) {
+            ulog_logging_msg_t lmsg;
+            lmsg.log_level = p->read_buf[0];
+            memcpy(&lmsg.timestamp, p->read_buf + 1, 8);
+            lmsg.text = (const char *)(p->read_buf + 9);
+            lmsg.text_len = msg_size - 9;
+            p->logging_cb(&lmsg, p->logging_userdata);
+        }
         // Skip non-DATA messages (DROPOUT, LOGGING, etc.)
     }
 }
@@ -449,6 +457,12 @@ uint64_t ulog_parser_get_uint64(const ulog_data_msg_t *msg, int offset) {
     uint64_t v;
     memcpy(&v, msg->data + offset, sizeof(v));
     return v;
+}
+
+void ulog_parser_set_logging_callback(ulog_parser_t *p,
+                                       ulog_logging_callback_t cb, void *userdata) {
+    p->logging_cb = cb;
+    p->logging_userdata = userdata;
 }
 
 void ulog_parser_close(ulog_parser_t *p) {

--- a/src/ulog_parser.h
+++ b/src/ulog_parser.h
@@ -65,6 +65,16 @@ typedef struct {
     int data_len;
 } ulog_data_msg_t;
 
+typedef struct {
+    uint8_t log_level;    // 0=EMERG .. 7=DEBUG
+    uint64_t timestamp;
+    const char *text;     // valid until next read
+    int text_len;
+} ulog_logging_msg_t;
+
+// Callback for logging messages encountered during parsing.
+typedef void (*ulog_logging_callback_t)(const ulog_logging_msg_t *msg, void *userdata);
+
 // Timestamp index entry for seeking
 typedef struct {
     uint64_t timestamp;
@@ -91,6 +101,10 @@ typedef struct {
 
     uint64_t start_timestamp;
     uint64_t end_timestamp;
+
+    // Optional logging message callback
+    ulog_logging_callback_t logging_cb;
+    void *logging_userdata;
 
     bool eof;
 } ulog_parser_t;
@@ -122,6 +136,10 @@ double   ulog_parser_get_double(const ulog_data_msg_t *msg, int offset);
 int32_t  ulog_parser_get_int32(const ulog_data_msg_t *msg, int offset);
 uint8_t  ulog_parser_get_uint8(const ulog_data_msg_t *msg, int offset);
 uint64_t ulog_parser_get_uint64(const ulog_data_msg_t *msg, int offset);
+
+// Set logging callback before calling ulog_parser_next() to receive 'L' messages.
+void ulog_parser_set_logging_callback(ulog_parser_t *p,
+                                       ulog_logging_callback_t cb, void *userdata);
 
 // Close file and free resources.
 void ulog_parser_close(ulog_parser_t *p);

--- a/src/ulog_replay.c
+++ b/src/ulog_replay.c
@@ -4,6 +4,21 @@
 #include <string.h>
 #include <stdio.h>
 
+// STATUSTEXT logging callback — pushes into ring buffer
+static void logging_cb(const ulog_logging_msg_t *msg, void *userdata) {
+    ulog_replay_ctx_t *ctx = (ulog_replay_ctx_t *)userdata;
+    statustext_ring_t *ring = &ctx->statustext;
+    statustext_entry_t *e = &ring->entries[ring->head];
+    e->severity = msg->log_level;
+    float time_s = (float)((double)(msg->timestamp - ctx->parser.start_timestamp) / 1e6);
+    e->time_s = time_s;
+    int len = msg->text_len < STATUSTEXT_MSG_MAX - 1 ? msg->text_len : STATUSTEXT_MSG_MAX - 1;
+    memcpy(e->text, msg->text, len);
+    e->text[len] = '\0';
+    ring->head = (ring->head + 1) % STATUSTEXT_RING_SIZE;
+    if (ring->count < STATUSTEXT_RING_SIZE) ring->count++;
+}
+
 // PX4 nav_state display names
 const char *ulog_nav_state_name(uint8_t nav_state) {
     switch (nav_state) {
@@ -257,6 +272,9 @@ int ulog_replay_init(ulog_replay_ctx_t *ctx, const char *filepath) {
 
     int ret = ulog_parser_open(&ctx->parser, filepath);
     if (ret != 0) return ret;
+
+    // Enable STATUSTEXT logging message capture
+    ulog_parser_set_logging_callback(&ctx->parser, logging_cb, ctx);
 
     // Find subscriptions
     ctx->sub_attitude = ulog_parser_find_subscription(&ctx->parser, "vehicle_attitude");

--- a/src/ulog_replay.c
+++ b/src/ulog_replay.c
@@ -273,9 +273,6 @@ int ulog_replay_init(ulog_replay_ctx_t *ctx, const char *filepath) {
     int ret = ulog_parser_open(&ctx->parser, filepath);
     if (ret != 0) return ret;
 
-    // Enable STATUSTEXT logging message capture
-    ulog_parser_set_logging_callback(&ctx->parser, logging_cb, ctx);
-
     // Find subscriptions
     ctx->sub_attitude = ulog_parser_find_subscription(&ctx->parser, "vehicle_attitude");
     ctx->sub_global_pos = ulog_parser_find_subscription(&ctx->parser, "vehicle_global_position");
@@ -509,6 +506,11 @@ int ulog_replay_init(ulog_replay_ctx_t *ctx, const char *filepath) {
             ctx->current_nav_state = ctx->mode_changes[0].nav_state;
         ulog_parser_rewind(&ctx->parser);
     }
+
+    // Enable STATUSTEXT logging message capture (after pre-scan so the ring
+    // only fills with messages encountered during actual playback, not during
+    // the full-file pre-scan pass above).
+    ulog_parser_set_logging_callback(&ctx->parser, logging_cb, ctx);
 
     float dur = (float)((double)(ctx->parser.end_timestamp - ctx->parser.start_timestamp) / 1e6);
     printf("ULog replay: %s (%.1fs, %d index entries)\n", filepath, dur, ctx->parser.index_count);

--- a/src/ulog_replay.h
+++ b/src/ulog_replay.h
@@ -8,6 +8,21 @@
 // Flight mode change event (from nav_state transitions)
 #define ULOG_MAX_MODE_CHANGES 256
 
+#define STATUSTEXT_MSG_MAX 128
+#define STATUSTEXT_RING_SIZE 16
+
+typedef struct {
+    uint8_t severity;
+    float time_s;
+    char text[STATUSTEXT_MSG_MAX];
+} statustext_entry_t;
+
+typedef struct statustext_ring {
+    statustext_entry_t entries[STATUSTEXT_RING_SIZE];
+    int head;
+    int count;
+} statustext_ring_t;
+
 typedef struct {
     float time_s;          // seconds from log start
     uint8_t nav_state;     // PX4 nav_state value
@@ -110,6 +125,9 @@ typedef struct {
 
     // Time alignment (set by caller after all logs pre-scanned)
     double time_offset_s;       // seconds to add when computing log target timestamp
+
+    // STATUSTEXT messages (populated during playback)
+    statustext_ring_t statustext;
 } ulog_replay_ctx_t;
 
 // Initialize replay context, parse file, build index. Returns 0 on success.

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -1044,8 +1044,8 @@ void vehicle_truncate_trail(vehicle_t *v, float time_s) {
 
 Color vehicle_marker_color(float roll, float pitch, float vert, float speed,
                            float speed_max, const theme_t *theme, int trail_mode,
-                           Color drone_color, bool multi_drone) {
-    if (trail_mode == 3 || multi_drone) {
+                           Color drone_color) {
+    if (trail_mode == 3) {
         return drone_color;
     }
     if (trail_mode == 2) {
@@ -1111,7 +1111,7 @@ void vehicle_draw_markers(Vector3 *positions, char labels[][48], int count,
                           int current_marker, Vector3 cam_pos, Camera3D camera,
                           float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                           float speed_max, const theme_t *theme, int trail_mode,
-                          marker_type_t type, Color drone_color, bool multi_drone) {
+                          marker_type_t type, Color drone_color) {
     (void)labels;
     bool is_system = (type == MARKER_SYSTEM);
 
@@ -1126,7 +1126,7 @@ void vehicle_draw_markers(Vector3 *positions, char labels[][48], int count,
         bool is_current = (i == current_marker);
 
         Color col = vehicle_marker_color(m_roll[i], m_pitch[i], m_vert[i], m_speed[i],
-                                         speed_max, theme, trail_mode, drone_color, multi_drone);
+                                         speed_max, theme, trail_mode, drone_color);
 
         if (is_current) {
             if (theme->thick_trails) {
@@ -1182,7 +1182,7 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
                                 Font font_label, Font font_value,
                                 float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                                 float speed_max, const theme_t *theme, int trail_mode,
-                                marker_type_t type, Color drone_color, bool multi_drone) {
+                                marker_type_t type, Color drone_color) {
     bool is_system = (type == MARKER_SYSTEM);
     Vector3 cam_fwd = Vector3Normalize(Vector3Subtract(camera.target, camera.position));
 
@@ -1232,7 +1232,7 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
         float rh = tw.y + pad_y * 2;
 
         Color text_col = vehicle_marker_color(m_roll[i], m_pitch[i], m_vert[i], m_speed[i],
-                                              speed_max, theme, trail_mode, drone_color, multi_drone);
+                                              speed_max, theme, trail_mode, drone_color);
         if (is_current) {
             if (theme->thick_trails) {
                 text_col.r = (unsigned char)(text_col.r * 0.55f);

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -168,7 +168,7 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
                                 marker_type_t type, Color drone_color);
 
 // Compute marker color from snapshotted telemetry.
-// drone_color used when trail_mode == 3 (ID trails) or multi-drone mode.
+// drone_color used when trail_mode == 3 (ID trails).
 Color vehicle_marker_color(float roll, float pitch, float vert, float speed,
                            float speed_max, const theme_t *theme, int trail_mode,
                            Color drone_color);

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -157,7 +157,7 @@ void vehicle_draw_markers(Vector3 *positions, char labels[][48], int count,
                           int current_marker, Vector3 cam_pos, Camera3D camera,
                           float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                           float speed_max, const theme_t *theme, int trail_mode,
-                          marker_type_t type, Color drone_color, bool multi_drone);
+                          marker_type_t type, Color drone_color);
 
 // Draw billboarded marker labels (call AFTER EndMode3D, in 2D pass).
 void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count,
@@ -165,13 +165,13 @@ void vehicle_draw_marker_labels(Vector3 *positions, char labels[][48], int count
                                 Font font_label, Font font_value,
                                 float *m_roll, float *m_pitch, float *m_vert, float *m_speed,
                                 float speed_max, const theme_t *theme, int trail_mode,
-                                marker_type_t type, Color drone_color, bool multi_drone);
+                                marker_type_t type, Color drone_color);
 
 // Compute marker color from snapshotted telemetry.
 // drone_color used when trail_mode == 3 (ID trails) or multi-drone mode.
 Color vehicle_marker_color(float roll, float pitch, float vert, float speed,
                            float speed_max, const theme_t *theme, int trail_mode,
-                           Color drone_color, bool multi_drone);
+                           Color drone_color);
 
 // Draw correlation curtain between two vehicles (cross-vehicle overlay).
 void vehicle_draw_correlation_curtain(


### PR DESCRIPTION
## Summary
Bundle of HUD visual improvements: event-driven micro-animations, ULog warning message parsing, responsive layout, and quality-of-life fixes.

- **STATUSTEXT parsing**: ULog logging messages ('L' type) parsed into per-drone ring buffer, exposed via `data_source.playback.statustext`
- **Notification ticker** (N key toggle): severity-colored warnings from drone palette colors, gradient-faded edges. Console: ticker zone above bar. Tactical: bottom-right panel. Entries persist until pushed out.
- **Adaptive numpad**: 3x3 (≤9 drones), 3x4 (10-12), 4x4 (13-16) with smaller font for two-digit numbers
- **Font scaling floors**: minimum readable sizes at small windows, label alpha reduced for better contrast
- **Interpolation toast**: I key shows toast instead of printf
- **Multi-drone trail default**: trail_mode defaults to ID trails (mode 3) when multiple logs loaded. T key still cycles all modes.
- **Correlation line colors**: ortho and radar correlation lines now use the pinned drone's color instead of a blended midpoint
- **Removed multi_drone marker color override**: markers use velocity/directional colors again in all trail modes
- **Annunciator system** (`hud_annunciators.c/h`):
  - Console tab fade: per-drone left color bar double-pulses on marker crossing
  - Gimbal ring bounce: pinned drone cell bounces on marker crossing (tactical)
  - Radar droplet wave: two expanding rings from drone blip on marker crossing (tactical)
  - Ticker warning flash: background brightens + text inverts on STATUSTEXT arrival
  - Ring shake: gimbal cell oscillates horizontally on STATUSTEXT warning (tactical)

## Blocked by
- #73 (tactical HUD mode)
- #72 (multi-drone marker support)

## Test plan
- [x] All 7 existing tests pass
- [x] Adaptive numpad: 3x4 with 7 drones, 4x4 with 16
- [x] Font scaling: readable at small window sizes
- [x] I key shows interpolation toast
- [x] N key toggles notifications on/off with toast
- [x] STATUSTEXT warnings render in console ticker zone with gradient edges
- [x] STATUSTEXT warnings render in tactical bottom-right panel
- [x] Tab fade: color bar pulses on marker crossing (console)
- [x] Gimbal ring bounce on marker crossing (tactical, pinned drones)
- [x] Radar droplet wave on marker crossing (tactical)
- [x] Ticker flash on STATUSTEXT arrival
- [x] Ring shake on STATUSTEXT warning (tactical, pinned drones)
- [x] Tested with fixture 1040ff85 (694 logging messages, emergency battery + preflight fails)
- [ ] Multi-drone trail defaults to ID trails (mode 3), T key cycles normally
- [ ] Correlation lines in ortho/radar use pinned drone's color
- [ ] Marker colors use velocity/directional coloring (not drone ID) in non-ID trail modes