### PR TITLE
Android release signing, AAB build, and prerelease version codes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -71,6 +71,12 @@ jobs:
     # release job runs.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # The secrets context is unavailable in every if condition, job-level and step-level
+    # alike, so presence is computed here as a boolean: the expression result is the
+    # string "true" or "false", which is all the later guards need, and no secret
+    # material lands in any step's environment.
+    env:
+      HAS_UPLOAD_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -81,14 +87,13 @@ jobs:
         with:
           cxx-cache-prefix: ndk-release
 
-      # The keystore secret is scoped to this one step (the secrets context is valid in a
-      # step-level if, just not a job-level one); later steps branch on the
+      # The keystore secret itself is scoped to this one step; later steps branch on the
       # HAWKEYE_UPLOAD_KEYSTORE path this step exports rather than re-reading the secret,
       # so no other step, including third-party actions, ever sees the keystore. Forks
       # have no secrets, skip this step, and build unsigned, exactly like a local
       # checkout.
       - name: Decode upload keystore
-        if: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 != '' }}
+        if: env.HAS_UPLOAD_KEYSTORE == 'true'
         env:
           UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,6 +45,13 @@ jobs:
 
       - uses: ./.github/actions/setup-android-build
 
+      # build-logic is an included build, so its tests are not reached by any app-side
+      # Gradle task and have to be invoked explicitly. They gate the versionCode
+      # derivation the release artifacts depend on.
+      - name: Build-logic tests
+        working-directory: android
+        run: ./gradlew -p build-logic :convention:test
+
       - name: Build
         working-directory: android
         run: ./gradlew assembleDebug

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,15 +59,11 @@ jobs:
   release-build:
     name: Release build
     # Skipped on pull requests to keep review turnaround fast. Runs on pushes to main and
-    # on workflow_dispatch so the tasks release.yml depends on are exercised before any
-    # tag is pushed, and so the ndk-release-* cache is warm when the release job runs.
+    # on workflow_dispatch so the tasks the tag-driven release path depends on are
+    # exercised before any tag is pushed, and so the ndk-release-* cache is warm when the
+    # release job runs.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    # The secrets context is unavailable in a job-level if, so the keystore is routed
-    # through the job env and the signing steps are guarded on it. Forks have no secrets
-    # and build unsigned, exactly like a local checkout.
-    env:
-      UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}
 
     steps:
       - uses: actions/checkout@v4
@@ -78,8 +74,16 @@ jobs:
         with:
           cxx-cache-prefix: ndk-release
 
+      # The keystore secret is scoped to this one step (the secrets context is valid in a
+      # step-level if, just not a job-level one); later steps branch on the
+      # HAWKEYE_UPLOAD_KEYSTORE path this step exports rather than re-reading the secret,
+      # so no other step, including third-party actions, ever sees the keystore. Forks
+      # have no secrets, skip this step, and build unsigned, exactly like a local
+      # checkout.
       - name: Decode upload keystore
-        if: env.UPLOAD_KEYSTORE_B64 != ''
+        if: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 != '' }}
+        env:
+          UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}
         run: |
           printf '%s' "$UPLOAD_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
           echo "HAWKEYE_UPLOAD_KEYSTORE=$RUNNER_TEMP/upload-keystore.jks" >> "$GITHUB_ENV"
@@ -91,19 +95,30 @@ jobs:
           HAWKEYE_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
         run: ./gradlew assembleRelease bundleRelease -PhawkeyeVersionName=0.0.0-ci
 
-      # The same verification the release job runs. This is the only genuinely new shell
-      # in the release path, so exercising it here is the point of this job.
+      # The verification the tag-driven release path runs (release.yml adopts the signed
+      # and bundle checks in the follow-up that adds its keystore). These scripts are the
+      # only genuinely new shell in the release path, so exercising them here is the
+      # point of this job.
       - name: Verify APK
         run: |
-          if [ -n "$UPLOAD_KEYSTORE_B64" ]; then
+          if [ -n "${HAWKEYE_UPLOAD_KEYSTORE:-}" ]; then
             android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.0.0-ci --signed
           else
             android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.0.0-ci
           fi
 
       - name: Verify AAB
-        run: android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
+        run: |
+          if [ -n "${HAWKEYE_UPLOAD_KEYSTORE:-}" ]; then
+            android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab --signed
+          else
+            android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
+          fi
 
+      # On the signed path this artifact carries the real upload-key signature. That is
+      # deliberate: it is a rehearsal build with versionCode 1, so it cannot install over
+      # any real release, and a signature exposes only the certificate, which ships in
+      # every published APK anyway.
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,10 +59,15 @@ jobs:
   release-build:
     name: Release build
     # Skipped on pull requests to keep review turnaround fast. Runs on pushes to main and
-    # on workflow_dispatch so the task release.yml depends on is exercised before any tag
-    # is pushed, and so the ndk-release-* cache is warm when the release job runs.
+    # on workflow_dispatch so the tasks release.yml depends on are exercised before any
+    # tag is pushed, and so the ndk-release-* cache is warm when the release job runs.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # The secrets context is unavailable in a job-level if, so the keystore is routed
+    # through the job env and the signing steps are guarded on it. Forks have no secrets
+    # and build unsigned, exactly like a local checkout.
+    env:
+      UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}
 
     steps:
       - uses: actions/checkout@v4
@@ -73,14 +78,31 @@ jobs:
         with:
           cxx-cache-prefix: ndk-release
 
-      - name: Build release APK
+      - name: Decode upload keystore
+        if: env.UPLOAD_KEYSTORE_B64 != ''
+        run: |
+          printf '%s' "$UPLOAD_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+          echo "HAWKEYE_UPLOAD_KEYSTORE=$RUNNER_TEMP/upload-keystore.jks" >> "$GITHUB_ENV"
+
+      - name: Build release APK and AAB
         working-directory: android
-        run: ./gradlew assembleRelease -PhawkeyeVersionName=0.0.0-ci
+        env:
+          HAWKEYE_UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
+          HAWKEYE_UPLOAD_KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
+        run: ./gradlew assembleRelease bundleRelease -PhawkeyeVersionName=0.0.0-ci
 
       # The same verification the release job runs. This is the only genuinely new shell
       # in the release path, so exercising it here is the point of this job.
       - name: Verify APK
-        run: android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.0.0-ci
+        run: |
+          if [ -n "$UPLOAD_KEYSTORE_B64" ]; then
+            android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.0.0-ci --signed
+          else
+            android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.0.0-ci
+          fi
+
+      - name: Verify AAB
+        run: android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ build-release/
 .dmux-hooks/
 
 # Android
+*.jks
+*.keystore
 android/local.properties
 android/.gradle/
 android/app/build/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,47 +8,10 @@ plugins {
 val hawkeyeVersionName: String =
     providers.gradleProperty("hawkeyeVersionName").getOrElse("0.0.0-dev")
 
-// Monotonic code derived from the semver: 0.4.0-rc1 -> 400001, 0.4.0 -> 400099,
-// 1.2.3 -> 100200399. The rc component orders every prerelease below its final
-// release, so both can ship to Google Play, which refuses a version code it has
-// already seen.
-//
-// Parsed strictly. A malformed version has to fail the build rather than degrade to a
-// low code, because Android refuses any upgrade whose version code is not greater than
-// the installed one, and a silently-wrong code would ship in a release.
-val hawkeyeVersionCode: Int = run {
-    val base = hawkeyeVersionName.substringBefore('-')
-    val suffix = hawkeyeVersionName.substringAfter('-', missingDelimiterValue = "")
-    val parts = base.split('.')
-    require(parts.size == 3) {
-        "hawkeyeVersionName must be MAJOR.MINOR.PATCH with an optional -suffix, got '$hawkeyeVersionName'"
-    }
-    val (major, minor, patch) = parts.map { part ->
-        part.toIntOrNull()?.takeIf { it in 0..999 }
-            ?: error("hawkeyeVersionName component '$part' is not an integer in 0..999, from '$hawkeyeVersionName'")
-    }
-    // The 100_000_000 radix overflows Google Play's version code cap of 2,100,000,000
-    // once major exceeds 20.
-    require(major <= 20) {
-        "hawkeyeVersionName major '$major' pushes the version code past Google Play's cap, from '$hawkeyeVersionName'"
-    }
-    // A final release takes 99 so it sorts above every rc of the same version; dev and
-    // ci builds take 0 so they sort below both. The empty-suffix branch also requires
-    // the absence of a '-', because a trailing-hyphen name like "0.4.0-" would otherwise
-    // silently take the final release's code and burn it on Google Play.
-    val rc = when {
-        suffix.isEmpty() && '-' !in hawkeyeVersionName -> 99
-        suffix == "dev" || suffix == "ci" -> 0
-        suffix.matches(Regex("rc[1-9][0-9]?")) ->
-            suffix.removePrefix("rc").toInt().also {
-                require(it <= 98) { "rc99 collides with the final release's version code, from '$hawkeyeVersionName'" }
-            }
-        else -> error("hawkeyeVersionName suffix '$suffix' is not rc1..rc98, dev, or ci, from '$hawkeyeVersionName'")
-    }
-    // 0.0.0-dev (the local fallback above) and CI's 0.0.0-ci both compute to 0, so the
-    // floor of 1 covers them both.
-    (major * 100_000_000 + minor * 100_000 + patch * 100 + rc).coerceAtLeast(1)
-}
+// Monotonic code derived from the semver: 0.4.0-rc1 -> 400001, 0.4.0 -> 400099. The
+// derivation and its rules live in build-logic (VersionCode.kt) behind a unit test,
+// because a silently wrong code would brick upgrades and ship in a release.
+val hawkeyeVersionCode: Int = com.px4.hawkeye.buildlogic.hawkeyeVersionCode(hawkeyeVersionName)
 
 // Release signing activates only when the environment provides an upload keystore
 // (HAWKEYE_UPLOAD_KEYSTORE is a path to a decoded .jks). CI injects it from repository

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,26 +33,30 @@ val hawkeyeVersionCode: Int = run {
         "hawkeyeVersionName major '$major' pushes the version code past Google Play's cap, from '$hawkeyeVersionName'"
     }
     // A final release takes 99 so it sorts above every rc of the same version; dev and
-    // ci builds take 0 so they sort below both.
+    // ci builds take 0 so they sort below both. The empty-suffix branch also requires
+    // the absence of a '-', because a trailing-hyphen name like "0.4.0-" would otherwise
+    // silently take the final release's code and burn it on Google Play.
     val rc = when {
-        suffix.isEmpty() -> 99
+        suffix.isEmpty() && '-' !in hawkeyeVersionName -> 99
         suffix == "dev" || suffix == "ci" -> 0
         suffix.matches(Regex("rc[1-9][0-9]?")) ->
             suffix.removePrefix("rc").toInt().also {
                 require(it <= 98) { "rc99 collides with the final release's version code, from '$hawkeyeVersionName'" }
             }
-        else -> error("hawkeyeVersionName suffix '$suffix' is not rcN, dev, or ci, from '$hawkeyeVersionName'")
+        else -> error("hawkeyeVersionName suffix '$suffix' is not rc1..rc98, dev, or ci, from '$hawkeyeVersionName'")
     }
-    // 0.0.0-dev is only reachable via the dev fallback above, which needs a floor of 1.
+    // 0.0.0-dev (the local fallback above) and CI's 0.0.0-ci both compute to 0, so the
+    // floor of 1 covers them both.
     (major * 100_000_000 + minor * 100_000 + patch * 100 + rc).coerceAtLeast(1)
 }
 
 // Release signing activates only when the environment provides an upload keystore
 // (HAWKEYE_UPLOAD_KEYSTORE is a path to a decoded .jks). CI injects it from repository
 // secrets; local and PR builds have none and keep producing an unsigned release APK.
-val uploadKeystore = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE")
-val uploadKeystorePassword = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE_PASSWORD")
-val uploadKeyAlias = providers.environmentVariable("HAWKEYE_UPLOAD_KEY_ALIAS")
+// Blank counts as absent because a workflow env mapping of an unset secret yields an
+// empty string, and that case has to stay on the unsigned path.
+val uploadKeystorePath: String? = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE")
+    .orNull?.takeIf { it.isNotBlank() }
 
 android {
     namespace = "com.px4.hawkeye.android"
@@ -81,29 +85,40 @@ android {
 
         externalNativeBuild {
             cmake {
-                // Changing this list means updating android/scripts/verify-release-apk.sh
-                // and the ABI list documented in docs/installation.md,
-                // docs/developer/releasing.md, docs/troubleshooting.md, and README.md.
+                // Changing this list means updating android/scripts/verify-release-apk.sh,
+                // android/scripts/verify-release-bundle.sh, and the ABI list documented
+                // in docs/installation.md, docs/developer/releasing.md,
+                // docs/troubleshooting.md, and README.md.
                 abiFilters += listOf("arm64-v8a", "x86_64")
             }
         }
     }
 
     signingConfigs {
-        if (uploadKeystore.isPresent) {
+        if (uploadKeystorePath != null) {
+            val password = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE_PASSWORD").orNull
+            val alias = providers.environmentVariable("HAWKEYE_UPLOAD_KEY_ALIAS").orNull
+            // Checked here rather than left to .get() so a half-configured environment
+            // fails at configuration time with the trio contract spelled out, not deep
+            // in :app:packageRelease. isNullOrEmpty, not isPresent: an env mapping of an
+            // unset secret arrives as an empty string.
+            require(!password.isNullOrEmpty() && !alias.isNullOrEmpty()) {
+                "HAWKEYE_UPLOAD_KEYSTORE is set, so HAWKEYE_UPLOAD_KEYSTORE_PASSWORD and " +
+                    "HAWKEYE_UPLOAD_KEY_ALIAS must be set too"
+            }
             create("upload") {
-                storeFile = file(uploadKeystore.get())
-                storePassword = uploadKeystorePassword.get()
-                keyAlias = uploadKeyAlias.get()
+                storeFile = file(uploadKeystorePath)
+                storePassword = password
+                keyAlias = alias
                 // The upload keystore is PKCS12, which has a single password.
-                keyPassword = uploadKeystorePassword.get()
+                keyPassword = password
             }
         }
     }
 
     buildTypes {
         release {
-            if (uploadKeystore.isPresent) {
+            if (uploadKeystorePath != null) {
                 signingConfig = signingConfigs.getByName("upload")
             }
             isMinifyEnabled = false

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,13 +8,18 @@ plugins {
 val hawkeyeVersionName: String =
     providers.gradleProperty("hawkeyeVersionName").getOrElse("0.0.0-dev")
 
-// Monotonic code derived from the semver: 0.4.0 -> 4000, 1.2.3 -> 1002003.
+// Monotonic code derived from the semver: 0.4.0-rc1 -> 400001, 0.4.0 -> 400099,
+// 1.2.3 -> 100200399. The rc component orders every prerelease below its final
+// release, so both can ship to Google Play, which refuses a version code it has
+// already seen.
 //
 // Parsed strictly. A malformed version has to fail the build rather than degrade to a
 // low code, because Android refuses any upgrade whose version code is not greater than
 // the installed one, and a silently-wrong code would ship in a release.
 val hawkeyeVersionCode: Int = run {
-    val parts = hawkeyeVersionName.substringBefore('-').split('.')
+    val base = hawkeyeVersionName.substringBefore('-')
+    val suffix = hawkeyeVersionName.substringAfter('-', missingDelimiterValue = "")
+    val parts = base.split('.')
     require(parts.size == 3) {
         "hawkeyeVersionName must be MAJOR.MINOR.PATCH with an optional -suffix, got '$hawkeyeVersionName'"
     }
@@ -22,10 +27,32 @@ val hawkeyeVersionCode: Int = run {
         part.toIntOrNull()?.takeIf { it in 0..999 }
             ?: error("hawkeyeVersionName component '$part' is not an integer in 0..999, from '$hawkeyeVersionName'")
     }
-    // The 1000 radix leaves room for two-digit and three-digit minor/patch numbers.
-    // 0.0.0 is only reachable via the dev fallback above, which needs a floor of 1.
-    (major * 1_000_000 + minor * 1_000 + patch).coerceAtLeast(1)
+    // The 100_000_000 radix overflows Google Play's version code cap of 2,100,000,000
+    // once major exceeds 20.
+    require(major <= 20) {
+        "hawkeyeVersionName major '$major' pushes the version code past Google Play's cap, from '$hawkeyeVersionName'"
+    }
+    // A final release takes 99 so it sorts above every rc of the same version; dev and
+    // ci builds take 0 so they sort below both.
+    val rc = when {
+        suffix.isEmpty() -> 99
+        suffix == "dev" || suffix == "ci" -> 0
+        suffix.matches(Regex("rc[1-9][0-9]?")) ->
+            suffix.removePrefix("rc").toInt().also {
+                require(it <= 98) { "rc99 collides with the final release's version code, from '$hawkeyeVersionName'" }
+            }
+        else -> error("hawkeyeVersionName suffix '$suffix' is not rcN, dev, or ci, from '$hawkeyeVersionName'")
+    }
+    // 0.0.0-dev is only reachable via the dev fallback above, which needs a floor of 1.
+    (major * 100_000_000 + minor * 100_000 + patch * 100 + rc).coerceAtLeast(1)
 }
+
+// Release signing activates only when the environment provides an upload keystore
+// (HAWKEYE_UPLOAD_KEYSTORE is a path to a decoded .jks). CI injects it from repository
+// secrets; local and PR builds have none and keep producing an unsigned release APK.
+val uploadKeystore = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE")
+val uploadKeystorePassword = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE_PASSWORD")
+val uploadKeyAlias = providers.environmentVariable("HAWKEYE_UPLOAD_KEY_ALIAS")
 
 android {
     namespace = "com.px4.hawkeye.android"
@@ -62,8 +89,23 @@ android {
         }
     }
 
+    signingConfigs {
+        if (uploadKeystore.isPresent) {
+            create("upload") {
+                storeFile = file(uploadKeystore.get())
+                storePassword = uploadKeystorePassword.get()
+                keyAlias = uploadKeyAlias.get()
+                // The upload keystore is PKCS12, which has a single password.
+                keyPassword = uploadKeystorePassword.get()
+            }
+        }
+    }
+
     buildTypes {
         release {
+            if (uploadKeystore.isPresent) {
+                signingConfig = signingConfigs.getByName("upload")
+            }
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/android/build-logic/convention/build.gradle.kts
+++ b/android/build-logic/convention/build.gradle.kts
@@ -13,6 +13,17 @@ dependencies {
     compileOnly(libs.android.gradle.plugin)
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.kotlin.compose.compiler.gradle.plugin)
+
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.assertk)
+}
+
+// This is an included build, so these tests are not reached by the app's test task;
+// android.yml runs them explicitly.
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 gradlePlugin {

--- a/android/build-logic/convention/src/main/kotlin/com/px4/hawkeye/buildlogic/VersionCode.kt
+++ b/android/build-logic/convention/src/main/kotlin/com/px4/hawkeye/buildlogic/VersionCode.kt
@@ -1,0 +1,46 @@
+package com.px4.hawkeye.buildlogic
+
+/**
+ * Monotonic Android versionCode derived from the semver versionName:
+ * 0.4.0-rc1 -> 400001, 0.4.0 -> 400099, 1.2.3 -> 100200399.
+ *
+ * The rc component orders every prerelease below its final release, so both can ship to
+ * Google Play, which refuses a version code it has already seen. A final release takes
+ * 99 so it sorts above every rc of the same version; dev and ci builds take 0 so they
+ * sort below both.
+ *
+ * Parsed strictly. A malformed version has to fail the build rather than degrade to a
+ * low code, because Android refuses any upgrade whose version code is not greater than
+ * the installed one, and a silently-wrong code would ship in a release. That includes a
+ * trailing-hyphen name like "0.4.0-", which must not silently take the final release's
+ * code and burn it on Google Play. VersionCodeTest holds the boundary table.
+ */
+fun hawkeyeVersionCode(versionName: String): Int {
+    val base = versionName.substringBefore('-')
+    val suffix = versionName.substringAfter('-', missingDelimiterValue = "")
+    val parts = base.split('.')
+    require(parts.size == 3) {
+        "hawkeyeVersionName must be MAJOR.MINOR.PATCH with an optional -suffix, got '$versionName'"
+    }
+    val (major, minor, patch) = parts.map { part ->
+        part.toIntOrNull()?.takeIf { it in 0..999 }
+            ?: error("hawkeyeVersionName component '$part' is not an integer in 0..999, from '$versionName'")
+    }
+    // The 100_000_000 radix overflows Google Play's version code cap of 2,100,000,000
+    // once major exceeds 20.
+    require(major <= 20) {
+        "hawkeyeVersionName major '$major' pushes the version code past Google Play's cap, from '$versionName'"
+    }
+    val rc = when {
+        suffix.isEmpty() && '-' !in versionName -> 99
+        suffix == "dev" || suffix == "ci" -> 0
+        suffix.matches(Regex("rc[1-9][0-9]?")) ->
+            suffix.removePrefix("rc").toInt().also {
+                require(it <= 98) { "rc99 collides with the final release's version code, from '$versionName'" }
+            }
+        else -> error("hawkeyeVersionName suffix '$suffix' is not rc1..rc98, dev, or ci, from '$versionName'")
+    }
+    // 0.0.0-dev (the local fallback) and CI's 0.0.0-ci both compute to 0, so the floor
+    // of 1 covers them both.
+    return (major * 100_000_000 + minor * 100_000 + patch * 100 + rc).coerceAtLeast(1)
+}

--- a/android/build-logic/convention/src/test/kotlin/com/px4/hawkeye/buildlogic/VersionCodeTest.kt
+++ b/android/build-logic/convention/src/test/kotlin/com/px4/hawkeye/buildlogic/VersionCodeTest.kt
@@ -1,0 +1,78 @@
+package com.px4.hawkeye.buildlogic
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.messageContains
+import org.junit.jupiter.api.Test
+
+class VersionCodeTest {
+
+    @Test
+    fun `final releases take rc component 99`() {
+        assertThat(hawkeyeVersionCode("0.4.0")).isEqualTo(400_099)
+        assertThat(hawkeyeVersionCode("1.2.3")).isEqualTo(100_200_399)
+        // The old scheme shipped v0.3.0 as 3000; every new code must stay above it.
+        assertThat(hawkeyeVersionCode("0.3.0")).isEqualTo(300_099)
+        // Largest representable version stays under Google Play's 2,100,000,000 cap.
+        assertThat(hawkeyeVersionCode("20.999.999")).isEqualTo(2_099_999_999)
+    }
+
+    @Test
+    fun `rc suffixes sort below their final release and above the previous one`() {
+        assertThat(hawkeyeVersionCode("0.4.0-rc1")).isEqualTo(400_001)
+        assertThat(hawkeyeVersionCode("0.4.0-rc98")).isEqualTo(400_098)
+        assertThat(hawkeyeVersionCode("0.4.1-rc1")).isEqualTo(400_101)
+    }
+
+    @Test
+    fun `dev and ci builds floor to 1`() {
+        assertThat(hawkeyeVersionCode("0.0.0-dev")).isEqualTo(1)
+        assertThat(hawkeyeVersionCode("0.0.0-ci")).isEqualTo(1)
+        // A non-zero version with the suffix keeps its computed code.
+        assertThat(hawkeyeVersionCode("0.4.0-dev")).isEqualTo(400_000)
+    }
+
+    @Test
+    fun `trailing hyphen is rejected instead of taking the final release's code`() {
+        assertFailure { hawkeyeVersionCode("0.4.0-") }
+            .messageContains("'0.4.0-'")
+    }
+
+    @Test
+    fun `malformed rc suffixes are rejected`() {
+        assertFailure { hawkeyeVersionCode("0.4.0-rc0") }.messageContains("rc1..rc98")
+        assertFailure { hawkeyeVersionCode("0.4.0-rc01") }.messageContains("rc1..rc98")
+        assertFailure { hawkeyeVersionCode("0.4.0-rc100") }.messageContains("rc1..rc98")
+        assertFailure { hawkeyeVersionCode("0.4.0-RC1") }.messageContains("rc1..rc98")
+        assertFailure { hawkeyeVersionCode("0.4.0-rc1-hotfix") }.messageContains("rc1..rc98")
+    }
+
+    @Test
+    fun `rc99 is rejected because it collides with the final release`() {
+        assertFailure { hawkeyeVersionCode("0.4.0-rc99") }
+            .messageContains("rc99 collides")
+    }
+
+    @Test
+    fun `unknown suffixes are rejected`() {
+        assertFailure { hawkeyeVersionCode("0.4.0-beta1") }.messageContains("beta1")
+        assertFailure { hawkeyeVersionCode("0.4.0-snapshot") }.messageContains("snapshot")
+    }
+
+    @Test
+    fun `major above 20 is rejected to stay under the Play cap`() {
+        assertFailure { hawkeyeVersionCode("21.0.0") }.messageContains("cap")
+    }
+
+    @Test
+    fun `malformed base versions are rejected`() {
+        assertFailure { hawkeyeVersionCode("0.4") }.messageContains("MAJOR.MINOR.PATCH")
+        assertFailure { hawkeyeVersionCode("0.4.0.1") }.messageContains("MAJOR.MINOR.PATCH")
+        assertFailure { hawkeyeVersionCode("a.b.c") }.messageContains("0..999")
+        assertFailure { hawkeyeVersionCode("0.1000.0") }.messageContains("0..999")
+        // The hyphen splits before the base parse, so this fails the shape check.
+        assertFailure { hawkeyeVersionCode("0.-1.0") }.messageContains("MAJOR.MINOR.PATCH")
+        assertFailure { hawkeyeVersionCode("") }.messageContains("MAJOR.MINOR.PATCH")
+    }
+}

--- a/android/scripts/verify-release-apk.sh
+++ b/android/scripts/verify-release-apk.sh
@@ -56,7 +56,9 @@ if [ ! -f "$apk" ]; then
     exit 1
 fi
 
-listing=$(unzip -l "$apk")
+# -Z1 lists bare entry names only; a plain -l listing includes an "Archive: <path>"
+# header, which lets the APK's own on-disk path satisfy an entry check.
+listing=$(unzip -Z1 "$apk")
 for entry in \
     lib/arm64-v8a/libhawkeye.so \
     lib/x86_64/libhawkeye.so \

--- a/android/scripts/verify-release-apk.sh
+++ b/android/scripts/verify-release-apk.sh
@@ -10,20 +10,32 @@
 # Resolves the APK from AGP's output-metadata.json rather than globbing the output
 # directory, so it stays correct if a second variant or an ABI split is ever added.
 #
-# Usage:   verify-release-apk.sh <apk-output-dir> <expected-version-name>
+# With --signed, additionally requires the APK to carry a valid signature, verified by
+# apksigner from the newest installed build-tools.
+#
+# Usage:   verify-release-apk.sh <apk-output-dir> <expected-version-name> [--signed]
 # Example: android/scripts/verify-release-apk.sh android/app/build/outputs/apk/release 0.4.0
 #
 # Prints the resolved APK path on stdout; diagnostics go to stderr.
 
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-    echo "usage: $0 <apk-output-dir> <expected-version-name>" >&2
+usage() {
+    echo "usage: $0 <apk-output-dir> <expected-version-name> [--signed]" >&2
     exit 2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
 fi
 
 output_dir=$1
 expected_version=$2
+signed=0
+if [ "$#" -eq 3 ]; then
+    [ "$3" = "--signed" ] || usage
+    signed=1
+fi
 metadata="${output_dir}/output-metadata.json"
 
 if [ ! -f "$metadata" ]; then
@@ -73,6 +85,21 @@ fi
 if [ "$version_code" -lt 1 ]; then
     echo "versionCode is '${version_code}', which Android will not accept" >&2
     exit 1
+fi
+
+if [ "$signed" -eq 1 ]; then
+    sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+    if [ -z "$sdk" ] || [ ! -d "${sdk}/build-tools" ]; then
+        echo "--signed needs ANDROID_SDK_ROOT or ANDROID_HOME pointing at an SDK with build-tools" >&2
+        exit 1
+    fi
+    # Any recent apksigner can verify; the newest installed build-tools wins.
+    apksigner=$(find "${sdk}/build-tools" -maxdepth 2 -name apksigner | sort -V | tail -n 1)
+    if [ -z "$apksigner" ]; then
+        echo "no apksigner found under ${sdk}/build-tools" >&2
+        exit 1
+    fi
+    "$apksigner" verify --print-certs "$apk" >&2
 fi
 
 echo "$apk"

--- a/android/scripts/verify-release-bundle.sh
+++ b/android/scripts/verify-release-bundle.sh
@@ -7,26 +7,41 @@
 # materialize them). Version checks live in verify-release-apk.sh, which reads them
 # from the same Gradle invocation that produced this bundle.
 #
-# Usage:   verify-release-bundle.sh <path-to-aab>
+# With --signed, additionally requires a verifiable jar signature. Bundles are jar-signed
+# with the upload key, and Google Play rejects an AAB whose signature does not match the
+# registered upload certificate, so this is the check that has to pass before an upload.
+#
+# Usage:   verify-release-bundle.sh <path-to-aab> [--signed]
 # Example: android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
 #
 # Prints the bundle path on stdout; diagnostics go to stderr.
 
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-    echo "usage: $0 <path-to-aab>" >&2
+usage() {
+    echo "usage: $0 <path-to-aab> [--signed]" >&2
     exit 2
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    usage
 fi
 
 aab=$1
+signed=0
+if [ "$#" -eq 2 ]; then
+    [ "$2" = "--signed" ] || usage
+    signed=1
+fi
 
 if [ ! -f "$aab" ]; then
     echo "no bundle at ${aab}; was bundleRelease run?" >&2
     exit 1
 fi
 
-listing=$(unzip -l "$aab")
+# -Z1 lists bare entry names only; a plain -l listing includes an "Archive: <path>"
+# header, which lets the bundle's own on-disk path satisfy an entry check.
+listing=$(unzip -Z1 "$aab")
 for entry in \
     base/lib/arm64-v8a/libhawkeye.so \
     base/lib/x86_64/libhawkeye.so \
@@ -41,6 +56,26 @@ for entry in \
         exit 1
     fi
 done
+
+if [ "$signed" -eq 1 ]; then
+    if command -v jarsigner >/dev/null 2>&1; then
+        jarsigner=jarsigner
+    elif [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/jarsigner" ]; then
+        jarsigner="${JAVA_HOME}/bin/jarsigner"
+    else
+        echo "--signed needs jarsigner on PATH or JAVA_HOME pointing at a JDK" >&2
+        exit 1
+    fi
+    # jarsigner exits 0 even for an unsigned jar (it just prints "jar is unsigned."),
+    # so the verdict line is the actual check. -strict is avoided deliberately: it
+    # fails on the self-signed certificate every Android upload key has.
+    verdict=$("$jarsigner" -verify "$aab")
+    printf '%s\n' "$verdict" >&2
+    if ! grep -qF "jar verified" <<<"$verdict"; then
+        echo "bundle is unsigned or its signature does not verify" >&2
+        exit 1
+    fi
+fi
 
 echo "${aab}: both ABIs and all four asset trees present" >&2
 echo "$aab"

--- a/android/scripts/verify-release-bundle.sh
+++ b/android/scripts/verify-release-bundle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Verifies a release AAB without needing bundletool or a device.
+#
+# Checks that both ABIs and all four asset trees made it into the bundle (the assets
+# are symlinks into the repo root, so this catches a checkout that failed to
+# materialize them). Version checks live in verify-release-apk.sh, which reads them
+# from the same Gradle invocation that produced this bundle.
+#
+# Usage:   verify-release-bundle.sh <path-to-aab>
+# Example: android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
+#
+# Prints the bundle path on stdout; diagnostics go to stderr.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <path-to-aab>" >&2
+    exit 2
+fi
+
+aab=$1
+
+if [ ! -f "$aab" ]; then
+    echo "no bundle at ${aab}; was bundleRelease run?" >&2
+    exit 1
+fi
+
+listing=$(unzip -l "$aab")
+for entry in \
+    base/lib/arm64-v8a/libhawkeye.so \
+    base/lib/x86_64/libhawkeye.so \
+    base/assets/models/ \
+    base/assets/shaders/ \
+    base/assets/fonts/ \
+    base/assets/themes/ ; do
+    # Herestring rather than a pipe, for the same pipefail reason as in
+    # verify-release-apk.sh.
+    if ! grep -qF "$entry" <<<"$listing"; then
+        echo "bundle is missing ${entry}" >&2
+        exit 1
+    fi
+done
+
+echo "${aab}: both ABIs and all four asset trees present" >&2
+echo "$aab"


### PR DESCRIPTION
Adds the repository half of the signing work tracked in #106.

- Release builds sign with an upload keystore when the environment provides one (`HAWKEYE_UPLOAD_KEYSTORE`, `HAWKEYE_UPLOAD_KEYSTORE_PASSWORD`, `HAWKEYE_UPLOAD_KEY_ALIAS`). Local, PR, and fork builds have no keystore and keep producing an unsigned APK, exactly as before.
- versionCode gains a prerelease component: `major*100000000 + minor*100000 + patch*100 + rc`, where a final release takes 99, `rcN` takes N (1..98), and `dev`/`ci` builds take 0. `v0.4.0-rc1` now yields 400001 instead of colliding with `v0.4.0` (400099), which unblocks rc tags and Google Play uploads. Major is capped at 20 to stay under Play's version code ceiling of 2,100,000,000.
- `verify-release-apk.sh` accepts `--signed`, which runs `apksigner verify` from the newest installed build-tools.
- New `verify-release-bundle.sh` asserts the AAB contains both ABIs and all four asset trees.
- The `android.yml` `release-build` job now runs `assembleRelease bundleRelease`, decodes the keystore from the `ANDROID_UPLOAD_KEYSTORE_BASE64` secret when present, and verifies both artifacts, so the entire signing and bundling path is exercised on pushes to main before any tag exists.

Verified locally:

- Unsigned build of `0.4.0-rc1` passes the existing checks with versionCode 400001.
- `--signed` fails on an unsigned APK (`DOES NOT VERIFY`) and passes on a build signed with a throwaway test keystore.
- The AAB check passes on a real `bundleRelease` output and fails when pointed at an APK.
- Suffix parsing rejects `beta1`, `rc0`, `rc99`, and major 21 with clear messages; `rc1`, finals, `dev`, `ci`, and `20.999.999` configure cleanly.

The release.yml changes that consume this (signed asset name, Play upload) come in a follow-up so this lands independently. Part of #106.
