### PR TITLE
Privacy policy, and disable cloud backup of flight logs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,17 @@
     <uses-feature android:glEsVersion="0x00030000" android:required="true" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!--
+        Backup is off on purpose. Imported ULog files live in filesDir/library and carry
+        the flight's GPS track, so with Auto Backup enabled a user's flight paths would be
+        copied to their Google Drive. allowBackup="false" stops cloud backup; it does not
+        reliably stop device-to-device transfer on Android 12+, so data_extraction_rules.xml
+        excludes everything from that path too. Re-enabling either means updating
+        docs/privacy.md and the Play Data safety declaration to match.
+    -->
     <application
         android:name=".HawkeyeApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+   Nothing leaves the device. Imported ULog files in filesDir/library carry the flight's
+   GPS track, and the replay library database records the original file names, so neither
+   belongs in a cloud backup or a device transfer.
+
+   android:allowBackup="false" in AndroidManifest.xml already disables cloud backup, but
+   for apps targeting Android 12 or higher it does not reliably disable device-to-device
+   transfer, which varies by manufacturer. These rules close that path explicitly.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/android/feature/about/presentation/src/main/kotlin/com/px4/hawkeye/feature/about/presentation/AboutScreen.kt
+++ b/android/feature/about/presentation/src/main/kotlin/com/px4/hawkeye/feature/about/presentation/AboutScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -93,11 +95,32 @@ fun AboutScreen(
                 header = stringResource(R.string.about_disclaimer_header),
                 body = stringResource(R.string.about_disclaimer_body),
             )
+            PrivacySection()
 
             HorizontalDivider(modifier = Modifier.padding(top = HawkeyeDimens.sectionSpacing))
             LicensesSection(state = state, onAction = onAction)
         }
     }
+}
+
+@Composable
+private fun PrivacySection() {
+    val uriHandler = LocalUriHandler.current
+    val url = stringResource(R.string.about_privacy_url)
+
+    Section(
+        header = stringResource(R.string.about_privacy_header),
+        body = stringResource(R.string.about_privacy_body),
+    )
+    Text(
+        text = stringResource(R.string.about_privacy_link),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button) { uriHandler.openUri(url) }
+            .padding(vertical = HawkeyeDimens.itemSpacing),
+    )
 }
 
 @Composable

--- a/android/feature/about/presentation/src/main/res/values/strings.xml
+++ b/android/feature/about/presentation/src/main/res/values/strings.xml
@@ -12,6 +12,11 @@
     <string name="about_disclaimer_header">Disclaimer</string>
     <string name="about_disclaimer_body">Hawkeye is a visualization and analysis tool. It is not a flight-safety device and is not certified for operational use. Do not make flight decisions based on what it displays. The software is provided \"AS IS\", without warranty of any kind.</string>
 
+    <string name="about_privacy_header">Privacy</string>
+    <string name="about_privacy_body">Hawkeye collects no personal data. Your flight logs and settings stay on this device, and backup to cloud storage is disabled.</string>
+    <string name="about_privacy_link">Read the privacy policy</string>
+    <string name="about_privacy_url" translatable="false">https://px4.github.io/Hawkeye/privacy</string>
+
     <string name="about_licenses_header">Open-source licenses</string>
     <string name="about_licenses_summary">Hawkeye is licensed under BSD-3-Clause and includes the third-party components listed here.</string>
     <string name="about_licenses_show">Show</string>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
           { text: 'Releasing', link: '/developer/releasing' },
         ],
       },
+      { text: 'Privacy Policy', link: '/privacy' },
     ],
 
     socialLinks: [
@@ -84,7 +85,7 @@ export default defineConfig({
     ],
 
     footer: {
-      message: 'Released under the BSD-3-Clause License.',
+      message: 'Released under the BSD-3-Clause License. <a href="/Hawkeye/privacy">Privacy Policy</a>.',
       copyright: 'Copyright © PX4 / Dronecode Foundation',
     },
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -115,6 +115,22 @@ Whoever edits it should keep three things in the description:
 Forks are asked to change their app name, icon, and `applicationId` before publishing, and to carry a non-affiliation notice; the policy they are pointed at is [FORKS.md](https://github.com/PX4/Hawkeye/blob/main/FORKS.md) in the repository root.
 If a listing turns up that misrepresents itself as this app, report it through Google Play's [impersonation report](https://support.google.com/googleplay/android-developer/answer/16341334).
 
+### Privacy policy and Data safety
+
+Google Play requires both a privacy policy URL and a completed Data safety form for every app, including apps that collect nothing, and both must be in place before the app is promoted beyond the internal test track.
+Neither can be scripted; they are filled in by hand in the Play Console.
+
+- The privacy policy URL is <https://px4.github.io/Hawkeye/privacy>, published from [`docs/privacy.md`](../privacy.md).
+- The Data safety form should declare **no data collected and no data shared**.
+
+That declaration holds because of what the app actually does, and it is worth knowing why rather than taking it on faith.
+Google defines collection as transmitting data off the device, and explicitly exempts data that is only processed locally.
+Hawkeye's flight logs, log library, and settings never leave the device: there is no Hawkeye server, no analytics, and no crash reporting, and Android backup is disabled so the platform does not copy them either.
+Live telemetry travels only between the app and the vehicle or simulator the user connected to.
+
+The form and the policy have to agree, since a mismatch is a common cause of listing rejection.
+Anything that changes the answer, in particular adding an analytics, crash-reporting, or advertising dependency, or re-enabling `android:allowBackup`, means updating `docs/privacy.md` and the Data safety form together.
+
 ## Checking a release build before tagging
 
 `.github/workflows/android.yml` has a `release-build` job that runs the same `assembleRelease` and `bundleRelease` tasks and the same verification scripts the release uses, including the signed path when the keystore secrets are present.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,71 @@
+# Privacy Policy
+
+Dronecode Project, Inc. publishes Hawkeye (`com.px4.hawkeye.android`) as an open source project. It is provided at no cost and is intended for use as is.
+
+This policy covers the Hawkeye Android app, the desktop builds for macOS, Linux, and Windows, and the browser replay.
+
+**Effective date: 2026-08-31**
+
+## The short version
+
+Hawkeye collects no personal data. It has no user accounts, no analytics, no crash reporting, no advertising, and no tracking of any kind. Nothing you open in Hawkeye is sent to Dronecode, to PX4, or to any third party, because there is no Hawkeye server to send it to.
+
+## What stays on your device
+
+Everything Hawkeye works with stays on the device you run it on:
+
+- **Flight logs.** ULog files you import are copied into the app's private storage so they can be replayed. **Flight logs contain location data**, including the vehicle's GPS coordinates and its home position, along with the times the flight took place.
+- **Your log library.** A local database records each imported log's original file name, its size, and when you imported it.
+- **Settings.** Your theme, unit preference, and the network port Hawkeye listens on.
+
+This data is read and rendered on the device and is never uploaded. Hawkeye has no share, upload, or export feature.
+
+Android's automatic backup is **disabled** for Hawkeye, so this data is not copied to Google Drive or transferred to a new device. That is a deliberate choice: flight logs contain location traces, and they should not leave your device without you moving them yourself.
+
+You can delete any imported log from within the app, and uninstalling Hawkeye removes all of it.
+
+## Network activity
+
+Hawkeye connects to a vehicle or simulator **that you choose**, over MAVLink on your local network. Two things are worth being precise about:
+
+- Traffic flows in both directions. Hawkeye listens for telemetry, and when a vehicle first responds it sends a small number of telemetry-request commands back to it, asking for the position and attitude messages it needs to draw the scene. It sends no flight or arming commands.
+- That traffic goes only to the address the telemetry came from, meaning your own vehicle or simulator. It never reaches a Dronecode or PX4 server.
+
+While a live session is running, Hawkeye accepts telemetry on all of the device's network interfaces, not only the loopback interface, so that a vehicle elsewhere on your network can reach it. It listens only while you have started a live session.
+
+Hawkeye does not check for updates, download maps, or contact any remote service.
+
+## Android permissions
+
+The Android app declares these permissions:
+
+| Permission | Why it is there |
+| --- | --- |
+| `INTERNET` | Sending and receiving MAVLink telemetry on your local network. |
+| `ACCESS_NETWORK_STATE` | Not used by Hawkeye. Added by the AndroidX media library that plays the background video on the home screen. |
+| `WAKE_LOCK` | Not used by Hawkeye. Added by the same media library. |
+| `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` | Not used by Hawkeye. Added by the AndroidX core library for its own internal messaging. It is signature level, so no other app can hold it. |
+
+Hawkeye requests no permission that Android classes as dangerous. It does not ask for your location, your files, your contacts, your camera, or your microphone. The location data it displays comes from the flight logs you open and from the vehicle you connect to, not from the device's location services.
+
+## Desktop and browser builds
+
+The desktop builds behave the same way: logs are read from the disk you point them at, telemetry stays on your local network, and nothing is uploaded.
+
+The browser replay processes the file you select inside the page itself. The file is not uploaded to a server.
+
+## This website
+
+These docs are published with GitHub Pages, and some pages load images and video from `artifacts.px4.io`. As with any website, those hosts receive standard request information such as your IP address and browser user agent in their server logs. The site sets no analytics or advertising cookies, and its search runs entirely in your browser.
+
+## Children's privacy
+
+Hawkeye is not directed at children under 13, and it collects no personal information from anyone, including children.
+
+## Changes to this policy
+
+If Hawkeye's behavior changes in a way that affects this policy, the policy will be updated here and the effective date above will change.
+
+## Contact
+
+Questions about this policy can go to [info@dronecode.org](mailto:info@dronecode.org), or to an issue on [GitHub](https://github.com/PX4/Hawkeye/issues).

--- a/docs/sitl.md
+++ b/docs/sitl.md
@@ -49,7 +49,7 @@ Hawkeye binds to UDP port 19410 by default.
 PX4 SIH sends `HIL_STATE_QUATERNION` messages to the same port
 The vehicle appears immediately in the Hawkeye window at the origin.
 
-<iframe width="720" height="405" src="https://www.youtube.com/embed/WudOSKFC0pc" frameborder="0" allowfullscreen></iframe>
+<iframe width="720" height="405" src="https://www.youtube-nocookie.com/embed/WudOSKFC0pc" frameborder="0" allowfullscreen></iframe>
 
 _<!-- 08-vid-01: Single vehicle SITL quickstart. -->_
 


### PR DESCRIPTION
Follow-up to #111, stacked on it (needs to be merged first; its base is that branch, so this diff shows only its own changes).

Google Play requires a privacy policy URL and a completed Data safety form for every app, including apps that collect nothing. Hawkeye has neither, and that is what blocks promoting the app past the internal test track. Dronecode's own policy covers its websites rather than its apps, so unlike the security policy in #112 there was nothing to inherit.

Adds `docs/privacy.md`, published at <https://px4.github.io/Hawkeye/privacy>, which is the URL for the Play listing:

- Written from an audit of the built APK rather than the source tree. Two claims about this app were wrong in #112 and caught in review, so every statement here was checked against the artifact.
- States the four permissions the shipped APK actually carries and attributes `ACCESS_NETWORK_STATE`, `WAKE_LOCK`, and the signature-level receiver permission to the media and AndroidX libraries, since Hawkeye does not use them.
- Describes the MAVLink listener as it behaves: bound on all interfaces, sending telemetry-request commands back to whichever vehicle answered, and reaching no Dronecode or PX4 server. It does not claim there is no outbound traffic.
- Covers the desktop and browser builds too, not just Android.
- Leaves out cookies, Play Services, service providers, and log collection. None apply, and a policy that contradicts the Data safety form is a common cause of rejection.

**Disables backup, which is the one behavior change here.** The app shipped with `allowBackup="true"` and both backup rule files left as unmodified AGP templates, so the default scope applied. That made imported ULog files, which carry the flight's GPS track, and the log library database eligible for copying to the user's Google Drive.

- `android:allowBackup="false"` stops cloud backup.
- That alone is not enough. Android's documentation notes that for apps targeting Android 12 or higher it "disables cloud-based backup and restore ... but doesn't disable device-to-device transfers" on some manufacturers' devices, and `targetSdk` is 36. So `data_extraction_rules.xml` now excludes every domain from both `cloud-backup` and `device-transfer`.
- Tradeoff: settings no longer restore on device migration. Logs can be re-imported from wherever they came from, and the per-app backup quota made log backup unreliable anyway.

Also:

- The SITL video embed moves to `youtube-nocookie.com`, so the site hosting the policy sets no third-party tracking cookies and the policy needs no cookie section.
- The About screen from #111 links the policy.
- `releasing.md` records the Play Console steps and why the no-data-collected declaration holds: Google defines collection as transmitting off-device and exempts data processed only locally.

Verified by rebuilding and checking the packaged manifest shows `allowBackup="false"` with both exclusion sections present, confirming the policy's permission table matches `aapt2 dump permissions` on the release APK, building the docs site and checking the page renders and is reachable from sidebar and footer, and running the Android unit tests.

One thing worth a maintainer's confirmation before the listing goes live: the policy names "Dronecode Project, Inc." with `info@dronecode.org`, matching QGroundControl's app policy exactly. Worth confirming that is the right entity and contact for Hawkeye too.
