### PR TITLE
fix(input): gate auto-align toggle behind Shift+A

### DIFF
--- a/src/hud_help.c
+++ b/src/hud_help.c
@@ -70,7 +70,7 @@ void hud_draw_help(Font font_value, Font font_label,
         {"Sh+B",        "Delete current marker"},
         {"[ / ]",       "Jump to prev/next marker"},
         {"Sh+[ / ]",    "Track from marker"},
-        {"A",           "Takeoff alignment"},
+        {"Sh+A",        "Takeoff alignment"},
     };
 
     int counts[3] = {

--- a/src/main.c
+++ b/src/main.c
@@ -281,7 +281,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    // ── Takeoff alignment state (toggled by A key) ──
+    // ── Takeoff alignment state (toggled by Shift+A) ──
     bool takeoff_aligned = false;
     if (is_replay && num_replay_files > 1) {
         // Set multi-file CONF for each source (always available)
@@ -1049,8 +1049,9 @@ int main(int argc, char *argv[]) {
                     markers[i].current = -1;
                 }
             }
-            // A key: toggle takeoff time alignment
-            if (IsKeyPressed(KEY_A) && num_replay_files > 1) {
+            // Shift+A: toggle takeoff time alignment (bare A is camera strafe)
+            bool shift_held = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
+            if (shift_held && IsKeyPressed(KEY_A) && num_replay_files > 1) {
                 takeoff_aligned = !takeoff_aligned;
                 const float takeoff_buffer = 5.0f;
                 for (int i = 0; i < nrf; i++) {

--- a/wasm/wasm_main.c
+++ b/wasm/wasm_main.c
@@ -950,8 +950,9 @@ static void frame(void *arg) {
             }
         }
 
-        // A takeoff alignment (main.c:1053)
-        if (IsKeyPressed(KEY_A) && g.vehicle_count > 1) {
+        // Shift+A takeoff alignment (main.c:1054)
+        bool shift_held = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
+        if (shift_held && IsKeyPressed(KEY_A) && g.vehicle_count > 1) {
             g.takeoff_aligned = !g.takeoff_aligned;
             const float takeoff_buffer = 5.0f;
             for (int i = 0; i < nrf; i++) {


### PR DESCRIPTION
## What
Auto-align is now toggled with **Shift+A** instead of bare `A`, on both the desktop and web frontends.

## Why
Bare `A` collided with the WASDEQ camera-left strafe — every camera-left touch flipped takeoff auto-align on/off. Gating the toggle on Shift frees bare `A` to strafe only.

## Changes
- `src/main.c` — Shift gate on the auto-align toggle
- `src/hud_help.c` — legend updated to `Sh+A → Takeoff alignment`
- `wasm/wasm_main.c` — same gate on the web frontend's mirrored handler

`wasm_main.c` keeps its own copy of the input handling (Emscripten drives a frame callback instead of a `while` loop), but it compiles `scene.c` and drives the camera through `scene_update_camera`, so bare `A` collided there identically. The help legend is shared source, so it needed no second edit.

## Test
- Bare `A` strafes camera left, does not toggle alignment
- Shift+A toggles auto-align (toast + timelines snap to lift-off-together)
- Verified on a 7-drone swarm replay
- WASM target builds clean (emscripten 5.0.6)
