### PR TITLE
feat: crash reporting via Firebase Crashlytics

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -77,6 +77,7 @@ jobs:
     # material lands in any step's environment.
     env:
       HAS_UPLOAD_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 != '' }}
+      HAS_FIREBASE_CONFIG: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +100,17 @@ jobs:
         run: |
           printf '%s' "$UPLOAD_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
           echo "HAWKEYE_UPLOAD_KEYSTORE=$RUNNER_TEMP/upload-keystore.jks" >> "$GITHUB_ENV"
+
+      # Unlike the keystore, this has to land inside the tree: the google-services plugin
+      # reads app/google-services.json and nothing else. It is gitignored, and the step is
+      # skipped on forks, which then build with Crashlytics dormant. This job does not
+      # upload symbols — only a real release does — but it does exercise the Firebase
+      # plugin path so a tag is never the first time it runs.
+      - name: Decode Firebase config
+        if: env.HAS_FIREBASE_CONFIG == 'true'
+        env:
+          FIREBASE_CONFIG_B64: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON }}
+        run: printf '%s' "$FIREBASE_CONFIG_B64" | base64 -d > android/app/google-services.json
 
       - name: Build release APK and AAB
         working-directory: android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,8 @@ jobs:
     env:
       HAS_UPLOAD_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 != '' }}
       HAS_PLAY_SERVICE_ACCOUNT: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+      HAS_FIREBASE_CONFIG: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON != '' }}
+      HAS_FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -343,6 +345,15 @@ jobs:
         run: |
           printf '%s' "$UPLOAD_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
           echo "HAWKEYE_UPLOAD_KEYSTORE=$RUNNER_TEMP/upload-keystore.jks" >> "$GITHUB_ENV"
+
+      # Unlike the keystore, this has to land inside the tree: the google-services plugin
+      # reads app/google-services.json and nothing else. It is gitignored, and a fork
+      # without the secret skips this step and ships with Crashlytics dormant.
+      - name: Decode Firebase config
+        if: env.HAS_FIREBASE_CONFIG == 'true'
+        env:
+          FIREBASE_CONFIG_B64: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON }}
+        run: printf '%s' "$FIREBASE_CONFIG_B64" | base64 -d > android/app/google-services.json
 
       - name: Build release APK and AAB
         working-directory: android
@@ -375,6 +386,29 @@ jobs:
           else
             android/scripts/verify-release-bundle.sh android/app/build/outputs/bundle/release/app-release.aab
           fi
+
+      # Without this, a native crash in the renderer arrives as raw hex addresses. The
+      # unstripped libhawkeye.so only exists in this job's build tree, so the symbols have
+      # to be sent from here, and before the APK is published rather than after, so a
+      # failure stops the release instead of shipping an unsymbolicated one. The service
+      # account is scoped to this step, the only one that consumes it.
+      - name: Upload native symbols to Crashlytics
+        # Both secrets, not just the config: this step runs between verifying the AAB and
+        # publishing the APK, so failing here on a missing service account would strand a
+        # tag half-released. Absent either secret the release simply ships unsymbolicated.
+        if: env.HAS_FIREBASE_CONFIG == 'true' && env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        working-directory: android
+        env:
+          VERSION: ${{ needs.source-tarball.outputs.version }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          # Trap rather than a trailing rm, so the key is shredded even when the upload
+          # fails and the shell exits early.
+          trap 'rm -f "$RUNNER_TEMP/firebase-sa.json"' EXIT
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/firebase-sa.json"
+          GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/firebase-sa.json" \
+            ./gradlew uploadCrashlyticsSymbolFileRelease -PhawkeyeVersionName="$VERSION"
 
       - name: Upload APK to release
         run: gh release upload "${{ github.ref_name }}" "${{ steps.apk.outputs.file }}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build-tests/
 # Android
 *.jks
 *.keystore
+# Firebase config for the Dronecode project. CI injects it from a repository secret;
+# it is deliberately absent from the tree so forks build with Crashlytics dormant.
+android/app/google-services.json
 android/local.properties
 android/.gradle/
 android/app/build/

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -9,6 +9,192 @@ This file lists the third-party components Hawkeye builds against or ships, and 
 | MAVLink generated C library (`c_library_v2`) | MIT (generator output exception) | Git submodule at `lib/c_library_v2` |
 | Vehicle 3D models in `models/`         | BSD-3-Clause           | Derived from PX4/jMAVSim assets          |
 | JetBrains Mono, Inter                  | SIL OFL 1.1            | Bundled fonts in `fonts/`                |
+| Android libraries (AndroidX, Jetpack Compose, Kotlin, Koin, Firebase Crashlytics) | Apache-2.0 | Maven dependencies of the Android app only |
+
+## Android libraries
+
+The Android app depends on AndroidX and Jetpack Compose, the Kotlin standard library and coroutines, Room, DataStore, Media3, Koin, and the Firebase Crashlytics SDK. All are distributed under the Apache License 2.0, reproduced below. None of them are part of the desktop or browser builds.
+
+Firebase Crashlytics is worth naming separately because it is the only dependency that sends anything off the device. What it transmits, and how to turn it off, are described in the [privacy policy](https://px4.github.io/Hawkeye/privacy).
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+```
 
 ## raylib
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,6 @@ Hawkeye visualizes and analyzes flight data. It sends no flight or arming comman
 
 Generally out of scope: issues that require an attacker to already control the device, and the absence of authentication in the MAVLink protocol itself, which is a property of the protocol rather than a defect in Hawkeye.
 
-Hawkeye bundles no analytics and no crash reporting, and sends no data to the Hawkeye project or the Dronecode Foundation. Its network traffic goes only to the vehicle or simulator you connect it to.
+Hawkeye bundles no analytics. The Android app reports crashes to Firebase Crashlytics, in a Firebase project held by the Dronecode Foundation, and a report carries the failure, device state, and an installation identifier but nothing from a flight log; it can be turned off in Settings, and the desktop and browser builds have no crash reporting at all. See the [privacy policy](https://px4.github.io/Hawkeye/privacy) for what a report contains. Apart from that, Hawkeye's network traffic goes only to the vehicle or simulator you connect it to.
 
 For bugs that are not security issues, open an issue on [PX4/Hawkeye](https://github.com/PX4/Hawkeye/issues).

--- a/android/README.md
+++ b/android/README.md
@@ -116,6 +116,8 @@ fun ReplayScreen(state: ReplayState, onAction: (ReplayAction) -> Unit) { /* rend
 
 Every data source / repository returns `Result<T, E>` where `E` is a typed error (`ReplayError`, `DataError.Local`, etc.). Never throw exceptions for expected failures — catch them at the layer that owns the cause and return `Result.Error(...)`.
 
+Failures that reach the `UNKNOWN` branch of an error mapper — and only those — are reported through `CrashReporter` (`core:domain`), injected into the data class that owns the mapping. Expected outcomes the user already sees, such as `NOT_FOUND` or `DISK_FULL`, are never reported; a dashboard full of full disks hides the defects worth fixing. `CrashReporter.None` is the dormant implementation used by forks and tests, and it is deliberately not a constructor default, so a dropped injection fails to compile instead of silently going quiet.
+
 User-facing strings that come from resources are wrapped in `UiText` so the ViewModel can carry them without holding a `Context`. Each feature defines a `<FeatureError>.toUiText()` extension in its presentation module — `ReplayError.toUiText()` lives next to `ReplayViewModel`.
 
 ### Dependency injection (Koin)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,9 @@
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+
 plugins {
+    // Must stay first: the Crashlytics plugin applied below refuses to load unless
+    // com.android.application is already on the project, and this convention plugin is
+    // what applies it.
     id("hawkeye.android.application")
 }
 
@@ -20,6 +25,18 @@ val hawkeyeVersionCode: Int = com.px4.hawkeye.buildlogic.hawkeyeVersionCode(hawk
 // empty string, and that case has to stay on the unsigned path.
 val uploadKeystorePath: String? = providers.environmentVariable("HAWKEYE_UPLOAD_KEYSTORE")
     .orNull?.takeIf { it.isNotBlank() }
+
+// Crashlytics activates only when google-services.json is present. CI decodes it from a
+// repository secret; local checkouts and forks have none and build with Firebase dormant,
+// exactly like the unsigned-release path above. The google-services plugin fails the build
+// outright when the file is missing, so it has to be applied conditionally rather than
+// declared in the plugins block. Both plugins are on the classpath via `apply false` in
+// android/build.gradle.kts.
+val firebaseEnabled: Boolean = file("google-services.json").exists()
+if (firebaseEnabled) {
+    apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
+}
 
 android {
     namespace = "com.px4.hawkeye.android"
@@ -89,6 +106,17 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Upload libhawkeye.so's DWARF to Crashlytics so native crashes in the
+            // renderer resolve to a function and line instead of a hex address. AGP builds
+            // release native code as RelWithDebInfo (-O2 -g) and the unstripped objects
+            // survive in merged_native_libs, so the symbols already exist; this only sends
+            // them. Debug is left at the default (off) — uploading on every local build
+            // would cost minutes and tell us nothing.
+            if (firebaseEnabled) {
+                configure<CrashlyticsExtension> {
+                    nativeSymbolUploadEnabled = true
+                }
+            }
         }
     }
 
@@ -121,6 +149,13 @@ dependencies {
 
     implementation(libs.koin.android)
     implementation(libs.koin.androidx.compose)
+
+    // Unconditional on purpose: :app references these types, so making them conditional
+    // would break compilation for forks. Without google-services.json the SDK simply never
+    // initializes and AppModule falls back to CrashReporter.None.
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.crashlytics.ndk)
 
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,17 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.HawkeyeAndroid">
 
+        <!--
+            Crash reporting is on by default, and Settings offers a switch to turn it off.
+            The runtime override Crashlytics persists takes precedence over this value, so
+            a user who opts out stays opted out across updates and across both processes.
+            Changing this default means updating docs/privacy.md and the Play Data safety
+            declaration to match.
+        -->
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="true" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/android/app/src/main/java/com/px4/hawkeye/android/HawkeyeApp.kt
+++ b/android/app/src/main/java/com/px4/hawkeye/android/HawkeyeApp.kt
@@ -1,6 +1,8 @@
 package com.px4.hawkeye.android
 
 import android.app.Application
+import com.px4.hawkeye.android.crash.CrashReportingConsent
+import com.px4.hawkeye.android.crash.initCrashReporting
 import com.px4.hawkeye.android.di.appModule
 import com.px4.hawkeye.core.navigation.di.navigationModule
 import com.px4.hawkeye.feature.about.presentation.di.aboutPresentationModule
@@ -17,11 +19,17 @@ import org.koin.core.context.startKoin
 class HawkeyeApp : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        // Before the process guard below, because the renderer returns early and is exactly
+        // where Crashlytics is most needed: Firebase's own ContentProvider does not reach a
+        // secondary process, so without this the native signal handler never installs.
+        initCrashReporting(this, Application.getProcessName())
+
         // The renderer runs in a separate ":renderer" process (see HawkeyeActivity) and is a
         // bare NativeActivity that needs no DI. Only wire Koin in the main process — this also
         // prevents two processes from opening the Room database concurrently.
         if (Application.getProcessName() != packageName) return
-        startKoin {
+        val koin = startKoin {
             androidContext(this@HawkeyeApp)
             modules(
                 appModule,
@@ -35,6 +43,8 @@ class HawkeyeApp : Application() {
                 liveDataModule,
                 livePresentationModule,
             )
-        }
+        }.koin
+
+        koin.get<CrashReportingConsent>().start()
     }
 }

--- a/android/app/src/main/java/com/px4/hawkeye/android/crash/CrashReporting.kt
+++ b/android/app/src/main/java/com/px4/hawkeye/android/crash/CrashReporting.kt
@@ -1,0 +1,35 @@
+package com.px4.hawkeye.android.crash
+
+import android.content.Context
+import com.google.firebase.FirebaseApp
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.px4.hawkeye.core.domain.CrashReporter
+
+/**
+ * Starts Crashlytics in the calling process and labels which process that is.
+ *
+ * Firebase normally bootstraps itself from `FirebaseInitProvider`, so most apps never call
+ * this. Hawkeye has to: that provider is declared with no `android:process`, and Android
+ * instantiates a provider only in the process its declaration names — the default one.
+ * ":renderer", where every line of native code runs, is therefore never initialized by it.
+ * Skipping this call means no NDK signal handler in the one process that can segfault.
+ *
+ * [FirebaseApp.initializeApp] is idempotent, so calling it in the main process too is
+ * harmless. It returns null when no `google_app_id` resource was baked in, which is every
+ * fork and every local checkout: nothing to start, and nothing to report.
+ */
+fun initCrashReporting(context: Context, processName: String) {
+    FirebaseApp.initializeApp(context) ?: return
+    // Distinguishes a Compose/Kotlin failure in the main process from a native one in the
+    // renderer, which otherwise arrive looking alike.
+    FirebaseCrashlytics.getInstance().setCustomKey(PROCESS_KEY, processName)
+}
+
+/**
+ * Picks the live reporter or the no-op, depending on whether [initCrashReporting] managed
+ * to start Firebase in this process. Must be called after it.
+ */
+fun createCrashReporter(context: Context): CrashReporter =
+    if (FirebaseApp.getApps(context).isNotEmpty()) FirebaseCrashReporter() else CrashReporter.None
+
+private const val PROCESS_KEY = "process"

--- a/android/app/src/main/java/com/px4/hawkeye/android/crash/CrashReportingConsent.kt
+++ b/android/app/src/main/java/com/px4/hawkeye/android/crash/CrashReportingConsent.kt
@@ -1,0 +1,34 @@
+package com.px4.hawkeye.android.crash
+
+import com.px4.hawkeye.core.domain.CrashReporter
+import com.px4.hawkeye.feature.settings.domain.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Mirrors the user's Settings choice into the crash reporter.
+ *
+ * The reporter persists the flag itself, and every process reads it at startup, so the
+ * renderer picks up a change on its next launch — which is always, because HawkeyeActivity
+ * halts its process on the way out. Only the main process runs this: DataStore is
+ * single-process here, the same reason Koin is.
+ *
+ * Extracted from [com.px4.hawkeye.android.HawkeyeApp] so the one privacy-critical path in
+ * the app can be unit-tested with a fake repository instead of needing a device.
+ */
+class CrashReportingConsent(
+    private val settings: SettingsRepository,
+    private val reporter: CrashReporter,
+    private val scope: CoroutineScope,
+) {
+    /** Collects for the life of [scope], which is the life of the process. */
+    fun start(): Job = scope.launch {
+        settings.settings
+            .map { it.crashReportingEnabled }
+            .distinctUntilChanged()
+            .collect(reporter::setEnabled)
+    }
+}

--- a/android/app/src/main/java/com/px4/hawkeye/android/crash/FirebaseCrashReporter.kt
+++ b/android/app/src/main/java/com/px4/hawkeye/android/crash/FirebaseCrashReporter.kt
@@ -1,0 +1,31 @@
+package com.px4.hawkeye.android.crash
+
+import com.google.firebase.crashlytics.CustomKeysAndValues
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.px4.hawkeye.core.domain.CrashReporter
+
+/**
+ * Crashlytics-backed reporter. Only constructed once Firebase is confirmed initialized
+ * (see AppModule), so [crashlytics] is safe to resolve.
+ */
+class FirebaseCrashReporter(
+    private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
+) : CrashReporter {
+
+    override fun recordException(throwable: Throwable, origin: String) {
+        // Scoped keys rather than setCustomKey: the latter is sticky and would attach this
+        // origin to every later report from the same session.
+        crashlytics.recordException(
+            throwable,
+            CustomKeysAndValues.Builder().putString(ORIGIN_KEY, origin).build(),
+        )
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        crashlytics.setCrashlyticsCollectionEnabled(enabled)
+    }
+
+    private companion object {
+        const val ORIGIN_KEY = "origin"
+    }
+}

--- a/android/app/src/main/java/com/px4/hawkeye/android/di/AppModule.kt
+++ b/android/app/src/main/java/com/px4/hawkeye/android/di/AppModule.kt
@@ -1,12 +1,19 @@
 package com.px4.hawkeye.android.di
 
 import com.px4.hawkeye.android.about.AndroidAboutInfoProvider
+import com.px4.hawkeye.android.crash.CrashReportingConsent
+import com.px4.hawkeye.android.crash.createCrashReporter
 import com.px4.hawkeye.android.live.AndroidLivePlaybackLauncher
 import com.px4.hawkeye.android.replay.AndroidReplayPlaybackLauncher
 import com.px4.hawkeye.android.shell.ShellViewModel
+import com.px4.hawkeye.core.domain.CrashReporter
 import com.px4.hawkeye.core.presentation.AboutInfoProvider
 import com.px4.hawkeye.core.presentation.LivePlaybackLauncher
 import com.px4.hawkeye.core.presentation.ReplayPlaybackLauncher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -16,4 +23,16 @@ val appModule = module {
     single<ReplayPlaybackLauncher> { AndroidReplayPlaybackLauncher() }
     single<LivePlaybackLauncher> { AndroidLivePlaybackLauncher(get()) }
     single<AboutInfoProvider> { AndroidAboutInfoProvider(get()) }
+    // Resolved once: whether Firebase is up is fixed for the life of the process, so this
+    // is a build-shape decision rather than something to re-check per call site.
+    single<CrashReporter> { createCrashReporter(androidContext()) }
+    // The scope is built here rather than bound as a type of its own: nothing else should
+    // be able to inject a bare application-lifetime CoroutineScope by accident.
+    single {
+        CrashReportingConsent(
+            settings = get(),
+            reporter = get(),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        )
+    }
 }

--- a/android/app/src/test/java/com/px4/hawkeye/android/crash/CrashReportingConsentTest.kt
+++ b/android/app/src/test/java/com/px4/hawkeye/android/crash/CrashReportingConsentTest.kt
@@ -1,0 +1,77 @@
+package com.px4.hawkeye.android.crash
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import com.px4.hawkeye.core.domain.CrashReporter
+import com.px4.hawkeye.feature.settings.domain.AppSettings
+import com.px4.hawkeye.feature.settings.domain.DistanceUnit
+import com.px4.hawkeye.feature.settings.domain.SettingsRepository
+import com.px4.hawkeye.feature.settings.domain.ThemeMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CrashReportingConsentTest {
+
+    private class FakeSettingsRepository : SettingsRepository {
+        private val state = MutableStateFlow(AppSettings())
+        override val settings = state
+        override suspend fun setThemeMode(mode: ThemeMode) = Unit
+        override suspend fun setDistanceUnit(unit: DistanceUnit) = Unit
+        override suspend fun setListenPort(port: Int) = Unit
+        override suspend fun setCrashReportingEnabled(enabled: Boolean) {
+            state.value = state.value.copy(crashReportingEnabled = enabled)
+        }
+    }
+
+    private class RecordingCrashReporter : CrashReporter {
+        val enabledCalls = mutableListOf<Boolean>()
+        override fun recordException(throwable: Throwable, origin: String) = Unit
+        override fun setEnabled(enabled: Boolean) { enabledCalls += enabled }
+    }
+
+    @Test
+    fun `pushes the persisted choice through on start`() = runTest(UnconfinedTestDispatcher()) {
+        val reporter = RecordingCrashReporter()
+        val job = CrashReportingConsent(FakeSettingsRepository(), reporter, this).start()
+
+        // Collection defaults on, so a fresh install must arrive as enabled rather than
+        // leaving the reporter on whatever the SDK last persisted.
+        assertThat(reporter.enabledCalls).containsExactly(true)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `opting out and back in reaches the reporter`() = runTest(UnconfinedTestDispatcher()) {
+        val settings = FakeSettingsRepository()
+        val reporter = RecordingCrashReporter()
+        val job = CrashReportingConsent(settings, reporter, this).start()
+
+        settings.setCrashReportingEnabled(false)
+        settings.setCrashReportingEnabled(true)
+
+        assertThat(reporter.enabledCalls).containsExactly(true, false, true)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `an unchanged setting does not re-notify`() = runTest(UnconfinedTestDispatcher()) {
+        val settings = FakeSettingsRepository()
+        val reporter = RecordingCrashReporter()
+        val job = CrashReportingConsent(settings, reporter, this).start()
+
+        // An unrelated settings write re-emits AppSettings; the reporter must not be
+        // touched again, or every theme change would rewrite the SDK's persisted flag.
+        settings.setCrashReportingEnabled(true)
+        settings.setThemeMode(ThemeMode.DARK)
+
+        assertThat(reporter.enabledCalls).containsExactly(true)
+
+        job.cancel()
+    }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,4 +5,9 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
+    // Put the Firebase plugins on the classpath without applying them. :app applies both
+    // conditionally, only when google-services.json is present, so a fork without the
+    // config still builds. See android/app/build.gradle.kts.
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }

--- a/android/core/domain/src/main/kotlin/com/px4/hawkeye/core/domain/CrashReporter.kt
+++ b/android/core/domain/src/main/kotlin/com/px4/hawkeye/core/domain/CrashReporter.kt
@@ -1,0 +1,41 @@
+package com.px4.hawkeye.core.domain
+
+/**
+ * Records unexpected failures for later diagnosis.
+ *
+ * Deliberately free of any Firebase or Android type so the modules that report through it
+ * stay testable on the JVM and gain no dependency on the reporting backend. The only real
+ * implementation is the Crashlytics-backed one in `:app`; [None] stands in whenever
+ * Firebase is dormant, which is every fork and every local checkout.
+ *
+ * This is for failures nobody predicted. Expected outcomes that already have a
+ * user-visible result — a missing file, a full disk — are modelled as [DataError] and must
+ * not be reported, or real defects drown in noise.
+ */
+interface CrashReporter {
+
+    /**
+     * Records [throwable] as a non-fatal event. [origin] names the operation that failed,
+     * so the report is attributable without a stack trace that ends in a shared helper.
+     */
+    fun recordException(throwable: Throwable, origin: String)
+
+    /**
+     * Turns collection on or off in response to the user's Settings choice. The backend
+     * persists this, so it survives restarts and applies to every process.
+     */
+    fun setEnabled(enabled: Boolean)
+
+    /**
+     * Discards everything. Used where Firebase never initializes (every fork and local
+     * checkout) and by tests that do not care about reporting.
+     *
+     * Deliberately not a default argument on production constructors: a reporter that
+     * silently does nothing is a degraded value, and this whole seam exists to stop
+     * failures being invisible. Injection sites must name it.
+     */
+    object None : CrashReporter {
+        override fun recordException(throwable: Throwable, origin: String) = Unit
+        override fun setEnabled(enabled: Boolean) = Unit
+    }
+}

--- a/android/feature/about/presentation/src/main/res/values/strings.xml
+++ b/android/feature/about/presentation/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="about_disclaimer_body">Hawkeye is a visualization and analysis tool. It is not a flight-safety device and is not certified for operational use. Do not make flight decisions based on what it displays. The software is provided \"AS IS\", without warranty of any kind.</string>
 
     <string name="about_privacy_header">Privacy</string>
-    <string name="about_privacy_body">Hawkeye collects no personal data. Your flight logs and settings stay on this device, and backup to cloud storage is disabled.</string>
+    <string name="about_privacy_body">Hawkeye collects no personal data. Your flight logs and settings stay on this device, and backup to cloud storage is disabled. Crash reports are sent so faults can be fixed; they never include your logs, and you can turn them off in Settings.</string>
     <string name="about_privacy_link">Read the privacy policy</string>
     <string name="about_privacy_url" translatable="false">https://px4.github.io/Hawkeye/privacy</string>
 

--- a/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/LibraryFileStore.kt
+++ b/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/LibraryFileStore.kt
@@ -1,5 +1,6 @@
 package com.px4.hawkeye.feature.replay.data
 
+import com.px4.hawkeye.core.domain.CrashReporter
 import com.px4.hawkeye.core.domain.DataError
 import com.px4.hawkeye.core.domain.EmptyResult
 import com.px4.hawkeye.core.domain.Result
@@ -19,6 +20,7 @@ import java.io.InputStream
  */
 class LibraryFileStore(
     filesDir: File,
+    private val crashReporter: CrashReporter,
     private val clock: () -> Long = System::currentTimeMillis,
 ) {
     private val libraryDir = File(filesDir, "library")
@@ -107,10 +109,17 @@ class LibraryFileStore(
             DataError.Local.DISK_FULL
         e is IOException && e.message?.contains("space", ignoreCase = true) == true ->
             DataError.Local.DISK_FULL
-        else -> DataError.Local.UNKNOWN
+        // Only the unclassified branch is reported: a missing file and a full disk are
+        // expected outcomes the user already sees.
+        else -> {
+            crashReporter.recordException(e, ORIGIN)
+            DataError.Local.UNKNOWN
+        }
     }
 
     private companion object {
+        const val ORIGIN = "replay-library-files"
+
         /** Extra swarm payloads (and their tmp files) from a previous multi-drone session. */
         val SWARM_FILE_PATTERN = Regex("""swarm_\d+\.ulg(\.tmp)?""")
     }

--- a/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepository.kt
+++ b/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepository.kt
@@ -1,6 +1,7 @@
 package com.px4.hawkeye.feature.replay.data
 
 import android.database.sqlite.SQLiteFullException
+import com.px4.hawkeye.core.domain.CrashReporter
 import com.px4.hawkeye.core.domain.DataError
 import com.px4.hawkeye.core.domain.EmptyResult
 import com.px4.hawkeye.core.domain.Result
@@ -22,6 +23,7 @@ import java.util.UUID
 class RoomReplayLibraryRepository(
     private val dao: ReplayLibraryDao,
     private val fileManager: ReplayFileManager,
+    private val crashReporter: CrashReporter,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val clock: () -> Long = System::currentTimeMillis,
     private val idGenerator: () -> String = { UUID.randomUUID().toString() },
@@ -100,8 +102,17 @@ class RoomReplayLibraryRepository(
             }.getOrElse { Result.Error(it.toLocalError()) }
         }
 
+    // Only the unclassified branch is reported. A full disk is an expected outcome the
+    // user already sees; reporting it would bury the defects worth finding.
     private fun Throwable.toLocalError(): DataError.Local = when (this) {
         is SQLiteFullException -> DataError.Local.DISK_FULL
-        else -> DataError.Local.UNKNOWN
+        else -> {
+            crashReporter.recordException(this, ORIGIN)
+            DataError.Local.UNKNOWN
+        }
+    }
+
+    private companion object {
+        const val ORIGIN = "replay-library-db"
     }
 }

--- a/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/di/ReplayDataModule.kt
+++ b/android/feature/replay/data/src/main/kotlin/com/px4/hawkeye/feature/replay/data/di/ReplayDataModule.kt
@@ -19,7 +19,9 @@ val replayDataModule = module {
         ).build()
     }
     single { get<ReplayDatabase>().libraryDao() }
-    single { LibraryFileStore(androidContext().filesDir) }
+    single { LibraryFileStore(androidContext().filesDir, crashReporter = get()) }
     single<ReplayFileManager> { AndroidReplayFileManager(androidContext().contentResolver, get()) }
-    single<ReplayLibraryRepository> { RoomReplayLibraryRepository(get(), get()) }
+    single<ReplayLibraryRepository> {
+        RoomReplayLibraryRepository(dao = get(), fileManager = get(), crashReporter = get())
+    }
 }

--- a/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/LibraryFileStoreTest.kt
+++ b/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/LibraryFileStoreTest.kt
@@ -4,6 +4,9 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import com.px4.hawkeye.core.domain.CrashReporter
 import com.px4.hawkeye.core.domain.DataError
 import com.px4.hawkeye.core.domain.Result
 import org.junit.jupiter.api.Test
@@ -13,7 +16,11 @@ import java.io.File
 
 class LibraryFileStoreTest {
 
-    private fun store(dir: File, now: Long = 1_000L) = LibraryFileStore(dir, clock = { now })
+    private fun store(
+        dir: File,
+        now: Long = 1_000L,
+        crashReporter: CrashReporter = CrashReporter.None,
+    ) = LibraryFileStore(dir, crashReporter, clock = { now })
 
     @Test
     fun `write copies bytes into the library and returns the size`(@TempDir dir: File) {
@@ -114,7 +121,7 @@ class LibraryFileStoreTest {
         store.write(ByteArrayInputStream("alpha".toByteArray()), "a.ulg")
         store.stage("a.ulg")
 
-        val later = LibraryFileStore(dir, clock = { 9_999L })
+        val later = store(dir, now = 9_999L)
         val result = later.stage(listOf("a.ulg", "ghost.ulg"))
 
         assertThat(result).isEqualTo(Result.Error(DataError.Local.NOT_FOUND))
@@ -135,7 +142,7 @@ class LibraryFileStoreTest {
         store.write(ByteArrayInputStream("good".toByteArray()), "good.ulg")
         File(File(dir, "library"), "broken.ulg").mkdirs()
 
-        val later = LibraryFileStore(dir, clock = { 9_999L })
+        val later = store(dir, now = 9_999L)
         val result = later.stage(listOf("good.ulg", "broken.ulg"))
 
         assertThat(result is Result.Error).isTrue()
@@ -164,5 +171,30 @@ class LibraryFileStoreTest {
         store.delete("a.ulg")
 
         assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `an unclassified failure is reported`(@TempDir dir: File) {
+        val reporter = RecordingCrashReporter()
+        // A directory where the payload belongs makes renameTo fail with a plain IOException,
+        // which classify() cannot attribute — exactly the case worth reporting.
+        File(File(dir, "library"), "abc.ulg").mkdirs()
+
+        val result = store(dir, crashReporter = reporter)
+            .write(ByteArrayInputStream("x".toByteArray()), "abc.ulg")
+
+        assertThat(result).isEqualTo(Result.Error(DataError.Local.UNKNOWN))
+        assertThat(reporter.recorded).hasSize(1)
+        assertThat(reporter.recorded.single().second).isEqualTo("replay-library-files")
+    }
+
+    @Test
+    fun `a missing file is an expected failure and is not reported`(@TempDir dir: File) {
+        val reporter = RecordingCrashReporter()
+
+        val result = store(dir, crashReporter = reporter).stage("nope.ulg")
+
+        assertThat(result).isEqualTo(Result.Error(DataError.Local.NOT_FOUND))
+        assertThat(reporter.recorded).isEmpty()
     }
 }

--- a/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/RecordingCrashReporter.kt
+++ b/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/RecordingCrashReporter.kt
@@ -1,0 +1,12 @@
+package com.px4.hawkeye.feature.replay.data
+
+import com.px4.hawkeye.core.domain.CrashReporter
+
+/** Captures what would have been reported, so tests can assert on it. */
+class RecordingCrashReporter : CrashReporter {
+    val recorded = mutableListOf<Pair<Throwable, String>>()
+    override fun recordException(throwable: Throwable, origin: String) {
+        recorded += throwable to origin
+    }
+    override fun setEnabled(enabled: Boolean) = Unit
+}

--- a/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepositoryTest.kt
+++ b/android/feature/replay/data/src/test/kotlin/com/px4/hawkeye/feature/replay/data/RoomReplayLibraryRepositoryTest.kt
@@ -2,6 +2,8 @@ package com.px4.hawkeye.feature.replay.data
 
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -22,15 +24,18 @@ class RoomReplayLibraryRepositoryTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private lateinit var dao: FakeReplayLibraryDao
     private lateinit var files: FakeReplayFileManager
+    private lateinit var crashReporter: RecordingCrashReporter
 
     @BeforeEach fun setUp() {
         dao = FakeReplayLibraryDao()
         files = FakeReplayFileManager()
+        crashReporter = RecordingCrashReporter()
     }
 
     private fun repository() = RoomReplayLibraryRepository(
         dao = dao,
         fileManager = files,
+        crashReporter = crashReporter,
         ioDispatcher = dispatcher,
         clock = { 1_000L },
         idGenerator = { "fixed-id" },
@@ -58,6 +63,9 @@ class RoomReplayLibraryRepositoryTest {
 
         assertThat(result).isEqualTo(Result.Error(DataError.Local.DISK_FULL))
         assertThat(dao.getById("fixed-id")).isNull()
+        // A full disk is an expected outcome the user already sees. Reporting it would
+        // bury the failures worth acting on.
+        assertThat(crashReporter.recorded).isEmpty()
     }
 
     @Test
@@ -68,6 +76,18 @@ class RoomReplayLibraryRepositoryTest {
 
         assertThat(result).isEqualTo(Result.Error(DataError.Local.UNKNOWN))
         assertThat(files.deletedFileNames).containsExactly("fixed-id.ulg")
+    }
+
+    @Test
+    fun `an unclassified DAO failure is reported with its origin`() = runTest {
+        val boom = RuntimeException("db locked")
+        dao.insertShouldThrow = boom
+
+        repository().import("content://doc")
+
+        assertThat(crashReporter.recorded).hasSize(1)
+        assertThat(crashReporter.recorded.single().first).isEqualTo(boom)
+        assertThat(crashReporter.recorded.single().second).isEqualTo("replay-library-db")
     }
 
     @Test

--- a/android/feature/settings/data/src/main/kotlin/com/px4/hawkeye/feature/settings/data/DataStoreSettingsRepository.kt
+++ b/android/feature/settings/data/src/main/kotlin/com/px4/hawkeye/feature/settings/data/DataStoreSettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.px4.hawkeye.feature.settings.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -17,6 +18,7 @@ private val Context.dataStore by preferencesDataStore(name = "hawkeye_settings")
 private val THEME = stringPreferencesKey("theme_mode")
 private val UNIT = stringPreferencesKey("distance_unit")
 private val LISTEN_PORT = intPreferencesKey("listen_port")
+private val CRASH_REPORTING = booleanPreferencesKey("crash_reporting_enabled")
 
 internal fun parseThemeMode(name: String?): ThemeMode =
     ThemeMode.entries.firstOrNull { it.name == name } ?: ThemeMode.SYSTEM
@@ -31,6 +33,8 @@ class DataStoreSettingsRepository(private val context: Context) : SettingsReposi
             themeMode = parseThemeMode(prefs[THEME]),
             distanceUnit = parseDistanceUnit(prefs[UNIT]),
             listenPort = prefs[LISTEN_PORT] ?: DEFAULT_LIVE_PORT,
+            // Absent means the user has never touched the switch, which is consent on.
+            crashReportingEnabled = prefs[CRASH_REPORTING] ?: true,
         )
     }
 
@@ -44,5 +48,9 @@ class DataStoreSettingsRepository(private val context: Context) : SettingsReposi
 
     override suspend fun setListenPort(port: Int) {
         context.dataStore.edit { it[LISTEN_PORT] = port }
+    }
+
+    override suspend fun setCrashReportingEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[CRASH_REPORTING] = enabled }
     }
 }

--- a/android/feature/settings/domain/src/main/kotlin/com/px4/hawkeye/feature/settings/domain/AppSettings.kt
+++ b/android/feature/settings/domain/src/main/kotlin/com/px4/hawkeye/feature/settings/domain/AppSettings.kt
@@ -6,4 +6,7 @@ data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val distanceUnit: DistanceUnit = DistanceUnit.METRIC,
     val listenPort: Int = DEFAULT_LIVE_PORT,
+    // Defaults on, matching the manifest's firebase_crashlytics_collection_enabled. The
+    // user can turn it off in Settings; see docs/privacy.md.
+    val crashReportingEnabled: Boolean = true,
 )

--- a/android/feature/settings/domain/src/main/kotlin/com/px4/hawkeye/feature/settings/domain/SettingsRepository.kt
+++ b/android/feature/settings/domain/src/main/kotlin/com/px4/hawkeye/feature/settings/domain/SettingsRepository.kt
@@ -7,4 +7,5 @@ interface SettingsRepository {
     suspend fun setThemeMode(mode: ThemeMode)
     suspend fun setDistanceUnit(unit: DistanceUnit)
     suspend fun setListenPort(port: Int)
+    suspend fun setCrashReportingEnabled(enabled: Boolean)
 }

--- a/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsAction.kt
+++ b/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsAction.kt
@@ -7,4 +7,5 @@ sealed interface SettingsAction {
     data class OnThemeModeSelected(val mode: ThemeMode) : SettingsAction
     data class OnDistanceUnitSelected(val unit: DistanceUnit) : SettingsAction
     data class OnListenPortChanged(val raw: String) : SettingsAction
+    data class OnCrashReportingToggled(val enabled: Boolean) : SettingsAction
 }

--- a/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsScreen.kt
+++ b/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsScreen.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -106,6 +108,25 @@ fun SettingsScreen(
         )
 
         Text(
+            text = stringResource(R.string.settings_diagnostics_header),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(
+                top = HawkeyeDimens.itemSpacing,
+                bottom = HawkeyeDimens.titleSpacing,
+            ),
+        )
+        ToggleRow(
+            label = stringResource(R.string.settings_crash_reporting_label),
+            checked = state.crashReportingEnabled,
+            onCheckedChange = { onAction(SettingsAction.OnCrashReportingToggled(it)) },
+        )
+        Text(
+            text = stringResource(R.string.settings_crash_reporting_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Text(
             text = stringResource(R.string.settings_about_header),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(
@@ -163,6 +184,37 @@ private fun OptionRow(
         Text(
             text = label,
             modifier = Modifier.padding(start = HawkeyeDimens.inlineSpacing),
+        )
+    }
+}
+
+@Composable
+private fun ToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            // Toggling from anywhere on the row, with the Switch itself inert, so the
+            // control and its label are one target and one accessibility node — the same
+            // arrangement OptionRow uses for its radio rows.
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Switch,
+            )
+            .padding(vertical = HawkeyeDimens.rowVerticalPadding),
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = null,
         )
     }
 }

--- a/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsState.kt
+++ b/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsState.kt
@@ -12,4 +12,5 @@ data class SettingsState(
     // overwriting the persisted port. Seeded from the saved value, updated on each keystroke.
     val portInput: String = DEFAULT_LIVE_PORT.toString(),
     val portError: UiText? = null,
+    val crashReportingEnabled: Boolean = true,
 )

--- a/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsViewModel.kt
+++ b/android/feature/settings/presentation/src/main/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsViewModel.kt
@@ -28,6 +28,7 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
                         // Only reseed the field from persistence while it holds a valid value,
                         // so an in-progress invalid edit isn't clobbered by the saved port.
                         portInput = if (it.portError == null) s.listenPort.toString() else it.portInput,
+                        crashReportingEnabled = s.crashReportingEnabled,
                     )
                 }
             }
@@ -41,6 +42,8 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
             is SettingsAction.OnDistanceUnitSelected ->
                 viewModelScope.launch { repository.setDistanceUnit(action.unit) }
             is SettingsAction.OnListenPortChanged -> onListenPortChanged(action.raw)
+            is SettingsAction.OnCrashReportingToggled ->
+                viewModelScope.launch { repository.setCrashReportingEnabled(action.enabled) }
         }
     }
 

--- a/android/feature/settings/presentation/src/main/res/values/strings.xml
+++ b/android/feature/settings/presentation/src/main/res/values/strings.xml
@@ -11,6 +11,9 @@
     <string name="settings_listen_port_label">MAVLink listen port</string>
     <string name="settings_port_error_number">Enter a number.</string>
     <string name="settings_port_error_range">Enter a port between 1024 and 65535.</string>
+    <string name="settings_diagnostics_header">Diagnostics</string>
+    <string name="settings_crash_reporting_label">Send crash reports</string>
+    <string name="settings_crash_reporting_description">Sends a report when Hawkeye crashes or hits an unexpected error, so it can be fixed. A report contains the failure itself, your device model, and your Android version. Your flight logs, their location data, and the vehicles you connect to are never included.</string>
     <string name="settings_about_header">About</string>
     <string name="settings_about_label">Version, official builds, and licenses</string>
 </resources>

--- a/android/feature/settings/presentation/src/test/kotlin/com/px4/hawkeye/feature/settings/presentation/FakeSettingsRepository.kt
+++ b/android/feature/settings/presentation/src/test/kotlin/com/px4/hawkeye/feature/settings/presentation/FakeSettingsRepository.kt
@@ -12,4 +12,7 @@ class FakeSettingsRepository : SettingsRepository {
     override suspend fun setThemeMode(mode: ThemeMode) { state.value = state.value.copy(themeMode = mode) }
     override suspend fun setDistanceUnit(unit: DistanceUnit) { state.value = state.value.copy(distanceUnit = unit) }
     override suspend fun setListenPort(port: Int) { state.value = state.value.copy(listenPort = port) }
+    override suspend fun setCrashReportingEnabled(enabled: Boolean) {
+        state.value = state.value.copy(crashReportingEnabled = enabled)
+    }
 }

--- a/android/feature/settings/presentation/src/test/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsViewModelTest.kt
+++ b/android/feature/settings/presentation/src/test/kotlin/com/px4/hawkeye/feature/settings/presentation/SettingsViewModelTest.kt
@@ -3,8 +3,10 @@ package com.px4.hawkeye.feature.settings.presentation
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import com.px4.hawkeye.core.domain.DEFAULT_LIVE_PORT
 import com.px4.hawkeye.feature.settings.domain.DistanceUnit
 import com.px4.hawkeye.feature.settings.domain.ThemeMode
@@ -85,6 +87,17 @@ class SettingsViewModelTest {
             assertThat(expectMostRecentItem().portError).isNotNull()
         }
         assertThat(repo.settings.value.listenPort).isEqualTo(DEFAULT_LIVE_PORT)
+    }
+
+    @Test
+    fun `crash reporting defaults on and opting out persists`() = runTest {
+        val vm = SettingsViewModel(repo)
+        vm.state.test {
+            assertThat(awaitItem().crashReportingEnabled).isTrue()
+            vm.onAction(SettingsAction.OnCrashReportingToggled(false))
+            assertThat(awaitItem().crashReportingEnabled).isFalse()
+        }
+        assertThat(repo.settings.value.crashReportingEnabled).isFalse()
     }
 
     @Test

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -35,6 +35,12 @@ kotlinxCoroutines = "1.10.2"
 # DI
 koin = "4.0.0"
 
+# Crashlytics. The BOM pins the SDK artifacts; the two Gradle plugins version
+# independently of it and of each other.
+firebaseBom = "34.18.0"
+googleServices = "4.5.0"
+firebaseCrashlytics = "3.0.8"
+
 # Testing
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -96,6 +102,12 @@ koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = 
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
 koin-test = { group = "io.insert-koin", name = "koin-test-junit4", version.ref = "koin" }
 
+# Crashlytics (consumed only by :app — no other module sees Firebase). Versions come
+# from the BOM, so the two SDK entries deliberately carry none of their own.
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-crashlytics-ndk = { group = "com.google.firebase", name = "firebase-crashlytics-ndk" }
+
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }
@@ -121,3 +133,5 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -121,15 +121,23 @@ Google Play requires both a privacy policy URL and a completed Data safety form 
 Neither can be scripted; they are filled in by hand in the Play Console.
 
 - The privacy policy URL is <https://px4.github.io/Hawkeye/privacy>, published from [`docs/privacy.md`](../privacy.md).
-- The Data safety form should declare **no data collected and no data shared**.
+- The Data safety form declares three data types, all *collected*, none *shared*, and all marked **optional** because crash reporting can be turned off in Settings:
+  - **Crash logs** and **Diagnostics**, under *App info and performance*.
+  - **Device or other IDs**, because Crashlytics sends a Crashlytics installation UUID and a Firebase installation ID with each report. This one is easy to miss: it comes from the SDK rather than from anything Hawkeye asks for, and Firebase's own [Play data disclosure](https://firebase.google.com/docs/android/play-data-disclosure) is the authority on what has to be declared.
+  - Every type is answered *not processed ephemerally* (Google retains reports for 90 days) with purpose **Analytics**, whose Play definition covers diagnosing and fixing crashes. Security practices declare data encrypted in transit; data deletion is declared as not offered, since reports key to an anonymous install ID that no user can identify as theirs.
 
 That declaration holds because of what the app actually does, and it is worth knowing why rather than taking it on faith.
 Google defines collection as transmitting data off the device, and explicitly exempts data that is only processed locally.
-Hawkeye's flight logs, log library, and settings never leave the device: there is no Hawkeye server, no analytics, and no crash reporting, and Android backup is disabled so the platform does not copy them either.
+Hawkeye's flight logs, log library, and settings never leave the device: there is no Hawkeye server and no analytics, and Android backup is disabled so the platform does not copy them either.
 Live telemetry travels only between the app and the vehicle or simulator the user connected to.
+The single outbound path is Firebase Crashlytics, which sends a crash trace, device state, and an installation identifier when the app fails. It carries nothing from a flight log, which is why the location categories stay unchecked.
 
 The form and the policy have to agree, since a mismatch is a common cause of listing rejection.
-Anything that changes the answer, in particular adding an analytics, crash-reporting, or advertising dependency, or re-enabling `android:allowBackup`, means updating `docs/privacy.md` and the Data safety form together.
+Anything that changes the answer, in particular adding an analytics or advertising dependency, widening what Crashlytics reports, or re-enabling `android:allowBackup`, means updating `docs/privacy.md` and the Data safety form together.
+
+Crashlytics also needs two repository secrets, and a release built without them is not broken, just unreported: `FIREBASE_GOOGLE_SERVICES_JSON` (base64 of `google-services.json`) and `FIREBASE_SERVICE_ACCOUNT_JSON` (a service account key for the Firebase project, holding `roles/firebasecrashlytics.admin`; the Gradle upload task reads it through `GOOGLE_APPLICATION_CREDENTIALS`).
+The two are gated independently. Without `FIREBASE_GOOGLE_SERVICES_JSON` the build ships with crash reporting dormant, exactly as a fork's CI does. Without `FIREBASE_SERVICE_ACCOUNT_JSON` the build still reports crashes, but the symbol upload is skipped and native stack traces arrive as raw addresses.
+The symbol upload runs before the APK is published, so a failure there stops the release rather than shipping a build whose native crashes cannot be read.
 
 ## Checking a release build before tagging
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -4,11 +4,38 @@ Dronecode Project, Inc. publishes Hawkeye (`com.px4.hawkeye.android`) as an open
 
 This policy covers the Hawkeye Android app, the desktop builds for macOS, Linux, and Windows, and the browser replay.
 
-**Effective date: 2026-08-31**
+**Effective date: 2026-09-06**
 
 ## The short version
 
-Hawkeye collects no personal data. It has no user accounts, no analytics, no crash reporting, no advertising, and no tracking of any kind. Nothing you open in Hawkeye is sent to Dronecode, to PX4, or to any third party, because there is no Hawkeye server to send it to.
+Hawkeye collects no personal data. It has no user accounts, no analytics, no advertising, and no tracking of any kind. Nothing you open in Hawkeye is sent to Dronecode, to PX4, or to any third party, because there is no Hawkeye server to send it to.
+
+The one exception is crash reporting, and it applies to the Android app only. When the app crashes or hits an unexpected error, it sends a diagnostic report so the fault can be fixed. **Your flight logs and their location data are never part of a report**, and you can turn crash reporting off. The next section says exactly what a report contains.
+
+## Crash reporting
+
+The Android app uses [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics), a Google service, to report crashes and unexpected errors. This is the only feature that sends anything off your device, and it exists so that faults which would otherwise be invisible get fixed.
+
+**What a report contains:**
+
+- The failure itself: the exception or fatal signal, and the sequence of function calls that led to it. For a crash in the 3D renderer this includes a memory dump of the crashed threads.
+- The state of the device and the app: your device model, CPU architecture, and Android version; how much memory and storage were free; whether the device is rooted; whether the app was in the foreground; and which version of Hawkeye you are running.
+- Two randomly generated installation identifiers, which let separate crashes from the same install be recognized as related. They are not tied to you, your Google account, or your device's advertising ID, and they are reset if you reinstall the app.
+
+Google publishes the exhaustive list of what Crashlytics records on its [Firebase privacy page](https://firebase.google.com/support/privacy).
+
+**What a report never contains:**
+
+- Your flight logs, or any part of them. Nothing from a `.ulg` file is read into a report.
+- Location data of any kind, whether the vehicle's or the device's.
+- The addresses of vehicles or simulators you connect to.
+- Your name, email address, or any account identifier. Hawkeye has no accounts.
+
+Reports go to a Firebase project held by the Dronecode Foundation. Google processes them on Dronecode's behalf, under [Google's privacy policy](https://policies.google.com/privacy). Google states that it keeps crash traces, dump data, and the associated identifiers for 90 days before beginning to remove them from live and backup systems.
+
+**Turning it off.** Crash reporting is on when you first install the app. To turn it off, open **Settings** and switch off **Send crash reports**. The choice is remembered, applies to the whole app including the 3D renderer, and survives updates. With it off, nothing is sent.
+
+Crash reporting exists only in the Android app. The desktop builds and the browser replay have none.
 
 ## What stays on your device
 
@@ -33,7 +60,7 @@ Hawkeye connects to a vehicle or simulator **that you choose**, over MAVLink on 
 
 While a live session is running, Hawkeye accepts telemetry on all of the device's network interfaces, not only the loopback interface, so that a vehicle elsewhere on your network can reach it. It listens only while you have started a live session.
 
-Hawkeye does not check for updates, download maps, or contact any remote service.
+Apart from crash reports, Hawkeye does not check for updates, download maps, or contact any remote service.
 
 ## Android permissions
 
@@ -42,15 +69,15 @@ The Android app declares these permissions:
 | Permission | Why it is there |
 | --- | --- |
 | `INTERNET` | Sending and receiving MAVLink telemetry on your local network. |
-| `ACCESS_NETWORK_STATE` | Not used by Hawkeye. Added by the AndroidX media library that plays the background video on the home screen. |
-| `WAKE_LOCK` | Not used by Hawkeye. Added by the same media library. |
+| `ACCESS_NETWORK_STATE` | Letting crash reporting wait for a working connection before sending a report. Also required by the AndroidX media library that plays the background video on the home screen. |
+| `WAKE_LOCK` | Not used by Hawkeye. Added by the media library above. |
 | `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` | Not used by Hawkeye. Added by the AndroidX core library for its own internal messaging. It is signature level, so no other app can hold it. |
 
 Hawkeye requests no permission that Android classes as dangerous. It does not ask for your location, your files, your contacts, your camera, or your microphone. The location data it displays comes from the flight logs you open and from the vehicle you connect to, not from the device's location services.
 
 ## Desktop and browser builds
 
-The desktop builds behave the same way: logs are read from the disk you point them at, telemetry stays on your local network, and nothing is uploaded.
+The desktop builds behave the same way: logs are read from the disk you point them at, telemetry stays on your local network, and nothing is uploaded. They have no crash reporting.
 
 The browser replay processes the file you select inside the page itself. The file is not uploaded to a server.
 


### PR DESCRIPTION
Adds opt-out crash reporting to the Android app, so failures we never see on a desk actually reach us.

## What's here

- **Both processes.** Firebase's own ContentProvider never reaches `:renderer`, so we initialize it by hand. That's the process running all the native code, and the one that can segfault.
- **A `CrashReporter` seam in `core:domain`**, free of any Firebase or Android type. The data layer reports only the `UNKNOWN` branch of its error mappers. A missing file or a full disk is something the user already sees, and reporting it would bury the real defects.
- **A switch in Settings**, on by default, off whenever the user wants. The choice persists and applies to both processes.
- **Dormant for forks.** No `google-services.json`, no Firebase, and `CrashReporter.None` gets injected instead. Nothing to configure to build the app.
- **Native symbols** upload during a release, before the APK is published, so a renderer crash resolves to a function and line instead of hex.

Privacy policy, NOTICE, SECURITY, and the release runbook are updated together, including what to put in the Play Data safety form.

## Before merging

Two repository secrets need to exist, otherwise the build ships with reporting dormant:

- `FIREBASE_GOOGLE_SERVICES_JSON` (base64 of `google-services.json`)
- `FIREBASE_SERVICE_ACCOUNT_JSON` (service account key with `roles/firebasecrashlytics.admin`)

## Testing

185 unit tests pass, including new coverage for the consent plumbing and for which failures do and don't get reported. `assembleDebug` and the build-logic tests are green.
