### PR TITLE
Feature/android camera controls

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(gh release:*)",
       "Bash(wc -l src/*.c src/*.h)",
       "WebFetch(domain:github.com)",
-      "Bash(gh search:*)"
+      "Bash(gh search:*)",
+      "Bash(gh auth *)"
     ]
   }
 }

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+docs/superpowers/

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(hawkeye SHARED
     android_main.c
     ${HAWKEYE_SRC}/scene.c
     ${HAWKEYE_SRC}/vehicle.c
-    ${HAWKEYE_SRC}/asset_path.c
     ${HAWKEYE_SRC}/theme.c
     ${HAWKEYE_SRC}/ortho_panel.c
 )
@@ -43,4 +42,6 @@ target_link_libraries(hawkeye
 
 # ANativeActivity_onCreate is called by the Android Java runtime via JNI, not by any
 # C code — so the linker would silently strip it from the shared library without this.
-target_link_options(hawkeye PRIVATE "-Wl,-u,ANativeActivity_onCreate")
+target_link_options(hawkeye PRIVATE
+    "-Wl,-u,ANativeActivity_onCreate"
+)

--- a/android/app/src/main/cpp/android_main.c
+++ b/android/app/src/main/cpp/android_main.c
@@ -1,54 +1,360 @@
 #include "raylib.h"
+#include "raymath.h"
+#include "asset_path.h"
 #include "scene.h"
 #include "vehicle.h"
 #include <android/asset_manager.h>
+#include <android/input.h>
+#include <android/keycodes.h>
+#include <android/log.h>
 #include <android_native_app_glue.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+// Bump this string whenever APK assets change to force re-extraction on next launch.
+#define HAWKEYE_ASSET_VERSION "2"
+#define MAX_PATH_LEN ASSET_MAX_PATH
+
+#define TOUCH_ORBIT_SENSITIVITY  0.005f
+#define TOUCH_ZOOM_SENSITIVITY   0.01f
+#define TOUCH_PAN_SENSITIVITY    0.002f
+#define TOUCH_MIN_ORBIT_DIST     2.0f
+#define TOUCH_MAX_ORBIT_DIST    50.0f
 
 // Forward-declare Raylib's Android accessor (defined in rcore_android.c, not in raylib.h).
 struct android_app *GetAndroidApp(void);
 
-// Patch #version 330 → #version 300 es (+ precision mediump float for fragment shaders)
-// so the original desktop shaders work on OpenGL ES 3.0 without copying them.
-// Loads via AAssetManager directly to avoid recursing back into this callback.
-static char *patch_shader_source(const char *fileName) {
-    struct android_app *app = GetAndroidApp();
-    AAsset *asset = AAssetManager_open(app->activity->assetManager, fileName, AASSET_MODE_BUFFER);
-    if (!asset) return NULL;
+// Raylib returns 0 for volume keys, letting Android show the system volume overlay.
+// Wrap the input handler to consume them so the overlay never appears.
+static int32_t (*orig_input_handler)(struct android_app *, AInputEvent *) = NULL;
 
-    off_t size = AAsset_getLength(asset);
-    char *src = (char *)MemAlloc((unsigned int)size + 1);
-    if (!src) { AAsset_close(asset); return NULL; }
-    int bytes_read = AAsset_read(asset, src, (size_t)size);
-    AAsset_close(asset);
-    if (bytes_read != (int)size) { MemFree(src); return NULL; }
-    src[size] = '\0';
+static int32_t input_handler(struct android_app *app, AInputEvent *event) {
+    if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_KEY) {
+        int32_t kc = AKeyEvent_getKeyCode(event);
+        if (kc == AKEYCODE_VOLUME_UP || kc == AKEYCODE_VOLUME_DOWN)
+            return 1;
+    }
+    if (!orig_input_handler) {
+        __android_log_print(ANDROID_LOG_WARN, "Hawkeye", "input_handler: orig is NULL, all input dropped");
+        return 0;
+    }
+    return orig_input_handler(app, event);
+}
 
-    const char *old_ver = "#version 330";
-    const char *new_ver = "#version 300 es";
-    char *pos = strstr(src, old_ver);
-    if (!pos) return src; // not a versioned shader, return as-is
+// Android-specific asset_path implementation — all assets live under internalDataPath
+// after extract_assets() copies them from the APK on first launch.
+static char s_internal_data_path[MAX_PATH_LEN];
 
-    size_t len     = strlen(fileName);
-    int    is_fs   = (len >= 3 && strcmp(fileName + len - 3, ".fs") == 0);
+// Raylib's utils.h redefines fopen as android_fopen for all Android code. android_fopen
+// doesn't handle absolute paths: its fallback prepends internalDataPath to an already-
+// absolute path, producing a doubly-nested garbage path. These callbacks are registered
+// with Raylib so it calls into our code (no utils.h macro here) for all file I/O, letting
+// us open the extracted files directly with the real fopen.
+static char *read_text_from_disk(const char *fileName) {
+    FILE *f = fopen(fileName, "rt");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0) { fclose(f); return NULL; }
+    char *buf = (char *)MemAlloc((unsigned int)(size + 1));
+    if (!buf) { fclose(f); return NULL; }
+    size_t n = fread(buf, 1, (size_t)size, f);
+    buf[n] = '\0';
+    fclose(f);
+    return buf;
+}
+
+static unsigned char *read_data_from_disk(const char *fileName, int *dataSize) {
+    FILE *f = fopen(fileName, "rb");
+    if (!f) { *dataSize = 0; return NULL; }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0) { fclose(f); *dataSize = 0; return NULL; }
+    unsigned char *buf = (unsigned char *)MemAlloc((unsigned int)size);
+    if (!buf) { fclose(f); *dataSize = 0; return NULL; }
+    *dataSize = (int)fread(buf, 1, (size_t)size, f);
+    fclose(f);
+    return buf;
+}
+
+// Creates the immediate parent directory of path. Assumes all ancestor directories
+// already exist (single mkdir, not recursive).
+static void ensure_parent_dir(const char *path) {
+    char tmp[MAX_PATH_LEN];
+    snprintf(tmp, sizeof(tmp), "%s", path);
+    char *slash = strrchr(tmp, '/');
+    if (slash) { *slash = '\0'; mkdir(tmp, 0755); }
+}
+
+static bool save_data_to_disk(const char *fileName, void *data, int dataSize) {
+    ensure_parent_dir(fileName);
+    FILE *f = fopen(fileName, "wb");
+    if (!f) return false;
+    bool ok = ((int)fwrite(data, 1, (size_t)dataSize, f) == dataSize);
+    fclose(f);
+    return ok;
+}
+
+static bool save_text_to_disk(const char *fileName, char *text) {
+    ensure_parent_dir(fileName);
+    FILE *f = fopen(fileName, "wt");
+    if (!f) return false;
+    bool ok = (fputs(text, f) >= 0);
+    fclose(f);
+    return ok;
+}
+
+// No-op: s_internal_data_path is set in main() before any asset_path() calls.
+void asset_path_init(void) {}
+
+void asset_path(const char *subpath, char *out, size_t out_size) {
+    snprintf(out, out_size, "%s/%s", s_internal_data_path, subpath);
+}
+
+void asset_write_path(const char *subpath, char *out, size_t out_size) {
+    snprintf(out, out_size, "%s/%s", s_internal_data_path, subpath);
+    // Create the parent directory so callers can write without a separate mkdir.
+    char tmp[MAX_PATH_LEN];
+    snprintf(tmp, sizeof(tmp), "%s", out);
+    char *last_slash = strrchr(tmp, '/');
+    if (last_slash) { *last_slash = '\0'; mkdir(tmp, 0755); }
+}
+
+// Patch GLSL source from desktop (#version 330) to OpenGL ES (#version 300 es).
+// Fragment shaders also get a precision qualifier injected after the version line.
+// Returns a malloc'd buffer the caller must free; src_len bytes are consumed.
+static char *patch_glsl(const char *filename, const char *src, size_t src_len, size_t *out_len) {
+    size_t fn_len = strlen(filename);
+    int is_fs = (fn_len >= 3 && strcmp(filename + fn_len - 3, ".fs") == 0);
+
+    const char *old_ver  = "#version 330";
+    const char *new_ver  = "#version 300 es";
+    size_t old_len  = strlen(old_ver);
+    // src is NOT NUL-terminated (raw APK asset bytes) — use memmem, not strstr.
+    const char *pos = memmem(src, src_len, old_ver, old_len);
+    if (!pos) {
+        char *copy = malloc(src_len + 1);
+        if (!copy) return NULL;
+        memcpy(copy, src, src_len);
+        copy[src_len] = '\0';
+        *out_len = src_len;
+        return copy;
+    }
 
     const char *precision = "\nprecision mediump float;";
-    size_t old_len  = strlen(old_ver);
     size_t new_len  = strlen(new_ver);
     size_t prec_len = is_fs ? strlen(precision) : 0;
-    size_t src_len  = (size_t)size;
-    size_t out_len  = src_len - old_len + new_len + prec_len + 1;
+    size_t total    = src_len - old_len + new_len + prec_len;
 
-    char  *out    = (char *)MemAlloc((unsigned int)out_len);
-    if (!out) { MemFree(src); return NULL; }
+    char *out = malloc(total + 1);
+    if (!out) return NULL;
     size_t prefix = (size_t)(pos - src);
     memcpy(out, src, prefix);
     memcpy(out + prefix, new_ver, new_len);
     if (is_fs) memcpy(out + prefix + new_len, precision, prec_len);
-    memcpy(out + prefix + new_len + prec_len, pos + old_len, src_len - prefix - old_len + 1);
-
-    MemFree(src);
+    memcpy(out + prefix + new_len + prec_len, pos + old_len, src_len - prefix - old_len);
+    out[total] = '\0';
+    *out_len = total;
     return out;
+}
+
+static int write_file(const char *path, const void *data, size_t len) {
+    FILE *f = fopen(path, "wb");
+    if (!f) {
+        __android_log_print(ANDROID_LOG_ERROR, "Hawkeye", "extract: failed to write %s: %s", path, strerror(errno));
+        return 0;
+    }
+    size_t written = fwrite(data, 1, len, f);
+    fclose(f);
+    if (written != len) {
+        __android_log_print(ANDROID_LOG_ERROR, "Hawkeye", "extract: short write %s: %zu of %zu bytes", path, written, len);
+        return 0;
+    }
+    return 1;
+}
+
+// Copy APK assets to internalDataPath so fopen() can read them directly.
+// When force=false, skips files that already exist (only-if-missing policy).
+// When force=true, overwrites existing files (used after a version bump).
+// Shader files are GLSL-patched for OpenGL ES during the write.
+// Returns 1 if all files were written successfully, 0 if any file failed.
+static int extract_assets(AAssetManager *mgr, const char *dst_root, int force) {
+    static const char *dirs[] = { "fonts", "models", "shaders", "themes" };
+    int ok = 1;
+
+    for (int d = 0; d < (int)(sizeof(dirs) / sizeof(dirs[0])); d++) {
+        char subdir[MAX_PATH_LEN];
+        snprintf(subdir, sizeof(subdir), "%s/%s", dst_root, dirs[d]);
+        mkdir(subdir, 0755);
+
+        AAssetDir *dir = AAssetManager_openDir(mgr, dirs[d]);
+        if (!dir) continue;
+
+        const char *fname;
+        while ((fname = AAssetDir_getNextFileName(dir)) != NULL) {
+            char dest[MAX_PATH_LEN];
+            snprintf(dest, sizeof(dest), "%s/%s", subdir, fname);
+
+            struct stat st;
+            if (!force && stat(dest, &st) == 0) continue;
+
+            char rel[MAX_PATH_LEN];
+            snprintf(rel, sizeof(rel), "%s/%s", dirs[d], fname);
+
+            AAsset *asset = AAssetManager_open(mgr, rel, AASSET_MODE_BUFFER);
+            if (!asset) {
+                __android_log_print(ANDROID_LOG_ERROR, "Hawkeye", "extract: AAssetManager_open failed for %s", rel);
+                ok = 0;
+                continue;
+            }
+
+            const void *buf = AAsset_getBuffer(asset);
+            off_t len       = AAsset_getLength(asset);
+
+            if (!buf || len <= 0) {
+                __android_log_print(ANDROID_LOG_ERROR, "Hawkeye",
+                    "extract: AAsset_getBuffer NULL for %s (compressed?)", rel);
+                ok = 0;
+                AAsset_close(asset);
+                continue;
+            }
+
+            {
+                size_t fn_len = strlen(fname);
+                int is_shader = fn_len >= 3 &&
+                    (strcmp(fname + fn_len - 3, ".vs") == 0 ||
+                     strcmp(fname + fn_len - 3, ".fs") == 0);
+
+                if (is_shader) {
+                    size_t patched_len;
+                    char *patched = patch_glsl(fname, (const char *)buf, (size_t)len, &patched_len);
+                    if (patched) {
+                        if (!write_file(dest, patched, patched_len)) ok = 0;
+                        free(patched);
+                    } else {
+                        __android_log_print(ANDROID_LOG_ERROR, "Hawkeye", "extract: patch_glsl failed for %s", rel);
+                        ok = 0;
+                    }
+                } else {
+                    int primary_ok = write_file(dest, buf, (size_t)len);
+                    if (!primary_ok) ok = 0;
+                    // tinyobj opens MTL files by bare filename via android_fopen, whose fallback
+                    // constructs internalDataPath/<basename>. Mirror MTL files to the root so
+                    // that path resolves without any fopen wrapping.
+                    if (primary_ok && fn_len >= 5 && strcmp(fname + fn_len - 4, ".mtl") == 0) {
+                        char flat[MAX_PATH_LEN];
+                        snprintf(flat, sizeof(flat), "%s/%s", dst_root, fname);
+                        struct stat flat_st;
+                        if (force || stat(flat, &flat_st) != 0)
+                            if (!write_file(flat, buf, (size_t)len)) ok = 0;
+                    }
+                }
+            }
+
+            AAsset_close(asset);
+        }
+
+        AAssetDir_close(dir);
+    }
+    return ok;
+}
+
+static void handle_touch(Camera3D *cam, Vector3 *orbit_target,
+                          int *prev_count, Vector2 *prev_touch,
+                          float *prev_pinch_dist, Vector2 *prev_mid) {
+    int count = GetTouchPointCount();
+
+    // On finger count change: reset prev values to current to avoid a jump.
+    if (count != *prev_count) {
+        if (count >= 1) *prev_touch = GetTouchPosition(0);
+        if (count >= 2) {
+            Vector2 t0 = GetTouchPosition(0);
+            Vector2 t1 = GetTouchPosition(1);
+            *prev_pinch_dist = Vector2Distance(t0, t1);
+            *prev_mid = (Vector2){ (t0.x + t1.x) * 0.5f, (t0.y + t1.y) * 0.5f };
+        }
+        *prev_count = count;
+        return;
+    }
+
+    if (count == 1) {
+        Vector2 touch = GetTouchPosition(0);
+        Vector2 delta = { touch.x - prev_touch->x, touch.y - prev_touch->y };
+        *prev_touch = touch;
+
+        Vector3 offset = Vector3Subtract(cam->position, *orbit_target);
+        float r = Vector3Length(offset);
+        if (r < 0.001f) return;
+
+        // Yaw: rotate offset around world Y
+        Matrix yaw = MatrixRotate((Vector3){0, 1, 0}, -delta.x * TOUCH_ORBIT_SENSITIVITY);
+        offset = Vector3Transform(offset, yaw);
+
+        // Pitch: rotate offset around camera right axis
+        Vector3 forward = Vector3Normalize(Vector3Negate(offset));
+        Vector3 right   = Vector3Normalize(Vector3CrossProduct(forward, (Vector3){0, 1, 0}));
+        Matrix  pitch_m = MatrixRotate(right, -delta.y * TOUCH_ORBIT_SENSITIVITY);
+        offset = Vector3Transform(offset, pitch_m);
+
+        // Clamp elevation to ±89° to prevent gimbal flip
+        float len = Vector3Length(offset);
+        if (len < 0.001f) return;
+        float elevation = asinf(Clamp(offset.y / len, -1.0f, 1.0f));
+        float max_elev  = 89.0f * DEG2RAD;
+        if (elevation > max_elev || elevation < -max_elev) {
+            float azimuth = atan2f(offset.x, offset.z);
+            elevation = Clamp(elevation, -max_elev, max_elev);
+            offset.x  = len * cosf(elevation) * sinf(azimuth);
+            offset.y  = len * sinf(elevation);
+            offset.z  = len * cosf(elevation) * cosf(azimuth);
+        }
+
+        cam->position = Vector3Add(*orbit_target, Vector3Scale(Vector3Normalize(offset), r));
+        cam->target   = *orbit_target;
+        cam->up       = (Vector3){0, 1, 0};
+    } else if (count == 2) {
+        cam->up = (Vector3){0, 1, 0};
+
+        Vector2 t0  = GetTouchPosition(0);
+        Vector2 t1  = GetTouchPosition(1);
+        Vector2 mid = { (t0.x + t1.x) * 0.5f, (t0.y + t1.y) * 0.5f };
+        float   dist = Vector2Distance(t0, t1);
+
+        // Zoom: scale orbit radius proportionally so speed feels consistent at any distance
+        float   dist_delta = dist - *prev_pinch_dist;
+        Vector3 offset     = Vector3Subtract(cam->position, *orbit_target);
+        float   r          = Vector3Length(offset);
+        r *= (1.0f - dist_delta * TOUCH_ZOOM_SENSITIVITY);
+        if (r < TOUCH_MIN_ORBIT_DIST) r = TOUCH_MIN_ORBIT_DIST;
+        if (r > TOUCH_MAX_ORBIT_DIST) r = TOUCH_MAX_ORBIT_DIST;
+        if (r > 0.001f)
+            cam->position = Vector3Add(*orbit_target,
+                                       Vector3Scale(Vector3Normalize(offset), r));
+
+        // Pan: translate orbit_target along camera right and up
+        Vector2 mid_delta = { mid.x - prev_mid->x, mid.y - prev_mid->y };
+        float   pan_sens  = r * TOUCH_PAN_SENSITIVITY;
+        Vector3 forward   = Vector3Normalize(Vector3Subtract(cam->target, cam->position));
+        Vector3 right     = Vector3Normalize(Vector3CrossProduct(forward, cam->up));
+        Vector3 pan       = Vector3Add(
+            Vector3Scale(right,    -mid_delta.x * pan_sens),
+            Vector3Scale(cam->up,   mid_delta.y * pan_sens)
+        );
+        *orbit_target = Vector3Add(*orbit_target, pan);
+        cam->position = Vector3Add(cam->position, pan);
+        cam->target   = *orbit_target;
+
+        *prev_pinch_dist = dist;
+        *prev_mid        = mid;
+        *prev_touch      = GetTouchPosition(0);
+    }
 }
 
 // Raylib's rcore_android.c owns android_main and calls user main() after platform setup.
@@ -56,9 +362,29 @@ int main(int argc, char *argv[]) {
     (void)argc; (void)argv;
     // 0, 0 = use the device's native screen resolution (fullscreen)
     InitWindow(0, 0, "Hawkeye");
-    // Register after InitWindow so GetAndroidApp() is valid (platform is initialized).
-    SetLoadFileTextCallback(patch_shader_source);
+    struct android_app *android_app = GetAndroidApp();
+    snprintf(s_internal_data_path, sizeof(s_internal_data_path),
+             "%s", android_app->activity->internalDataPath);
+    char sentinel[MAX_PATH_LEN];
+    snprintf(sentinel, sizeof(sentinel), "%s/.hawkeye_assets_v%s",
+             s_internal_data_path, HAWKEYE_ASSET_VERSION);
+    struct stat sentinel_st;
+    int needs_extract = (stat(sentinel, &sentinel_st) != 0); /* force-overwrite when no sentinel */
+    int extract_ok = extract_assets(android_app->activity->assetManager, s_internal_data_path, needs_extract);
+    if (needs_extract && extract_ok) {
+        FILE *sf = fopen(sentinel, "wb");
+        if (sf) fclose(sf);
+    }
+    SetLoadFileTextCallback(read_text_from_disk);
+    SetLoadFileDataCallback(read_data_from_disk);
+    SetSaveFileDataCallback(save_data_to_disk);
+    SetSaveFileTextCallback(save_text_to_disk);
+
+    orig_input_handler = android_app->onInputEvent;
+    android_app->onInputEvent = input_handler;
     SetTargetFPS(60);
+
+    SetGesturesEnabled(GESTURE_DRAG | GESTURE_PINCH_IN | GESTURE_PINCH_OUT);
 
     scene_t scene = {0};
     scene_init(&scene);
@@ -69,7 +395,21 @@ int main(int argc, char *argv[]) {
     // Position vehicle slightly above origin so it's visible with the default camera
     vehicle.position = (Vector3){ 0.0f, 0.5f, 0.0f };
 
+    scene.cam_mode   = CAM_MODE_FREE;
+    scene.free_track = true;
+
+    Vector3 orbit_target    = vehicle.position;
+    Vector2 prev_touch      = {0};
+    float   prev_pinch_dist = 0.0f;
+    Vector2 prev_mid        = {0};
+    int     prev_count      = 0;
+
+    scene.camera.target = orbit_target;
+
     while (!WindowShouldClose()) {
+        handle_touch(&scene.camera, &orbit_target,
+                     &prev_count, &prev_touch,
+                     &prev_pinch_dist, &prev_mid);
         BeginDrawing();
             scene_draw_sky(&scene);
             BeginMode3D(scene.camera);
@@ -87,6 +427,10 @@ int main(int argc, char *argv[]) {
     vehicle_cleanup(&vehicle);
     scene_cleanup(&scene);
     SetLoadFileTextCallback(NULL);
+    SetLoadFileDataCallback(NULL);
+    SetSaveFileDataCallback(NULL);
+    SetSaveFileTextCallback(NULL);
+    android_app->onInputEvent = orig_input_handler;
     CloseWindow();
     return 0;
 }

--- a/src/asset_path.h
+++ b/src/asset_path.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+// Maximum length for any asset path (including null terminator).
+#define ASSET_MAX_PATH 512
+
 // Initialize asset path resolution. Call once at startup.
 void asset_path_init(void);
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -1,4 +1,5 @@
 #include "theme.h"
+#include "asset_path.h"
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -470,10 +471,14 @@ void theme_registry_init(theme_registry_t *reg) {
     reg->cyclable = 1;
     reg->user_count = 0;
 
-    // Scan ./themes/ for .mvt files (includes shipped Rez, Snow, and user themes)
+    // Scan themes/ for .mvt files (includes shipped Rez, Snow, and user themes)
+    char themes_dir[ASSET_MAX_PATH];
+    asset_path("themes", themes_dir, sizeof(themes_dir));
 #ifdef _WIN32
+    char themes_pattern[ASSET_MAX_PATH];
+    snprintf(themes_pattern, sizeof(themes_pattern), "%s\\*.mvt", themes_dir);
     WIN32_FIND_DATAA fd;
-    HANDLE hFind = FindFirstFileA("./themes/*.mvt", &fd);
+    HANDLE hFind = FindFirstFileA(themes_pattern, &fd);
     if (hFind == INVALID_HANDLE_VALUE) {
         printf("Loaded %d themes (1 built-in + 0 from themes/)\n", reg->count);
         return;
@@ -482,7 +487,7 @@ void theme_registry_init(theme_registry_t *reg) {
         if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
         const char *name = fd.cFileName;
 #else
-    DIR *dir = opendir("./themes");
+    DIR *dir = opendir(themes_dir);
     if (!dir) {
         printf("Loaded %d themes (1 built-in + 0 from themes/)\n", reg->count);
         return;
@@ -494,8 +499,8 @@ void theme_registry_init(theme_registry_t *reg) {
         int nlen = (int)strlen(name);
         if (nlen < 5 || strcmp(name + nlen - 4, ".mvt") != 0) continue;
 
-        char filepath[512];
-        snprintf(filepath, sizeof(filepath), "./themes/%s", name);
+        char filepath[ASSET_MAX_PATH + 256]; /* themes_dir + '/' + filename (≤255) + NUL */
+        snprintf(filepath, sizeof(filepath), "%s/%s", themes_dir, name);
 
         int idx = reg->user_count;
         int priority = 0;

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -97,18 +97,25 @@ static int parse_mtl_names(const char *obj_path, mtl_entry_t *entries, int max_e
         return 0;
     }
 
-    FILE *fp = fopen(mtl_path, "r");
-    if (!fp) return 0;
+    // LoadFileText routes through SetLoadFileTextCallback on Android (AAssetManager),
+    // so this works both on desktop (direct file read) and inside an APK.
+    char *text = LoadFileText(mtl_path);
+    if (!text) return 0;
 
     int count = 0;
     char current_name[64] = {0};
     char line[256];
+    const char *p = text;
 
-    while (fgets(line, sizeof(line), fp) && count < max_entries) {
-        // Strip newline
-        int ll = (int)strlen(line);
-        while (ll > 0 && (line[ll-1] == '\n' || line[ll-1] == '\r'))
-            line[--ll] = '\0';
+    while (*p && count < max_entries) {
+        // Collect one line
+        int ll = 0;
+        while (*p && *p != '\n' && ll < (int)sizeof(line) - 1)
+            line[ll++] = *p++;
+        if (*p == '\n') p++;
+        while (ll > 0 && (line[ll-1] == '\r' || line[ll-1] == ' '))
+            ll--;
+        line[ll] = '\0';
 
         if (strncmp(line, "newmtl ", 7) == 0) {
             snprintf(current_name, sizeof(current_name), "%s", line + 7);
@@ -130,7 +137,7 @@ static int parse_mtl_names(const char *obj_path, mtl_entry_t *entries, int max_e
         }
     }
 
-    fclose(fp);
+    UnloadFileText(text);
     return count;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ add_test(NAME obj_models COMMAND test_obj_models)
 
 # Theme parser + trail LOD tests (need raylib headers for Color/Vector3)
 if(TARGET raylib)
-    add_executable(test_theme test_theme.c ${CMAKE_SOURCE_DIR}/src/theme.c)
+    add_executable(test_theme test_theme.c ${CMAKE_SOURCE_DIR}/src/theme.c ${CMAKE_SOURCE_DIR}/src/asset_path.c)
     target_include_directories(test_theme PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_link_libraries(test_theme PRIVATE raylib)
     target_compile_definitions(test_theme PRIVATE FIXTURES_DIR="${FIXTURES_DIR}")

--- a/tests/test_theme.c
+++ b/tests/test_theme.c
@@ -7,6 +7,7 @@
  */
 
 #include "theme.h"
+#include "asset_path.h"
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
@@ -257,6 +258,7 @@ static void test_trail_lod_midpoint_averaging(void)
 
 int main(void)
 {
+    asset_path_init();
     printf("test_theme:\n");
 
     /* Theme parser */


### PR DESCRIPTION
## Summary

This PR adds gesture-based camera controls to the Android NativeActivity renderer and replaces the MTL/shader workaround machinery with a clean asset extraction pipeline.

### Touch controls (original feature)
- 1-finger drag: orbit camera around target
- 2-finger pinch: zoom (multiplicative, clamped)
- 2-finger drag: pan camera target

### Asset extraction pipeline (replaces `__wrap_fopen` workarounds)
- On first launch, all APK assets (fonts, models, shaders, themes) are extracted to `internalDataPath` so standard `fopen` works everywhere
- Shader GLSL patching (`#version 330` → `#version 300 es`, `precision mediump float`) moved from load-time callbacks to extraction-time — patched files written to disk once
- MTL files are mirrored to `internalDataPath/<basename>.mtl` so tinyobj's bare-filename `fopen` resolves via Raylib's `android_fopen` fallback
- Removed `__wrap_fopen`, `-Wl,--wrap,fopen`, and all in-memory MTL cache machinery
- Version sentinel (`.hawkeye_assets_v2`) controls re-extraction; bumped forces clean re-extract after pipeline changes

### Test / build fixes
- `test_theme` now links `asset_path.c` and calls `asset_path_init()` so the theme registry works in test context
- `src/theme.c` filepath buffer sized to `ASSET_MAX_PATH + 256` to silence `-Wformat-truncation`
- `ASSET_MAX_PATH 512` defined in `asset_path.h` and shared across files