### PR TITLE
feat: inject MAVLink diagnostic overlay and volatile render bypass

### DIFF
--- a/src/mavlink_receiver.c
+++ b/src/mavlink_receiver.c
@@ -22,6 +22,8 @@
 // MAVLink config: use common message set
 // MAVLINK_COMM_NUM_BUFFERS=16 set via CMake for multi-vehicle support
 #include <mavlink.h>
+#include <stdbool.h>
+volatile bool g_resonance_anomaly = false;
 
 #define DISCONNECT_TIMEOUT_S 2.0
 
@@ -137,6 +139,16 @@ void mavlink_receiver_poll(mavlink_receiver_t *recv) {
                 }
 
                 switch (msg.msgid) {
+        case MAVLINK_MSG_ID_NAMED_VALUE_FLOAT: {
+            mavlink_named_value_float_t val;
+            mavlink_msg_named_value_float_decode(&msg, &val);
+            if (strncmp(val.name, "resonance", 9) == 0) {
+                printf("\n[!!!] ANOMALY METRIC: %f [!!!]\n", val.value);
+                fflush(stdout);
+                g_resonance_anomaly = (val.value > 0.5f);
+            }
+            break;
+        }
                     case MAVLINK_MSG_ID_HEARTBEAT: {
                         mavlink_heartbeat_t hb;
                         mavlink_msg_heartbeat_decode(&msg, &hb);

--- a/src/vehicle.c
+++ b/src/vehicle.c
@@ -730,6 +730,8 @@ void vehicle_draw(vehicle_t *v, const theme_t *theme, bool selected,
             }
         }
 
+        extern volatile bool g_resonance_anomaly;
+        if (g_resonance_anomaly) mat.maps[MATERIAL_MAP_DIFFUSE].color = RED;
         DrawMesh(v->model.meshes[mi], mat, v->model.transform);
     }
     if (v->ghost_alpha < 1.0f) rlEnableDepthMask();


### PR DESCRIPTION
Implemented a live diagnostics overlay for anomaly detection.

Receiver Hook: Included handling for MAVLINK_MSG_ID_NAMED_VALUE_FLOAT to provide visual feedback through edge compute payloads.

Memory Safety: Defined the trigger as volatile to ensure that the Render Thread sees the changes in the trigger made by the MAVLink thread instantly (no CPU register caching).

Visual Indicator: The model flashes in RED if there is a 'resonance' anomaly.

See the attached Shot demo of the system in action using a 10Hz Python-based MAVLink stream.
<img width="1783" height="743" alt="new detection" src="https://github.com/user-attachments/assets/fbdbf24a-b737-4c2b-954f-3d8fb84b856b" />
