### PR TITLE
[Android] Reuse desktop HUD and bump scale for mobile readability

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -30,6 +30,20 @@ add_library(hawkeye SHARED
     ${HAWKEYE_SRC}/ulog_parser.c
     ${HAWKEYE_SRC}/ulog_replay.c
     ${HAWKEYE_SRC}/ulog_replay_apply.c
+
+    # HUD subsystem — shared with desktop and WASM builds. Mirrors wasm/CMakeLists.txt.
+    ${HAWKEYE_SRC}/hud.c
+    ${HAWKEYE_SRC}/hud_help.c
+    ${HAWKEYE_SRC}/hud_instruments.c
+    ${HAWKEYE_SRC}/hud_transport.c
+    ${HAWKEYE_SRC}/hud_telemetry.c
+    ${HAWKEYE_SRC}/hud_annunciators.c
+    ${HAWKEYE_SRC}/tactical_hud.c
+    ${HAWKEYE_SRC}/debug_panel.c
+    ${HAWKEYE_SRC}/replay_trail.c
+    ${HAWKEYE_SRC}/replay_markers.c
+    ${HAWKEYE_SRC}/replay_conflict.c
+    ${HAWKEYE_SRC}/ui_marker_input.c
 )
 
 target_include_directories(hawkeye PRIVATE

--- a/android/app/src/main/cpp/android_main.c
+++ b/android/app/src/main/cpp/android_main.c
@@ -493,6 +493,9 @@ int main(int argc, char *argv[]) {
     vehicle_init(&vehicle, MODEL_QUADROTOR, scene.lighting_shader);
 
     hud_init(&g_hud);
+    // Bump HUD scale on mobile so values/labels meet M3 readability floors
+    // (~42 px body, ~33 px label at this DPI). Desktop/WASM leave this at 1.0.
+    g_hud.scale_mul = 1.5f;
 
     // Position vehicle slightly above origin so it's visible with the default camera
     vehicle.position = (Vector3){ 0.0f, 0.5f, 0.0f };

--- a/android/app/src/main/cpp/android_main.c
+++ b/android/app/src/main/cpp/android_main.c
@@ -4,6 +4,7 @@
 #include "scene.h"
 #include "vehicle.h"
 #include "data_source.h"
+#include "hud.h"
 #include <android/asset_manager.h>
 #include <android/input.h>
 #include <android/keycodes.h>
@@ -366,6 +367,7 @@ static void handle_touch(Camera3D *cam, Vector3 *orbit_target,
 static data_source_t g_ds;
 static bool          g_ds_active = false;
 static long long     g_last_ready_token = 0;
+static hud_t         g_hud;
 // Initialized to a large negative value so the first poll always proceeds.
 static double        g_last_poll_time = -1e9;
 
@@ -490,6 +492,8 @@ int main(int argc, char *argv[]) {
     vehicle_t vehicle = {0};
     vehicle_init(&vehicle, MODEL_QUADROTOR, scene.lighting_shader);
 
+    hud_init(&g_hud);
+
     // Position vehicle slightly above origin so it's visible with the default camera
     vehicle.position = (Vector3){ 0.0f, 0.5f, 0.0f };
 
@@ -531,6 +535,12 @@ int main(int argc, char *argv[]) {
         handle_touch(&scene.camera, &orbit_target,
                      &prev_count, &prev_touch,
                      &prev_pinch_dist, &prev_mid);
+
+        hud_update(&g_hud,
+                   g_ds_active ? g_ds.state.time_usec : 0,
+                   g_ds_active ? g_ds.connected : false,
+                   GetFrameTime());
+
         BeginDrawing();
             scene_draw_sky(&scene);
             BeginMode3D(scene.camera);
@@ -542,6 +552,23 @@ int main(int argc, char *argv[]) {
                              /*cam_pos=*/scene.camera.position,
                              /*classic_colors=*/false);
             EndMode3D();
+
+            // HUD overlay. When no .ulg is loaded, hand hud_draw a zeroed
+            // data_source so the status row reads "Waiting…" without crashing.
+            {
+                data_source_t empty_src = {0};
+                const data_source_t *src_ptr = g_ds_active ? &g_ds : &empty_src;
+                hud_marker_data_t user_md = {0};
+                hud_marker_data_t sys_md  = {0};
+                bool has_awaiting_gps = g_ds_active && !vehicle.origin_set && g_ds.home.valid;
+                if (g_hud.mode == HUD_CONSOLE) {
+                    hud_draw(&g_hud, &vehicle, src_ptr, /*vehicle_count=*/1, /*selected=*/0,
+                             GetScreenWidth(), GetScreenHeight(),
+                             scene.theme, /*trail_mode=*/g_ds_active ? 1 : 0,
+                             &user_md, &sys_md, /*marker_vehicle_count=*/1,
+                             /*ghost_mode=*/false, /*has_tier3=*/false, has_awaiting_gps);
+                }
+            }
         EndDrawing();
     }
 
@@ -549,6 +576,7 @@ int main(int argc, char *argv[]) {
         data_source_close(&g_ds);
         g_ds_active = false;
     }
+    hud_cleanup(&g_hud);
     vehicle_cleanup(&vehicle);
     scene_cleanup(&scene);
     SetLoadFileTextCallback(NULL);

--- a/src/hud.c
+++ b/src/hud.c
@@ -27,6 +27,7 @@
 void hud_init(hud_t *h) {
     memset(h, 0, sizeof(*h));
     h->show_help = false;
+    h->scale_mul = 1.0f;
     for (int i = 0; i < HUD_MAX_PINNED; i++)
         h->pinned[i] = -1;
 
@@ -328,6 +329,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
     // Scale factor: 1.0 at 720p, ~1.33 at 1080p, ~1.6 at 1440p
     float s = powf(screen_h / 720.0f, 0.7f);
     if (s < 1.0f) s = 1.0f;
+    if (h->scale_mul > 0.0f) s *= h->scale_mul;
 
     // Scaled font sizes
     float fs_label = fmaxf(16 * s, 10.0f);
@@ -590,6 +592,7 @@ void hud_draw(const hud_t *h, const vehicle_t *vehicles,
 int hud_bar_height(const hud_t *h, int screen_h) {
     float s = powf(screen_h / 720.0f, 0.7f);
     if (s < 1.0f) s = 1.0f;
+    if (h->scale_mul > 0.0f) s *= h->scale_mul;
     int primary_h = (int)(120 * s);
     int secondary_h = (int)(38 * s);
     int transport_h = h->is_replay ? (int)(28 * s) : 0;

--- a/src/hud.h
+++ b/src/hud.h
@@ -42,6 +42,11 @@ typedef struct {
     Font font_value;    // JetBrains Mono for telemetry numbers
     Font font_label;    // Inter for labels and status text
 
+    // Extra multiplier on top of the screen-height-derived scale. 1.0 on
+    // desktop/WASM; mobile bumps this so labels/values meet M3 readability
+    // floors at typical phone hold distance.
+    float scale_mul;
+
     // Toast notification (fades in/out above timeline)
     char toast_text[64];
     float toast_timer;  // seconds remaining (0 = hidden)


### PR DESCRIPTION
## Summary
- Pulls the full HUD subsystem (`hud.c`, `hud_help`, `hud_instruments`, `hud_transport`, `hud_telemetry`, `hud_annunciators`, `tactical_hud`, `debug_panel`, `replay_trail/markers/conflict`, `ui_marker_input`) into the Android NDK build, mirroring the WASM target. `hud_init` / `hud_update` / `hud_draw` / `hud_cleanup` are wired into `android_main.c` so the bottom telemetry bar (HDG, ROLL, PITCH, ALT, GS, AS, VS), compass, ADI, transport timeline, and sim timer render under both empty-state and ULog-replay states.
- Adds `hud_t::scale_mul` (default 1.0 on desktop/WASM) and sets it to `1.5f` on Android so values/labels meet M3 readability floors (~46 px values, ~32 px labels at 1080 short-side) at typical phone hold distance.


<img width="2499" height="1183" alt="Screenshot_20260520_141301" src="https://github.com/user-attachments/assets/8cc4162d-8d4b-4bc0-8a17-f93a982a15b7" />

