### PR TITLE
Publish an Android APK with every release

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -1,0 +1,50 @@
+name: Set up Android build
+description: >
+  Installs the pinned NDK and CMake and restores the Gradle and native build caches.
+  Shared by the debug and release CI jobs in android.yml and the android-apk release job,
+  so the toolchain versions are pinned in one place.
+
+inputs:
+  cxx-cache-prefix:
+    description: >
+      Cache key prefix for the android/app/.cxx tree. Use a distinct prefix per build
+      variant: AGP writes debug into .cxx/Debug and release into .cxx/RelWithDebInfo, and
+      actions/cache only saves when the exact key is absent, so a shared key would let
+      whichever job finished first claim it and starve the other variant.
+    required: false
+    default: ndk
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Java 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Install NDK and CMake
+      shell: bash
+      run: |
+        yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager \
+          "ndk;30.0.14904198" \
+          "cmake;3.22.1"
+
+    - name: Cache Gradle
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: gradle-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
+        restore-keys: gradle-
+
+    # app/build.gradle.kts is in the hash because it pins ndkVersion and the CMake version.
+    # Without it, bumping the NDK would restore a stale cache, build into a new AGP config
+    # hash directory, and then never re-save because the key already exists.
+    - name: Cache native build artifacts
+      uses: actions/cache@v4
+      with:
+        path: android/app/.cxx
+        key: ${{ inputs.cxx-cache-prefix }}-${{ runner.os }}-${{ hashFiles('android/app/src/main/cpp/CMakeLists.txt', 'android/app/build.gradle.kts') }}
+        restore-keys: ${{ inputs.cxx-cache-prefix }}-${{ runner.os }}-

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,17 +1,37 @@
 name: Android
 
+# The Android native library is not self-contained: app/src/main/cpp/CMakeLists.txt
+# compiles 22 files out of the repo-root src/, includes the lib/c_library_v2 submodule,
+# and app/src/main/assets/ is four symlinks to the root asset directories. Those paths
+# have to trigger this workflow or a desktop-side change can break the release APK with
+# no CI signal until a tag is pushed.
 on:
   push:
     branches: [main]
     paths:
       - 'android/**'
       - '.github/workflows/android.yml'
+      - 'src/**'
+      - 'lib/**'
+      - 'fonts/**'
+      - 'models/**'
+      - 'shaders/**'
+      - 'themes/**'
   pull_request:
     branches: [main]
     paths:
       - 'android/**'
       - '.github/workflows/android.yml'
+      - 'src/**'
+      - 'lib/**'
+      - 'fonts/**'
+      - 'models/**'
+      - 'shaders/**'
+      - 'themes/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -22,35 +42,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          lfs: true
 
-      - name: Set up Java 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Install NDK and CMake
-        run: |
-          yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager \
-            "ndk;30.0.14904198" \
-            "cmake;3.22.1"
-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
-          restore-keys: gradle-
-
-      - name: Cache NDK build artifacts
-        uses: actions/cache@v4
-        with:
-          path: android/app/.cxx
-          key: ndk-${{ runner.os }}-${{ hashFiles('android/app/src/main/cpp/CMakeLists.txt') }}
-          restore-keys: ndk-${{ runner.os }}-
+      - uses: ./.github/actions/setup-android-build
 
       - name: Build
         working-directory: android
@@ -61,4 +54,37 @@ jobs:
         with:
           name: hawkeye-android-debug
           path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7
+
+  release-build:
+    name: Release build
+    # Skipped on pull requests to keep review turnaround fast. Runs on pushes to main and
+    # on workflow_dispatch so the task release.yml depends on is exercised before any tag
+    # is pushed, and so the ndk-release-* cache is warm when the release job runs.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/setup-android-build
+        with:
+          cxx-cache-prefix: ndk-release
+
+      - name: Build release APK
+        working-directory: android
+        run: ./gradlew assembleRelease -PhawkeyeVersionName=0.0.0-ci
+
+      # The same verification the release job runs. This is the only genuinely new shell
+      # in the release path, so exercising it here is the point of this job.
+      - name: Verify APK
+        run: android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.0.0-ci
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: hawkeye-android-release
+          path: android/app/build/outputs/apk/release/*.apk
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,46 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # ── Job 2e: Android universal APK ─────────────────────────────────────────
+  android-apk:
+    name: Android (APK)
+    needs: source-tarball
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/setup-android-build
+        with:
+          cxx-cache-prefix: ndk-release
+
+      - name: Build release APK
+        working-directory: android
+        env:
+          VERSION: ${{ needs.source-tarball.outputs.version }}
+        run: ./gradlew assembleRelease -PhawkeyeVersionName="$VERSION"
+
+      - name: Verify and stage APK
+        id: apk
+        env:
+          VERSION: ${{ needs.source-tarball.outputs.version }}
+        run: |
+          set -euo pipefail
+          SRC=$(android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release "$VERSION")
+          # Dropping "-unsigned" when a signing config lands means updating the asset name
+          # in docs/installation.md, docs/developer/releasing.md, docs/troubleshooting.md,
+          # and README.md.
+          NAME="hawkeye-${VERSION}-android-unsigned.apk"
+          cp "$SRC" "$NAME"
+          echo "file=${NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK to release
+        run: gh release upload "${{ github.ref_name }}" "${{ steps.apk.outputs.file }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # ── Job 3: Update Homebrew tap ─────────────────────────────────────────────
   update-tap:
     name: Update Homebrew tap

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install PX4/px4/hawkeye
 Download the `.deb` from the [latest release](https://github.com/PX4/Hawkeye/releases/latest):
 
 ```bash
-sudo dpkg -i hawkeye-*.deb
+sudo dpkg -i hawkeye_*.deb
 ```
 
 ### Windows
@@ -32,6 +32,12 @@ sudo dpkg -i hawkeye-*.deb
 Download `hawkeye-<version>-windows-x64.zip` from the [latest release](https://github.com/PX4/Hawkeye/releases/latest), extract it anywhere, and run `hawkeye.exe`.
 
 On first launch, Windows SmartScreen may warn that the binary is from an unknown publisher — click "More info" → "Run anyway". The ZIP is unsigned; we're working on winget distribution to remove this warning.
+
+### Android
+
+Download `hawkeye-<version>-android-unsigned.apk` from the [latest release](https://github.com/PX4/Hawkeye/releases/latest). It requires Android 10 or newer and bundles both `arm64-v8a` and `x86_64`.
+
+The APK is unsigned and cannot be installed as downloaded. Sign it with your own key first; see the [Android README](./android/README.md) for the commands.
 
 ### Source builds
 

--- a/android/README.md
+++ b/android/README.md
@@ -166,21 +166,13 @@ Fakes (in-memory implementations of the domain interface) catch more real bugs t
 
 ## Loading flight logs
 
-The app accepts `.ulg` files via Android `VIEW` and `SEND` intents — open a `.ulg` from Drive, Files, or Gmail and pick Hawkeye. There is no in-app file picker yet.
+Logs are imported through the replay library screen, which opens the system document picker via `ActivityResultContracts.OpenDocument()`. ULog has no registered MIME type, so the picker accepts `*/*`. Import is a raw byte copy with no format check, so a file that isn't a valid ULog is rejected when playback starts, not when it is picked. Imported payloads live in the app's library directory with their metadata in Room (`feature/replay/data/`), so a log only has to be picked once.
 
-Mechanism: the activity receives the inbound intent, copies the file bytes via `ContentResolver` to `filesDir/inbox/current.ulg` (via `.tmp` + atomic rename), and writes a millis token to `filesDir/inbox/.ready`. The native render loop checks that sentinel at roughly 1 Hz, reads its contents, and reloads the replay when the token changes, so re-sharing a different `.ulg` into the running app swaps the playback live. The activity uses `launchMode="singleTop"`, so if Hawkeye is already at the top, subsequent intents are delivered via `onNewIntent` to the existing instance.
+Mechanism: starting playback stages the selected library payloads into `filesDir/inbox/`. The first drone keeps the name `current.ulg` and the rest become `swarm_<i>.ulg`, then a `<millis>` token (or `<millis> <count>` for a swarm) is written to `filesDir/inbox/.ready`. The sentinel is bumped only after the whole batch has copied, so any I/O failure leaves the inbox exactly as the still-unchanged token describes it. The native render loop polls that sentinel at roughly 1 Hz and reloads the replay when the token changes.
 
-To test from the command line:
+Live mode uses the same directory: `RendererLauncher` writes an `inbox/.live` marker containing `<millis> <port>`, and native startup compares it against the replay `.ready` token, newest wins.
 
-```bash
-adb push some-flight.ulg /sdcard/Download/
-adb shell am start -a android.intent.action.VIEW \
-    -d "file:///sdcard/Download/some-flight.ulg" \
-    -t application/octet-stream \
-    com.px4.hawkeye.android/.IntentRouterActivity
-```
-
-`IntentRouterActivity` is the exported trampoline that receives `VIEW`/`SEND` intents; the native renderer (`HawkeyeActivity`) is not exported and is launched internally.
+The manifest declares no `VIEW` or `SEND` intent filters, so logs cannot currently be opened by sharing them into Hawkeye from Drive, Files, or Gmail.
 
 ## Shader Compatibility
 
@@ -224,10 +216,20 @@ The `assets/` directory uses symlinks into the parent repo (fonts, models, shade
 
 ## Requirements
 
-- Android SDK (API 29+)
-- NDK 30.0.14904198
-- CMake 3.22+
-- A device or emulator with OpenGL ES 3.0 support
+To build:
+
+- JDK 21
+- Android SDK Platform 36.1, set by `compileSdk` in `app/build.gradle.kts`
+- NDK 30.0.14904198, exactly; `ndkVersion` pins it and AGP will not substitute another
+- CMake 3.22.1, exactly; `externalNativeBuild` pins it the same way
+
+Gradle comes from the wrapper, so there is nothing to install for it.
+
+To run:
+
+- Android 10 (API 29) or newer, set by `minSdk`
+- An `arm64-v8a` or `x86_64` device or emulator, since those are the only ABIs built
+- OpenGL ES 3.0
 
 ## Building
 
@@ -237,6 +239,24 @@ The `assets/` directory uses symlinks into the parent repo (fonts, models, shade
 
 Raylib 5.5 is fetched automatically by CMake on the first build. Built ABIs: `arm64-v8a`, `x86_64`.
 
+### Release builds
+
+```bash
+./gradlew assembleRelease -PhawkeyeVersionName=0.4.0
+```
+
+`hawkeyeVersionName` sets the APK `versionName`, and `versionCode` is derived from it as `major * 1000000 + minor * 1000 + patch`, so `0.4.0` becomes `4000` and `1.2.3` becomes `1002003`. The value is parsed strictly: anything that isn't `MAJOR.MINOR.PATCH` with an optional suffix, or that has a component outside `0..999`, fails the build rather than producing a misleading version code. Omit the property and the build falls back to `0.0.0-dev` with version code `1`, which is why `assembleDebug` needs no flags. The release workflow passes the value from the git tag; see [Releasing](https://px4.github.io/Hawkeye/developer/releasing) for the full picture.
+
+The output is `app/build/outputs/apk/release/app-release-unsigned.apk`. There is no signing config in the project, so the APK is unsigned and cannot be installed until you sign it yourself (see below).
+
+To run the same checks CI runs against a release APK (both ABIs present, all four asset trees packaged, version as expected):
+
+```bash
+scripts/verify-release-apk.sh app/build/outputs/apk/release 0.4.0
+```
+
+AGP maps the `release` build type to CMake `RelWithDebInfo`, not `Release`. Native objects therefore land in a `.cxx/RelWithDebInfo/` tree separate from the debug one, and the first release build recompiles raylib from scratch even if a debug build is already warm.
+
 ## Deploying
 
 ```bash
@@ -245,4 +265,39 @@ adb shell am start -n com.px4.hawkeye.android/.MainActivity
 ```
 
 `MainActivity` is the launcher (the Compose shell). `HawkeyeActivity` is `exported="false"` and is launched from within the app, so it can't be started directly from `adb`.
+
+### Signing a release APK
+
+The release APK is unsigned, so `adb install` rejects it. Generate a key once, then align and sign before installing. `zipalign` and `apksigner` ship with the SDK build tools; substitute your installed version for `36.0.0`.
+
+```bash
+keytool -genkeypair -v -keystore hawkeye.jks -alias hawkeye \
+    -keyalg RSA -keysize 2048 -validity 10000
+
+$ANDROID_SDK_ROOT/build-tools/36.0.0/zipalign -p -f 4 \
+    app/build/outputs/apk/release/app-release-unsigned.apk hawkeye-aligned.apk
+
+$ANDROID_SDK_ROOT/build-tools/36.0.0/apksigner sign \
+    --ks hawkeye.jks --out hawkeye.apk hawkeye-aligned.apk
+
+adb install -r hawkeye.apk
+```
+
+Keep the keystore out of the repo. Reusing the same key across builds is what lets you install over a previous version instead of having to uninstall first.
+
+## Continuous Integration
+
+Three CI jobs build this app:
+
+| Workflow      | Job             | Variant | Runs on                                        |
+| ------------- | --------------- | ------- | ---------------------------------------------- |
+| `android.yml` | `build`         | Debug   | Pull requests, pushes to main, manual dispatch |
+| `android.yml` | `release-build` | Release | Pushes to main, manual dispatch                |
+| `release.yml` | `android-apk`   | Release | `v*` tag pushes only                           |
+
+`release-build` runs the same `assembleRelease` task and the same `scripts/verify-release-apk.sh` check the release uses, so a break shows up on a normal merge rather than on a live tag. It is skipped on pull requests to keep review turnaround fast, and can be triggered from a branch with `gh workflow run android.yml --ref <branch>`.
+
+All three jobs share `.github/actions/setup-android-build` for the toolchain install and caching, so the NDK and CMake versions are pinned in one place.
+
+`android.yml` triggers on the repo-root `src/`, `lib/`, `fonts/`, `models/`, `shaders/`, and `themes/` directories as well as `android/`. The native library compiles source files out of the root `src/` tree and `app/src/main/assets/` is symlinks into the root asset directories, so a desktop-side change can break this app and has to run Android CI.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,31 @@ plugins {
     id("hawkeye.android.application")
 }
 
+// Release builds take their version from the git tag, passed as
+// -PhawkeyeVersionName=<x.y.z> by .github/workflows/release.yml. Local and CI debug
+// builds fall back to a dev version so no extra flags are needed.
+val hawkeyeVersionName: String =
+    providers.gradleProperty("hawkeyeVersionName").getOrElse("0.0.0-dev")
+
+// Monotonic code derived from the semver: 0.4.0 -> 4000, 1.2.3 -> 1002003.
+//
+// Parsed strictly. A malformed version has to fail the build rather than degrade to a
+// low code, because Android refuses any upgrade whose version code is not greater than
+// the installed one, and a silently-wrong code would ship in a release.
+val hawkeyeVersionCode: Int = run {
+    val parts = hawkeyeVersionName.substringBefore('-').split('.')
+    require(parts.size == 3) {
+        "hawkeyeVersionName must be MAJOR.MINOR.PATCH with an optional -suffix, got '$hawkeyeVersionName'"
+    }
+    val (major, minor, patch) = parts.map { part ->
+        part.toIntOrNull()?.takeIf { it in 0..999 }
+            ?: error("hawkeyeVersionName component '$part' is not an integer in 0..999, from '$hawkeyeVersionName'")
+    }
+    // The 1000 radix leaves room for two-digit and three-digit minor/patch numbers.
+    // 0.0.0 is only reachable via the dev fallback above, which needs a floor of 1.
+    (major * 1_000_000 + minor * 1_000 + patch).coerceAtLeast(1)
+}
+
 android {
     namespace = "com.px4.hawkeye.android"
     compileSdk {
@@ -22,13 +47,16 @@ android {
     defaultConfig {
         applicationId = "com.px4.hawkeye.android"
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = hawkeyeVersionCode
+        versionName = hawkeyeVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         externalNativeBuild {
             cmake {
+                // Changing this list means updating android/scripts/verify-release-apk.sh
+                // and the ABI list documented in docs/installation.md,
+                // docs/developer/releasing.md, docs/troubleshooting.md, and README.md.
                 abiFilters += listOf("arm64-v8a", "x86_64")
             }
         }

--- a/android/build-logic/convention/src/main/kotlin/com/px4/hawkeye/buildlogic/AndroidCommon.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/px4/hawkeye/buildlogic/AndroidCommon.kt
@@ -5,6 +5,8 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
 internal const val PROJECT_COMPILE_SDK = 36
+// Raising this means updating the "Android 10 (API 29)" claim in docs/installation.md,
+// docs/developer/releasing.md, and README.md.
 internal const val PROJECT_MIN_SDK = 29
 internal const val PROJECT_TARGET_SDK = 36
 

--- a/android/scripts/verify-release-apk.sh
+++ b/android/scripts/verify-release-apk.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Verifies a release APK without needing a device or an emulator.
+#
+# Checks that both ABIs are present, that all four asset trees made it into the package
+# (they are symlinks into the repo root, so this catches a checkout that failed to
+# materialize them), and that the version the build produced is the one it was told to
+# produce.
+#
+# Resolves the APK from AGP's output-metadata.json rather than globbing the output
+# directory, so it stays correct if a second variant or an ABI split is ever added.
+#
+# Usage:   verify-release-apk.sh <apk-output-dir> <expected-version-name>
+# Example: android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.4.0
+#
+# Prints the resolved APK path on stdout; diagnostics go to stderr.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <apk-output-dir> <expected-version-name>" >&2
+    exit 2
+fi
+
+output_dir=$1
+expected_version=$2
+metadata="${output_dir}/output-metadata.json"
+
+if [ ! -f "$metadata" ]; then
+    echo "no output-metadata.json in ${output_dir}; was the APK built?" >&2
+    exit 1
+fi
+
+element_count=$(jq '.elements | length' "$metadata")
+if [ "$element_count" -ne 1 ]; then
+    echo "expected exactly one APK output, found ${element_count}" >&2
+    echo "if a split or flavor was added, this script needs to learn which one to ship" >&2
+    exit 1
+fi
+
+apk="${output_dir}/$(jq -r '.elements[0].outputFile' "$metadata")"
+if [ ! -f "$apk" ]; then
+    echo "output-metadata.json names ${apk}, which does not exist" >&2
+    exit 1
+fi
+
+listing=$(unzip -l "$apk")
+for entry in \
+    lib/arm64-v8a/libhawkeye.so \
+    lib/x86_64/libhawkeye.so \
+    assets/models/ \
+    assets/shaders/ \
+    assets/fonts/ \
+    assets/themes/ ; do
+    if ! printf '%s\n' "$listing" | grep -qF "$entry"; then
+        echo "APK is missing ${entry}" >&2
+        exit 1
+    fi
+done
+
+version_name=$(jq -r '.elements[0].versionName' "$metadata")
+version_code=$(jq -r '.elements[0].versionCode' "$metadata")
+echo "${apk}: versionName=${version_name} versionCode=${version_code}" >&2
+
+if [ "$version_name" != "$expected_version" ]; then
+    echo "versionName is '${version_name}', expected '${expected_version}'" >&2
+    exit 1
+fi
+
+if [ "$version_code" -lt 1 ]; then
+    echo "versionCode is '${version_code}', which Android will not accept" >&2
+    exit 1
+fi
+
+echo "$apk"

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
         items: [
           { text: 'Building from source', link: '/developer/build' },
           { text: 'Testing', link: '/developer/testing' },
+          { text: 'Releasing', link: '/developer/releasing' },
         ],
       },
     ],

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -2,6 +2,7 @@
 
 You only need to build from source if you want to modify Hawkeye or run pre-release code.
 For everyday use, the Homebrew formula, `.deb` package, or Windows ZIP described in [Installation](../installation.md) is the faster path.
+For how those packages are produced and published, see [Releasing](./releasing.md).
 
 ::: info
 Clone with `--recursive`.

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -1,0 +1,109 @@
+# Releasing
+
+Releases are cut by pushing a `v*` tag.
+`.github/workflows/release.yml` is the only thing that reacts to that tag, and it produces every published artifact.
+No version number is stored anywhere in the repository; the tag is the single source of truth.
+
+::: info
+The release workflow has no trigger other than the tag push, so it cannot be dry-run.
+Before tagging, exercise the build with the pre-tag check described in [Checking a release build before tagging](#checking-a-release-build-before-tagging).
+:::
+
+## Cutting a release
+
+Tag the commit and push the tag:
+
+```sh
+git tag -a v0.4.0 -m "v0.4.0"
+git push origin v0.4.0
+```
+
+The workflow creates the GitHub release immediately, then each platform job uploads its artifact as it finishes.
+The release is published rather than drafted, because the macOS bottle build needs the source tarball URL to be publicly fetchable.
+
+## Release artifacts
+
+A tag produces six assets:
+
+| Artifact                                       | Platform    | Job              |
+| ---------------------------------------------- | ----------- | ---------------- |
+| `hawkeye-<version>.tar.gz`                     | Source      | `source-tarball` |
+| `hawkeye-<version>.arm64_sonoma.bottle.tar.gz` | macOS arm64 | `bottle-arm64`   |
+| `hawkeye_<version>_amd64.deb`                  | Linux amd64 | `deb-amd64`      |
+| `hawkeye_<version>_arm64.deb`                  | Linux arm64 | `deb-arm64`      |
+| `hawkeye-<version>-windows-x64.zip`            | Windows x64 | `windows-x64`    |
+| `hawkeye-<version>-android-unsigned.apk`       | Android     | `android-apk`    |
+
+The `.deb` files use Debian policy naming with underscores, which is why the install command in [Installation](../installation.md) globs `hawkeye_*.deb` and not `hawkeye-*.deb`.
+
+Every platform job depends only on `source-tarball`, so one platform failing does not block the release or the other artifacts.
+A failed job leaves the release published with that asset missing; re-upload it by hand with `gh release upload <tag> <file>` once the cause is fixed.
+
+A seventh job, `update-tap`, is the exception.
+It depends on `bottle-arm64` as well as `source-tarball`, and it pushes the updated formula to the [PX4/homebrew-px4](https://github.com/PX4/homebrew-px4) tap.
+If the bottle build fails, the tap keeps pointing at the previous version while the GitHub release advertises the new one, so `brew install hawkeye` silently serves the old build until the job is re-run.
+That is the only failure in this workflow with a user-visible consequence beyond a missing asset.
+
+## How the version is derived
+
+The `source-tarball` job strips the leading `v` from the tag and exports the result, and every other job reads it from there.
+The two build systems receive it differently:
+
+| Build system | How it receives the version      |
+| ------------ | -------------------------------- |
+| CMake        | `-DHAWKEYE_VERSION=<version>`    |
+| Gradle       | `-PhawkeyeVersionName=<version>` |
+
+`android/app/build.gradle.kts` computes the Android `versionCode` from that string as `major * 1000000 + minor * 1000 + patch`, so CI passes one value and Gradle derives the other:
+
+| Tag      | versionName | versionCode |
+| -------- | ----------- | ----------- |
+| `v0.3.0` | `0.3.0`     | 3000        |
+| `v0.4.0` | `0.4.0`     | 4000        |
+| `v1.2.3` | `1.2.3`     | 1002003     |
+| no tag   | `0.0.0-dev` | 1           |
+
+A local build with no `-PhawkeyeVersionName` falls back to `0.0.0-dev`, so debug builds need no extra flags.
+The version is parsed strictly: a tag that is not `MAJOR.MINOR.PATCH` with an optional suffix, or that has a component outside `0..999`, fails the Android build rather than producing a misleading version code.
+
+::: warning
+A prerelease tag reuses the version code of the release it precedes.
+`v0.4.0-rc1` produces versionName `0.4.0-rc1` but versionCode `4000`, the same code the eventual `v0.4.0` gets, and Android refuses to install an APK whose version code is not greater than the installed one.
+Avoid prerelease tags until the derivation accounts for them.
+:::
+
+## The Android APK
+
+The `android-apk` job builds a single universal APK containing `arm64-v8a` and `x86_64`.
+There is no `armeabi-v7a` build, so 32-bit ARM devices are not supported.
+The minimum supported platform is Android 10 (API 29).
+
+The APK is unsigned.
+There is no signing configuration in the project and no keystore secret in the repository, so the artifact is named `-unsigned` to make that obvious.
+It has to be signed with your own key before it will install; see [Signing a release APK](https://github.com/PX4/Hawkeye/blob/main/android/README.md#signing-a-release-apk) in the Android README.
+
+Because the APK cannot be launched on a CI runner without an emulator, `android/scripts/verify-release-apk.sh` asserts on its contents instead:
+
+- Both `lib/arm64-v8a/libhawkeye.so` and `lib/x86_64/libhawkeye.so` are present.
+- All four asset trees are packaged: `assets/models/`, `assets/shaders/`, `assets/fonts/`, and `assets/themes/`.
+  These are symlinks into the repository root, so the check catches a runner that failed to materialize them.
+- The `versionName` AGP recorded matches the tag, and the `versionCode` is one Android will accept.
+
+That script takes the APK output directory and the expected version, so you can run the same check locally against your own build.
+
+## Checking a release build before tagging
+
+`.github/workflows/android.yml` has a `release-build` job that runs the same `assembleRelease` task and the same verification script the release uses.
+It runs on pushes to `main` and on manual dispatch, and is skipped on pull requests to keep review turnaround fast.
+
+Trigger it from a branch before tagging:
+
+```sh
+gh workflow run android.yml --ref my-branch
+```
+
+The push-to-`main` run of that job also warms the native build cache the release job reads, because a tag run restores caches from the default branch.
+A `--ref my-branch` dispatch does not warm it, since caches written on a branch are not visible to a later tag run.
+
+The workflow's path filter covers the repository root `src/`, `lib/`, `fonts/`, `models/`, `shaders/`, and `themes/` directories in addition to `android/`.
+The Android native library compiles source files out of the root `src/` tree and its assets are symlinks to the root asset directories, so a desktop-side change can break the APK and has to trigger Android CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ features:
     link: /views
     linkText: Views guide
   - title: Zero Dependencies
-    details: Built on Raylib and MAVLink. Ships as a single binary. macOS, Linux, and Windows supported out of the box.
+    details: Built on Raylib and MAVLink. Ships as a single binary on macOS, Linux, and Windows, plus an Android APK.
     link: /installation
     linkText: Install
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,7 @@
 # Installation
 
 Hawkeye ships as a Homebrew formula on macOS, a `.deb` package on Debian/Ubuntu, and a portable ZIP on Windows.
+Android builds are published as an unsigned APK for developers.
 If you want the latest development build, see [Building from source](./developer/build.md).
 
 ## macOS (Homebrew)
@@ -22,7 +23,7 @@ hawkeye
 Download the latest `.deb` from the [Hawkeye releases page](https://github.com/PX4/Hawkeye/releases/latest) and install it:
 
 ```sh
-sudo dpkg -i hawkeye-*.deb
+sudo dpkg -i hawkeye_*.deb
 ```
 
 ARM64 builds (Raspberry Pi, Jetson, cloud ARM instances) are published in the same release.
@@ -38,6 +39,20 @@ Windows SmartScreen may warn that `hawkeye.exe` is from an unknown publisher. Cl
 :::
 
 To launch from any terminal, add the extracted folder to your `PATH`.
+
+## Android
+
+Download `hawkeye-<version>-android-unsigned.apk` from the [Hawkeye releases page](https://github.com/PX4/Hawkeye/releases/latest).
+
+The APK bundles both `arm64-v8a` and `x86_64`, so it runs on 64-bit ARM devices and in the Android emulator.
+It requires Android 10 (API 29) or newer and a GPU with OpenGL ES 3.0.
+
+::: info Unsigned APK
+The release APK ships unsigned and cannot be installed as downloaded.
+Sign it with your own key using `zipalign` and `apksigner` from the Android SDK build tools first.
+See the [Android README](https://github.com/PX4/Hawkeye/blob/main/android/README.md) for the exact commands.
+Signed distribution is on the roadmap.
+:::
 
 ## Verifying the install
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,6 +199,33 @@ Common fixes:
 - **Linux**: install the proprietary NVIDIA or AMD driver (Mesa's OpenGL implementation should work but has been a source of issues)
 - **Windows**: reinstall the latest graphics driver from the GPU vendor's website
 
+## Android
+
+### The downloaded APK won't install
+
+The release APK is published unsigned, so the package installer rejects it.
+Confirm that is the cause with `apksigner` from the Android SDK build tools:
+
+```sh
+apksigner verify hawkeye-<version>-android-unsigned.apk
+```
+
+An unsigned APK reports `DOES NOT VERIFY` with `Missing META-INF/MANIFEST.MF`.
+Sign it with your own key before installing.
+The [Android README](https://github.com/PX4/Hawkeye/blob/main/android/README.md) has the `keytool`, `zipalign`, and `apksigner` commands.
+
+### The APK installs on one device but not another
+
+The APK bundles `arm64-v8a` and `x86_64` only.
+32-bit ARM devices have no matching native library and are not supported.
+Check what the device reports:
+
+```sh
+adb shell getprop ro.product.cpu.abilist
+```
+
+If that list contains neither `arm64-v8a` nor `x86_64`, the device cannot run Hawkeye.
+
 ## MAVLink port conflicts
 
 ### `bind: Address already in use`
@@ -222,7 +249,7 @@ If this page doesn't solve your problem:
 1. **Check the Hawkeye GitHub issues** for similar reports: [github.com/PX4/Hawkeye/issues](https://github.com/PX4/Hawkeye/issues)
 2. **File a new issue** with:
    - Your OS and version
-   - Build type (`make` debug / `make release` / package install)
+   - Build type (`make` debug / `make release` / package install / Android APK)
    - Reproduction steps
    - Full console output from launch to crash / error
    - Relevant log file if it's a ULog parsing issue (sanitize private data first)


### PR DESCRIPTION
Every `v*` tag now produces an Android APK alongside the existing tarball, Homebrew bottle, `.deb` packages, and Windows zip.

## Release

- New `android-apk` job in `release.yml`, a sibling of the other platform jobs, so a failure shows red without blocking the release or the other artifacts
- Ships `hawkeye-<version>-android-unsigned.apk`, a universal APK with `arm64-v8a` and `x86_64`
- The APK is **unsigned**. There is no signing config or keystore secret in the repo, so it must be signed with your own key before it will install. The filename says so, and the docs give the commands.

## Versioning

- `versionName` comes from the tag via `-PhawkeyeVersionName`, mirroring the `-DHAWKEYE_VERSION` the desktop jobs already pass to CMake. No version is stored in the repo.
- `versionCode` is derived as `major*1000000 + minor*1000 + patch`, so `0.4.0` is `4000` and `1.2.3` is `1002003`
- Parsed strictly: a malformed tag fails the build instead of silently shipping a version code lower than the previous release
- Local builds fall back to `0.0.0-dev`, so `assembleDebug` needs no flags

## CI

- APK verification lives in `android/scripts/verify-release-apk.sh` and is run by both the release job and a new `release-build` job on pushes to main, so the tag-time path is exercised before a tag exists rather than first running on a live release
- Checks both ABIs, all four asset trees, and the recorded version, resolving the APK from AGP's `output-metadata.json` rather than globbing
- Shared toolchain setup extracted into `.github/actions/setup-android-build`, pinning the NDK and CMake versions in one place. `android.yml` drops from 133 to 90 lines.
- Path filter widened to the repo-root `src/`, `lib/`, and asset directories, which the native library and assets actually depend on. A desktop-side change could previously break the Android build with no CI signal.

## Docs

- New Releasing page covering the tag-driven release, every artifact, and version derivation
- Android sections on the install page, in the root README, and in troubleshooting
- Release build, version contract, and signing steps in the Android README

## Drive-by fixes

- The documented `.deb` install globbed `hawkeye-*.deb` against an artifact named `hawkeye_0.3.0_amd64.deb`, so the command never worked
- `Loading flight logs` in the Android README described an `IntentRouterActivity` and VIEW/SEND intent handling that do not exist in the manifest, and claimed there was no in-app file picker when there is one. Rewritten against the actual import path.
- `Requirements` conflated `minSdk 29` with the SDK you need to build, and implied CMake accepted a version range

## Verification

- Full release build from a clean state, plus the derivation across `0.4.0`, `1.2.3`, `1.0.100` vs `1.1.0` (previously colliding), `1.2.3-rc1`, and the no-property fallback
- Malformed inputs (`2024-06`, `1.x.3`) confirmed to fail the build
- Verify script self-tested on both the passing and failing path
- `apksigner verify` confirms the APK is unsigned as intended
- Docs site builds; artifact table cross-checked against the real v0.3.0 assets

The one line not exercised is `gh release upload`, which only runs on a real tag. It is identical to the four existing upload steps, and a failure leaves the release and all other assets intact.