### PR TITLE
Name PX4 Development Team as the copyright holder

### DIFF
--- a/FORKS.md
+++ b/FORKS.md
@@ -36,7 +36,7 @@ Describing accurately where your work came from is normal, expected, and encoura
 
 - "based on Hawkeye", "a fork of Hawkeye", "compatible with Hawkeye"
 - Linking back to this repository
-- Keeping our copyright notices in the source, as the license requires
+- Keeping [LICENSE](LICENSE) and [NOTICE.md](NOTICE.md) intact, as the license requires
 - Private builds, internal builds, and research builds you do not publish under a confusable identity
 
 The line is between describing a relationship and claiming an identity. The first is fine; the second is what we are asking you to avoid.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, MAVLink Development Team
+Copyright (c) 2026, PX4 Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -86,7 +86,7 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the BSD-3-Clause License. <a href="/Hawkeye/privacy">Privacy Policy</a>.',
-      copyright: 'Copyright © PX4 / Dronecode Foundation',
+      copyright: 'Copyright © 2026 PX4 Development Team',
     },
 
     search: {


### PR DESCRIPTION
`LICENSE` line 3 read `Copyright (c) 2025, MAVLink Development Team`. That name appeared nowhere else in the repository, matched no contributor, and matched no sibling project, and the year was wrong: the initial commit is from March 2026. It was written once in the root commit and never revisited, which is consistent with scaffolding boilerplate.

Confirmed with the team that it should read `PX4 Development Team`, matching what PX4-Autopilot uses in the same org.

Three one-line changes:

- `LICENSE`: holder becomes `PX4 Development Team` and the year becomes 2026. The format now matches PX4-Autopilot's exactly.
- `docs/.vitepress/config.ts`: the docs footer claimed a third holder again, "PX4 / Dronecode Foundation". It now agrees with `LICENSE`.
- `FORKS.md`: the "what is always fine" list told forks to keep "our copyright notices in the source", but there are no per-file copyright headers or SPDX tags anywhere in the tree, so it asked for something that does not exist. It now points at `LICENSE` and `NOTICE.md`, which is what the license actually requires.

`docs/privacy.md` is deliberately left alone. It names Dronecode Project, Inc. as the entity that publishes the app, which is a separate claim from who holds copyright, and it is still accurate.

Worth knowing for context, since it shaped the choice of name: Hawkeye has no CLA and no DCO sign-off, so contributors retain their own copyright by default. Naming Dronecode in `LICENSE` would have asserted an assignment that never happened, whereas "&lt;Project&gt; Development Team" is conventional shorthand for the project's contributors.

Nothing in the license text itself changed beyond the holder line, so the repository is still detected as BSD-3-Clause. Verified by rebuilding the docs and confirming the new footer renders.
