### PR TITLE
Publish rc tags as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,17 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # gh release create infers nothing from the tag name, so without this an rc tag
+          # publishes as a full release and GitHub serves it as Latest to everyone. Any
+          # suffix after the patch version marks a prerelease; a bare MAJOR.MINOR.PATCH is
+          # the only final form.
+          case "$VERSION" in
+            *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Create source tarball
         id: tarball
@@ -45,7 +55,8 @@ jobs:
         run: |
           gh release create ${{ github.ref_name }} \
             --title "${{ github.ref_name }}" \
-            --generate-notes
+            --generate-notes \
+            --prerelease=${{ steps.version.outputs.prerelease }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -21,6 +21,10 @@ git push origin v0.4.0
 The workflow creates the GitHub release immediately, then each platform job uploads its artifact as it finishes.
 The release is published rather than drafted, because the macOS bottle build needs the source tarball URL to be publicly fetchable.
 
+A tag carrying a suffix, such as `v0.4.0-rc2`, is published as a prerelease; a bare `vMAJOR.MINOR.PATCH` tag is published as a full release.
+`gh release create` does not infer this from the tag, so the workflow derives it from the version string and passes `--prerelease` explicitly.
+This is what keeps an rc off the repository's "Latest release" slot, which is where the README download links and anyone landing on the releases page are pointed.
+
 ## Release artifacts
 
 A tag produces six assets:


### PR DESCRIPTION
`gh release create` does not infer prerelease status from the tag name, and the workflow never passed the flag, so every tag has been published as a full release.

The visible effect: `v0.4.0-rc2` currently occupies the repository's "Latest release" slot, so a release candidate is being served as the current version to anyone following the README download links or landing on the releases page.

Changes to `release.yml`:

- The version step derives a `prerelease` output from the version string. Any suffix after the patch version marks a prerelease, and a bare `MAJOR.MINOR.PATCH` stays a full release, which matches how the `versionCode` derivation already treats an `rcN` suffix.
- The create step passes `--prerelease=<bool>` explicitly.

`docs/developer/releasing.md` gains a short note on the behavior next to the existing description of how the release is created.

Two things to note:

- This affects new tags only. The published `v0.4.0-rc2` still needs its flag corrected by hand, either in the release UI or with `gh release edit v0.4.0-rc2 --prerelease`.
- Independent of #111 and #112, so this one is based on `main` and can merge in any order.

Verified by parsing the workflow and checking the derived value against every tag form the project uses (`v0.4.0`, `v0.4.0-rc1`, `v1.2.3`, `v10.0.0-rc98`), and by confirming `gh release create` accepts the `--prerelease=<bool>` form.
