### PR TITLE
Add long-press multi-select and batch delete to the replay library

### DIFF
--- a/android/app/src/androidTest/java/com/px4/hawkeye/android/ReplayLibrarySelectionTest.kt
+++ b/android/app/src/androidTest/java/com/px4/hawkeye/android/ReplayLibrarySelectionTest.kt
@@ -1,0 +1,177 @@
+package com.px4.hawkeye.android
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.Espresso
+import com.px4.hawkeye.core.designsystem.HawkeyeTheme
+import com.px4.hawkeye.feature.replay.presentation.LibraryEntryUi
+import com.px4.hawkeye.feature.replay.presentation.ReplayLibraryAction
+import com.px4.hawkeye.feature.replay.presentation.ReplayLibraryScreen
+import com.px4.hawkeye.feature.replay.presentation.ReplayLibraryState
+import com.px4.hawkeye.feature.replay.presentation.ReplayLibraryTestTags
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Drives [ReplayLibraryScreen] directly with injected state and a capturing `onAction`, so the
+ * new selection flows (tap-and-hold to select, the selection-bar delete action, and the
+ * batch-delete confirmation) are verified without a device DB or the renderer.
+ */
+class ReplayLibrarySelectionTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val robot by lazy { ReplayLibraryRobot(composeRule) }
+
+    @Test
+    fun longPressingARow_emitsOnEntryLongClicked() {
+        robot
+            .setContent(browseState())
+            .assertRowVisible(FIRST)
+            .longPressRow(FIRST)
+            .assertEmitted(ReplayLibraryAction.OnEntryLongClicked("1"))
+    }
+
+    @Test
+    fun selectionMode_showsDeleteAction_andEmitsClick() {
+        robot
+            .setContent(selectionState(selectedIds = listOf("1")))
+            .clickDeleteAction()
+            .assertEmitted(ReplayLibraryAction.OnDeleteSelectedClicked)
+    }
+
+    @Test
+    fun deleteAction_isDisabled_whenNothingSelected() {
+        robot
+            .setContent(selectionState(selectedIds = emptyList()))
+            .assertDeleteActionDisabled()
+    }
+
+    @Test
+    fun confirmationDialog_confirm_emitsOnConfirmDelete() {
+        robot
+            .setContent(selectionState(selectedIds = listOf("1"), showDeleteDialog = true))
+            .assertTitleDisplayed("Delete 1 log?")
+            .confirmDelete()
+            .assertEmitted(ReplayLibraryAction.OnConfirmDelete)
+    }
+
+    @Test
+    fun confirmationDialog_cancel_emitsOnDismissDelete() {
+        robot
+            .setContent(selectionState(selectedIds = listOf("1"), showDeleteDialog = true))
+            .cancelDelete()
+            .assertEmitted(ReplayLibraryAction.OnDismissDelete)
+    }
+
+    @Test
+    fun confirmationDialog_usesPluralTitle_forMultipleSelection() {
+        robot
+            .setContent(selectionState(selectedIds = listOf("1", "2"), showDeleteDialog = true))
+            .assertTitleDisplayed("Delete 2 logs?")
+    }
+
+    // The AlertDialog owns its own back handling, so system back while it is open must dismiss
+    // the dialog (OnDismissDelete) rather than fall through to the screen's selection-mode
+    // BackHandler (OnToggleSelectionMode) and wipe the selection.
+    @Test
+    fun systemBack_whileDialogOpen_dismissesDialog_notSelectionMode() {
+        robot
+            .setContent(selectionState(selectedIds = listOf("1"), showDeleteDialog = true))
+            .pressBack()
+            .assertEmitted(ReplayLibraryAction.OnDismissDelete)
+    }
+
+    private fun browseState() = ReplayLibraryState(
+        isLoading = false,
+        entries = ENTRIES,
+    )
+
+    private fun selectionState(
+        selectedIds: List<String>,
+        showDeleteDialog: Boolean = false,
+    ) = ReplayLibraryState(
+        isLoading = false,
+        entries = ENTRIES,
+        isSelectionMode = true,
+        selectedIds = selectedIds,
+        showDeleteDialog = showDeleteDialog,
+    )
+
+    private companion object {
+        const val FIRST = "flight_2026_05_28.ulg"
+        const val SECOND = "sitl_test.ulg"
+        val ENTRIES = listOf(
+            LibraryEntryUi("1", FIRST, "12.4 MB", "May 28, 2026"),
+            LibraryEntryUi("2", SECOND, "3.1 MB", "May 27, 2026"),
+        )
+    }
+}
+
+/** Encapsulates the Compose interactions for [ReplayLibraryScreen] (see the testing skill). */
+private class ReplayLibraryRobot(private val composeRule: ComposeContentTestRule) {
+
+    private val actions = mutableListOf<ReplayLibraryAction>()
+
+    fun setContent(state: ReplayLibraryState) = apply {
+        actions.clear()
+        composeRule.setContent {
+            HawkeyeTheme {
+                ReplayLibraryScreen(
+                    state = state,
+                    onAction = { actions += it },
+                    onBack = {},
+                )
+            }
+        }
+    }
+
+    fun longPressRow(name: String) = apply {
+        composeRule.onNodeWithText(name).performTouchInput { longClick() }
+    }
+
+    fun clickDeleteAction() = apply {
+        composeRule.onNodeWithTag(ReplayLibraryTestTags.DELETE_ACTION).performClick()
+    }
+
+    fun confirmDelete() = apply {
+        composeRule.onNodeWithTag(ReplayLibraryTestTags.DELETE_DIALOG_CONFIRM).performClick()
+    }
+
+    fun cancelDelete() = apply {
+        composeRule.onNodeWithTag(ReplayLibraryTestTags.DELETE_DIALOG_CANCEL).performClick()
+    }
+
+    fun pressBack() = apply {
+        composeRule.waitForIdle()
+        Espresso.pressBack()
+        composeRule.waitForIdle()
+    }
+
+    fun assertRowVisible(name: String) = apply {
+        composeRule.onNodeWithText(name).assertIsDisplayed()
+    }
+
+    fun assertDeleteActionDisabled() = apply {
+        composeRule.onNodeWithTag(ReplayLibraryTestTags.DELETE_ACTION).assertIsNotEnabled()
+    }
+
+    fun assertTitleDisplayed(title: String) = apply {
+        composeRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    // Strict: a single gesture must produce exactly one action (e.g. a long press must not
+    // also fire OnEntryClicked), so assert the whole captured list, not just membership.
+    fun assertEmitted(action: ReplayLibraryAction) = apply {
+        assertEquals(listOf(action), actions)
+    }
+}

--- a/android/core/domain/src/main/kotlin/com/px4/hawkeye/core/domain/ReplayLibraryRepository.kt
+++ b/android/core/domain/src/main/kotlin/com/px4/hawkeye/core/domain/ReplayLibraryRepository.kt
@@ -22,6 +22,13 @@ interface ReplayLibraryRepository {
     suspend fun delete(id: String): EmptyResult<DataError.Local>
 
     /**
+     * Removes the metadata rows and on-disk payloads for every id in [ids]. Resolves all ids
+     * first: a single unknown id fails the whole batch (returns [DataError.Local.NOT_FOUND])
+     * before anything is deleted, so a selection is never half-removed.
+     */
+    suspend fun deleteAll(ids: List<String>): EmptyResult<DataError.Local>
+
+    /**
      * Copies the library payloads for [ids] into the renderer's inbox (list order = drone
      * order for a multi-drone session) and bumps the sentinel so the native poll loop loads
      * them on the next launch.

--- a/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepository.kt
+++ b/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepository.kt
@@ -70,6 +70,22 @@ class RoomReplayLibraryRepository(
             }.getOrElse { Result.Error(it.toLocalError()) }
         }
 
+    override suspend fun deleteAll(ids: List<String>): EmptyResult<DataError.Local> =
+        withContext(ioDispatcher) {
+            runCatching {
+                // Resolve every id before touching the filesystem so an unknown id fails the
+                // whole batch instead of leaving a selection half-deleted.
+                val fileNames = ids.map { id -> dao.getById(id)?.fileName }
+                if (fileNames.isEmpty() || fileNames.any { it == null }) {
+                    Result.Error(DataError.Local.NOT_FOUND)
+                } else {
+                    fileNames.filterNotNull().forEach(fileManager::delete)
+                    dao.deleteByIds(ids)
+                    Result.Success(Unit)
+                }
+            }.getOrElse { Result.Error(it.toLocalError()) }
+        }
+
     override suspend fun stageForPlayback(ids: List<String>): EmptyResult<DataError.Local> =
         withContext(ioDispatcher) {
             runCatching {

--- a/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/db/ReplayLibraryDao.kt
+++ b/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/db/ReplayLibraryDao.kt
@@ -20,4 +20,7 @@ interface ReplayLibraryDao {
 
     @Query("DELETE FROM library_entries WHERE id = :id")
     suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM library_entries WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<String>)
 }

--- a/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/FakeReplayLibraryDao.kt
+++ b/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/FakeReplayLibraryDao.kt
@@ -26,4 +26,8 @@ class FakeReplayLibraryDao : ReplayLibraryDao {
     override suspend fun deleteById(id: String) {
         rows.value = rows.value.filterNot { it.id == id }
     }
+
+    override suspend fun deleteByIds(ids: List<String>) {
+        rows.value = rows.value.filterNot { it.id in ids }
+    }
 }

--- a/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepositoryTest.kt
+++ b/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepositoryTest.kt
@@ -103,6 +103,38 @@ class RoomReplayLibraryRepositoryTest {
     }
 
     @Test
+    fun `deleteAll removes every selected payload and row`() = runTest {
+        dao.seed(entity("a"), entity("b"), entity("c"))
+
+        val result = repository().deleteAll(listOf("a", "c"))
+
+        assertThat(result).isEqualTo(Result.Success(Unit))
+        assertThat(files.deletedFileNames).containsExactly("a.ulg", "c.ulg")
+        assertThat(dao.getById("a")).isNull()
+        assertThat(dao.getById("c")).isNull()
+        assertThat(dao.getById("b")).isNotNull()
+    }
+
+    @Test
+    fun `deleteAll fails with NOT_FOUND and deletes nothing when any id is unknown`() = runTest {
+        dao.seed(entity("a"))
+
+        val result = repository().deleteAll(listOf("a", "missing"))
+
+        assertThat(result).isEqualTo(Result.Error(DataError.Local.NOT_FOUND))
+        assertThat(files.deletedFileNames).isEqualTo(emptyList())
+        assertThat(dao.getById("a")).isNotNull()
+    }
+
+    @Test
+    fun `deleteAll with an empty list returns NOT_FOUND`() = runTest {
+        val result = repository().deleteAll(emptyList())
+
+        assertThat(result).isEqualTo(Result.Error(DataError.Local.NOT_FOUND))
+        assertThat(files.deletedFileNames).isEqualTo(emptyList())
+    }
+
+    @Test
     fun `stageForPlayback stages the entry's payload`() = runTest {
         dao.seed(entity("a"))
 

--- a/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryAction.kt
+++ b/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryAction.kt
@@ -4,7 +4,12 @@ sealed interface ReplayLibraryAction {
     data object OnOpenFileClicked : ReplayLibraryAction
     data class OnFilePicked(val uri: String?) : ReplayLibraryAction
     data class OnEntryClicked(val id: String) : ReplayLibraryAction
-    data class OnDeleteRequested(val id: String) : ReplayLibraryAction
+
+    /** Tap-and-hold a row: starts selection mode on that row, or toggles it if already selecting. */
+    data class OnEntryLongClicked(val id: String) : ReplayLibraryAction
+
+    /** Trash action in the selection top bar: opens the batch-delete confirmation. */
+    data object OnDeleteSelectedClicked : ReplayLibraryAction
     data object OnConfirmDelete : ReplayLibraryAction
     data object OnDismissDelete : ReplayLibraryAction
 

--- a/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryScreen.kt
+++ b/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -34,6 +35,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -119,7 +122,18 @@ fun ReplayLibraryScreen(
                     }
                 },
                 actions = {
-                    if (!state.isSelectionMode && state.entries.size >= 2) {
+                    if (state.isSelectionMode) {
+                        IconButton(
+                            onClick = { onAction(ReplayLibraryAction.OnDeleteSelectedClicked) },
+                            enabled = state.selectedIds.isNotEmpty(),
+                            modifier = Modifier.testTag(ReplayLibraryTestTags.DELETE_ACTION),
+                        ) {
+                            Icon(
+                                Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.replay_delete_selected),
+                            )
+                        }
+                    } else if (state.entries.size >= 2) {
                         TextButton(onClick = { onAction(ReplayLibraryAction.OnToggleSelectionMode) }) {
                             Text(stringResource(R.string.replay_select))
                         }
@@ -169,9 +183,9 @@ fun ReplayLibraryScreen(
         }
     }
 
-    state.pendingDelete?.let { entry ->
+    if (state.showDeleteDialog) {
         DeleteConfirmationDialog(
-            displayName = entry.displayName,
+            count = state.selectedIds.size,
             onConfirm = { onAction(ReplayLibraryAction.OnConfirmDelete) },
             onDismiss = { onAction(ReplayLibraryAction.OnDismissDelete) },
         )
@@ -195,11 +209,9 @@ private fun LibraryList(
                 isSelectionMode = isSelectionMode,
                 isSelected = entry.id in selectedIds,
                 onClick = { onAction(ReplayLibraryAction.OnEntryClicked(entry.id)) },
-                // Long-press keeps its delete meaning only outside selection mode, so a
-                // sloppy selection tap can never surface the destructive dialog.
-                onLongClick = {
-                    if (!isSelectionMode) onAction(ReplayLibraryAction.OnDeleteRequested(entry.id))
-                },
+                // Tap-and-hold starts (or extends) the selection; delete then happens from the
+                // selection top bar, so the destructive action always goes through a confirm.
+                onLongClick = { onAction(ReplayLibraryAction.OnEntryLongClicked(entry.id)) },
             )
         }
     }
@@ -270,19 +282,25 @@ private fun EmptyState(modifier: Modifier = Modifier) {
 
 @Composable
 private fun DeleteConfirmationDialog(
-    displayName: String,
+    count: Int,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.replay_delete_title)) },
-        text = { Text(stringResource(R.string.replay_delete_message, displayName)) },
+        title = { Text(pluralStringResource(R.plurals.replay_delete_title, count, count)) },
+        text = { Text(stringResource(R.string.replay_delete_message)) },
         confirmButton = {
-            TextButton(onClick = onConfirm) { Text(stringResource(R.string.replay_delete_confirm)) }
+            TextButton(
+                onClick = onConfirm,
+                modifier = Modifier.testTag(ReplayLibraryTestTags.DELETE_DIALOG_CONFIRM),
+            ) { Text(stringResource(R.string.replay_delete_confirm)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(R.string.replay_delete_cancel)) }
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.testTag(ReplayLibraryTestTags.DELETE_DIALOG_CANCEL),
+            ) { Text(stringResource(R.string.replay_delete_cancel)) }
         },
     )
 }
@@ -318,6 +336,27 @@ private fun ReplayLibrarySelectionPreview() {
                     LibraryEntryUi("1", "flight_2026_05_28.ulg", "12.4 MB", "May 28, 2026"),
                     LibraryEntryUi("2", "sitl_test.ulg", "3.1 MB", "May 27, 2026"),
                     LibraryEntryUi("3", "hover_check.ulg", "1.8 MB", "May 26, 2026"),
+                ),
+            ),
+            onAction = {},
+            onBack = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReplayLibraryDeleteDialogPreview() {
+    HawkeyeTheme {
+        ReplayLibraryScreen(
+            state = ReplayLibraryState(
+                isLoading = false,
+                isSelectionMode = true,
+                selectedIds = listOf("1", "2"),
+                showDeleteDialog = true,
+                entries = listOf(
+                    LibraryEntryUi("1", "flight_2026_05_28.ulg", "12.4 MB", "May 28, 2026"),
+                    LibraryEntryUi("2", "sitl_test.ulg", "3.1 MB", "May 27, 2026"),
                 ),
             ),
             onAction = {},

--- a/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryState.kt
+++ b/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryState.kt
@@ -7,10 +7,11 @@ data class ReplayLibraryState(
     val entries: List<LibraryEntryUi> = emptyList(),
     val isLoading: Boolean = true,
     val isImporting: Boolean = false,
-    val pendingDelete: LibraryEntryUi? = null,
     val isSelectionMode: Boolean = false,
     /** Click order, not list order: it becomes the swarm's drone order. */
     val selectedIds: List<String> = emptyList(),
+    /** Whether the batch-delete confirmation dialog is showing for the current selection. */
+    val showDeleteDialog: Boolean = false,
 )
 
 /** Presentation view of a library entry, with size/date already formatted for display. */

--- a/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryTestTags.kt
+++ b/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryTestTags.kt
@@ -1,0 +1,8 @@
+package com.px4.hawkeye.feature.replay.presentation
+
+/** Stable tags for driving the replay library's selection controls from UI tests. */
+object ReplayLibraryTestTags {
+    const val DELETE_ACTION = "replay_delete_action"
+    const val DELETE_DIALOG_CONFIRM = "replay_delete_dialog_confirm"
+    const val DELETE_DIALOG_CANCEL = "replay_delete_dialog_cancel"
+}

--- a/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryViewModel.kt
+++ b/android/feature/replay/presentation/src/main/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryViewModel.kt
@@ -44,13 +44,17 @@ class ReplayLibraryViewModel(
                 if (_state.value.isSelectionMode) toggleSelection(action.id)
                 else stageAndLaunch(listOf(action.id))
 
-            is ReplayLibraryAction.OnDeleteRequested ->
-                _state.update { state -> state.copy(pendingDelete = state.entries.find { it.id == action.id }) }
+            is ReplayLibraryAction.OnEntryLongClicked -> longClickEntry(action.id)
+
+            ReplayLibraryAction.OnDeleteSelectedClicked ->
+                if (_state.value.selectedIds.isNotEmpty()) {
+                    _state.update { it.copy(showDeleteDialog = true) }
+                }
 
             ReplayLibraryAction.OnConfirmDelete -> confirmDelete()
 
             ReplayLibraryAction.OnDismissDelete ->
-                _state.update { it.copy(pendingDelete = null) }
+                _state.update { it.copy(showDeleteDialog = false) }
 
             ReplayLibraryAction.OnToggleSelectionMode ->
                 _state.update {
@@ -58,6 +62,15 @@ class ReplayLibraryViewModel(
                 }
 
             ReplayLibraryAction.OnPlayTogetherClicked -> playTogether()
+        }
+    }
+
+    private fun longClickEntry(id: String) {
+        // First long-press starts selection on that row; once selecting, it toggles like a tap.
+        if (_state.value.isSelectionMode) {
+            toggleSelection(id)
+        } else {
+            _state.update { it.copy(isSelectionMode = true, selectedIds = listOf(id)) }
         }
     }
 
@@ -71,7 +84,7 @@ class ReplayLibraryViewModel(
                 viewModelScope.launch {
                     _events.send(
                         ReplayLibraryEvent.ShowError(
-                            UiText.StringResource(R.string.replay_swarm_cap),
+                            UiText.StringResource(R.string.replay_selection_cap),
                         ),
                     )
                 }
@@ -109,10 +122,14 @@ class ReplayLibraryViewModel(
     }
 
     private fun confirmDelete() {
-        val pending = _state.value.pendingDelete ?: return
-        _state.update { it.copy(pendingDelete = null) }
+        val ids = _state.value.selectedIds
+        if (ids.isEmpty()) return
+        _state.update { it.copy(showDeleteDialog = false) }
         viewModelScope.launch {
-            repository.delete(pending.id).onFailure { _events.send(ReplayLibraryEvent.ShowError(it.toUiText())) }
+            repository.deleteAll(ids)
+                // The observeLibrary flow re-emits the trimmed list; just drop selection mode.
+                .onSuccess { _state.update { it.copy(isSelectionMode = false, selectedIds = emptyList()) } }
+                .onFailure { _events.send(ReplayLibraryEvent.ShowError(it.toUiText())) }
         }
     }
 

--- a/android/feature/replay/presentation/src/main/res/values/strings.xml
+++ b/android/feature/replay/presentation/src/main/res/values/strings.xml
@@ -10,14 +10,18 @@
     <!-- Row caption: size and import date. Two placeholders so translators can reorder. -->
     <string name="replay_entry_meta">%1$s · %2$s</string>
 
-    <string name="replay_delete_title">Delete log?</string>
-    <string name="replay_delete_message">Remove \"%1$s\" from the library? This cannot be undone.</string>
+    <plurals name="replay_delete_title">
+        <item quantity="one">Delete %1$d log?</item>
+        <item quantity="other">Delete %1$d logs?</item>
+    </plurals>
+    <string name="replay_delete_message">This can\'t be undone.</string>
     <string name="replay_delete_confirm">Delete</string>
     <string name="replay_delete_cancel">Cancel</string>
+    <string name="replay_delete_selected">Delete selected</string>
 
     <string name="replay_select">Select</string>
     <string name="replay_exit_selection">Exit selection</string>
     <string name="replay_selection_title">%1$d selected</string>
     <string name="replay_play_together">Play together (%1$d)</string>
-    <string name="replay_swarm_cap">Up to 16 logs can play together</string>
+    <string name="replay_selection_cap">You can select up to 16 logs at a time</string>
 </resources>

--- a/android/feature/replay/presentation/src/test/kotlin/com/px4/hawkeye/feature/replay/presentation/FakeReplayLibraryRepository.kt
+++ b/android/feature/replay/presentation/src/test/kotlin/com/px4/hawkeye/feature/replay/presentation/FakeReplayLibraryRepository.kt
@@ -14,11 +14,11 @@ class FakeReplayLibraryRepository : ReplayLibraryRepository {
     var importResult: Result<LibraryEntry, DataError.Local> =
         Result.Success(LibraryEntry("new", "new.ulg", 10L, 0L))
     var stageResult: EmptyResult<DataError.Local> = Result.Success(Unit)
-    var deleteResult: EmptyResult<DataError.Local> = Result.Success(Unit)
+    var deleteAllResult: EmptyResult<DataError.Local> = Result.Success(Unit)
 
     val importedUris = mutableListOf<String>()
     val stagedBatches = mutableListOf<List<String>>()
-    val deletedIds = mutableListOf<String>()
+    val deletedBatches = mutableListOf<List<String>>()
 
     override fun observeLibrary() = entriesFlow
 
@@ -28,11 +28,16 @@ class FakeReplayLibraryRepository : ReplayLibraryRepository {
     }
 
     override suspend fun delete(id: String): EmptyResult<DataError.Local> {
-        deletedIds += id
-        if (deleteResult is Result.Success) {
-            entriesFlow.value = entriesFlow.value.filterNot { it.id == id }
+        entriesFlow.value = entriesFlow.value.filterNot { it.id == id }
+        return Result.Success(Unit)
+    }
+
+    override suspend fun deleteAll(ids: List<String>): EmptyResult<DataError.Local> {
+        deletedBatches += ids
+        if (deleteAllResult is Result.Success) {
+            entriesFlow.value = entriesFlow.value.filterNot { it.id in ids }
         }
-        return deleteResult
+        return deleteAllResult
     }
 
     override suspend fun stageForPlayback(ids: List<String>): EmptyResult<DataError.Local> {

--- a/android/feature/replay/presentation/src/test/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryViewModelTest.kt
+++ b/android/feature/replay/presentation/src/test/kotlin/com/px4/hawkeye/feature/replay/presentation/ReplayLibraryViewModelTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import com.px4.hawkeye.core.domain.DataError
 import com.px4.hawkeye.core.domain.Result
@@ -237,29 +236,111 @@ class ReplayLibraryViewModelTest {
     }
 
     @Test
-    fun `delete request then confirm deletes and clears the pending entry`() = runTest {
-        repo.entriesFlow.value = listOf(LibraryEntry("1", "a.ulg", 1L, 0L))
+    fun `long pressing an entry enters selection mode and selects it`() = runTest {
+        repo.entriesFlow.value = listOf(
+            LibraryEntry("1", "a.ulg", 1L, 0L),
+            LibraryEntry("2", "b.ulg", 1L, 0L),
+        )
         val vm = ReplayLibraryViewModel(repo)
 
-        vm.onAction(ReplayLibraryAction.OnDeleteRequested("1"))
-        assertThat(vm.state.value.pendingDelete?.id).isEqualTo("1")
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("2"))
 
-        vm.onAction(ReplayLibraryAction.OnConfirmDelete)
-
-        assertThat(vm.state.value.pendingDelete).isNull()
-        assertThat(repo.deletedIds).containsExactly("1")
-        assertThat(vm.state.value.entries).isEqualTo(emptyList())
+        assertThat(vm.state.value.isSelectionMode).isTrue()
+        assertThat(vm.state.value.selectedIds).containsExactly("2")
+        assertThat(repo.stagedBatches).isEqualTo(emptyList<List<String>>())
     }
 
     @Test
-    fun `delete request then dismiss does not delete`() = runTest {
-        repo.entriesFlow.value = listOf(LibraryEntry("1", "a.ulg", 1L, 0L))
+    fun `long pressing while already selecting toggles membership`() = runTest {
+        repo.entriesFlow.value = listOf(
+            LibraryEntry("1", "a.ulg", 1L, 0L),
+            LibraryEntry("2", "b.ulg", 1L, 0L),
+        )
         val vm = ReplayLibraryViewModel(repo)
 
-        vm.onAction(ReplayLibraryAction.OnDeleteRequested("1"))
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("1"))
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("2"))
+        assertThat(vm.state.value.selectedIds).containsExactly("1", "2")
+
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("1"))
+        assertThat(vm.state.value.selectedIds).containsExactly("2")
+    }
+
+    @Test
+    fun `delete selected shows the confirmation dialog`() = runTest {
+        repo.entriesFlow.value = listOf(LibraryEntry("1", "a.ulg", 1L, 0L))
+        val vm = ReplayLibraryViewModel(repo)
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("1"))
+
+        vm.onAction(ReplayLibraryAction.OnDeleteSelectedClicked)
+
+        assertThat(vm.state.value.showDeleteDialog).isTrue()
+        assertThat(repo.deletedBatches).isEqualTo(emptyList<List<String>>())
+    }
+
+    @Test
+    fun `delete selected with an empty selection does nothing`() = runTest {
+        repo.entriesFlow.value = listOf(LibraryEntry("1", "a.ulg", 1L, 0L))
+        val vm = ReplayLibraryViewModel(repo)
+        vm.onAction(ReplayLibraryAction.OnToggleSelectionMode)
+
+        vm.onAction(ReplayLibraryAction.OnDeleteSelectedClicked)
+
+        assertThat(vm.state.value.showDeleteDialog).isFalse()
+    }
+
+    @Test
+    fun `confirming delete removes the whole selection and exits selection mode`() = runTest {
+        repo.entriesFlow.value = listOf(
+            LibraryEntry("1", "a.ulg", 1L, 0L),
+            LibraryEntry("2", "b.ulg", 1L, 0L),
+            LibraryEntry("3", "c.ulg", 1L, 0L),
+        )
+        val vm = ReplayLibraryViewModel(repo)
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("1"))
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("3"))
+        vm.onAction(ReplayLibraryAction.OnDeleteSelectedClicked)
+
+        vm.onAction(ReplayLibraryAction.OnConfirmDelete)
+
+        assertThat(repo.deletedBatches).containsExactly(listOf("1", "3"))
+        assertThat(vm.state.value.showDeleteDialog).isFalse()
+        assertThat(vm.state.value.isSelectionMode).isFalse()
+        assertThat(vm.state.value.selectedIds).isEqualTo(emptyList())
+        assertThat(vm.state.value.entries.map { it.id }).containsExactly("2")
+    }
+
+    @Test
+    fun `delete failure reports an error and keeps the selection`() = runTest {
+        repo.entriesFlow.value = listOf(
+            LibraryEntry("1", "a.ulg", 1L, 0L),
+            LibraryEntry("2", "b.ulg", 1L, 0L),
+        )
+        repo.deleteAllResult = Result.Error(DataError.Local.UNKNOWN)
+        val vm = ReplayLibraryViewModel(repo)
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("1"))
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("2"))
+        vm.onAction(ReplayLibraryAction.OnDeleteSelectedClicked)
+
+        vm.events.test {
+            vm.onAction(ReplayLibraryAction.OnConfirmDelete)
+            assertThat(awaitItem()).isInstanceOf(ReplayLibraryEvent.ShowError::class)
+        }
+        assertThat(vm.state.value.isSelectionMode).isTrue()
+        assertThat(vm.state.value.selectedIds).containsExactly("1", "2")
+    }
+
+    @Test
+    fun `dismissing delete hides the dialog without deleting`() = runTest {
+        repo.entriesFlow.value = listOf(LibraryEntry("1", "a.ulg", 1L, 0L))
+        val vm = ReplayLibraryViewModel(repo)
+        vm.onAction(ReplayLibraryAction.OnEntryLongClicked("1"))
+        vm.onAction(ReplayLibraryAction.OnDeleteSelectedClicked)
+
         vm.onAction(ReplayLibraryAction.OnDismissDelete)
 
-        assertThat(vm.state.value.pendingDelete).isNull()
-        assertThat(repo.deletedIds).isEqualTo(emptyList())
+        assertThat(vm.state.value.showDeleteDialog).isFalse()
+        assertThat(repo.deletedBatches).isEqualTo(emptyList<List<String>>())
+        assertThat(vm.state.value.selectedIds).containsExactly("1")
     }
 }


### PR DESCRIPTION
Tap-and-hold a log now enters selection mode and selects that row, matching the familiar Android pattern. The Select button stays as the alternate entry point. In selection mode the top bar shows a Delete action that removes every selected log behind a confirmation dialog; opening is unchanged on the Play together FAB.

Adds ReplayLibraryRepository.deleteAll, which resolves all ids first so an unknown id fails the batch before any file is removed. Replaces the single-file long-press delete dialog with the selection-driven flow.

Covered by ViewModel unit tests, RoomReplayLibraryRepository tests, and a new on-device ReplayLibrarySelectionTest.